### PR TITLE
fix a bug: (DEF_HIST_mode=='one') put attribution to history file only on master

### DIFF
--- a/main/hydro/mod_soil_water.F90
+++ b/main/hydro/mod_soil_water.F90
@@ -3145,7 +3145,7 @@ contains
       vl  = soil_vliq_from_psi (psi, &
          vl_s, vl_r, psi_s, nprm, prms)
       do while (wa <= -(zwt-zmin)*(vl_s-vl))
-         zwt = zmin + (zwt-zmin)*2
+         zwt = zmin + (zwt-zmin)*2 + 0.1
          psi = psi_s - (zwt - zmin) * 0.5
          vl  = soil_vliq_from_psi (psi, &
             vl_s, vl_r, psi_s, nprm, prms)

--- a/main/mod_hist.F90
+++ b/main/mod_hist.F90
@@ -1222,7 +1222,7 @@ contains
       compress = DEF_HIST_COMPRESS_LEVEL 
       call hist_write_var_real8_2d (file_hist, varname, ghist, itime_in_file, flux_xy, compress) 
 
-      IF ((itime_in_file == 1) .and. (trim(DEF_HIST_mode) == 'one')) then
+      IF (p_is_master .and. (itime_in_file == 1) .and. (trim(DEF_HIST_mode) == 'one')) then
          CALL ncio_put_attr (file_hist, varname, 'long_name', longname)
          CALL ncio_put_attr (file_hist, varname, 'units', units)
          CALL ncio_put_attr (file_hist, varname, 'missing_value', spval)
@@ -1304,7 +1304,7 @@ contains
       call hist_write_var_real8_3d (file_hist, varname, dim1name, ghist, &
          itime_in_file, flux_xy, compress) 
 
-      IF ((itime_in_file == 1) .and. (trim(DEF_HIST_mode) == 'one')) then
+      IF (p_is_master .and. (itime_in_file == 1) .and. (trim(DEF_HIST_mode) == 'one')) then
          CALL ncio_put_attr (file_hist, varname, 'long_name', longname)
          CALL ncio_put_attr (file_hist, varname, 'units', units)
          CALL ncio_put_attr (file_hist, varname, 'missing_value', spval)
@@ -1388,7 +1388,7 @@ contains
       call hist_write_var_real8_4d (file_hist, varname, dim1name, dim2name, &
          ghist, itime_in_file, flux_xy, compress) 
 
-      IF ((itime_in_file == 1) .and. (trim(DEF_HIST_mode) == 'one')) then
+      IF (p_is_master .and. (itime_in_file == 1) .and. (trim(DEF_HIST_mode) == 'one')) then
          CALL ncio_put_attr (file_hist, varname, 'long_name', longname)
          CALL ncio_put_attr (file_hist, varname, 'units', units)
          CALL ncio_put_attr (file_hist, varname, 'missing_value', spval)
@@ -1470,7 +1470,7 @@ contains
       call hist_write_var_real8_2d (file_hist, varname, ghist, itime_in_file, flux_xy, &
          compress) 
 
-      IF ((itime_in_file == 1) .and. (trim(DEF_HIST_mode) == 'one')) then
+      IF (p_is_master .and. (itime_in_file == 1) .and. (trim(DEF_HIST_mode) == 'one')) then
          CALL ncio_put_attr (file_hist, varname, 'long_name', longname)
          CALL ncio_put_attr (file_hist, varname, 'units', units)
          CALL ncio_put_attr (file_hist, varname, 'missing_value', spval)


### PR DESCRIPTION
when (DEF_HIST_mode=='one') 
Putting attribution to history file should be only on master