### PR TITLE
Bug fix for lai=0 case for USGS cover.

### DIFF
--- a/main/MOD_Albedo.F90
+++ b/main/MOD_Albedo.F90
@@ -413,13 +413,25 @@ ENDIF
       IF (lai+sai > 1e-6) THEN
 
 IF (patchtype == 0) THEN
-#if(defined LULC_USGS || defined LULC_IGBP)
+
+#if(defined LULC_USGS)
+         IF (lai > 1e-6) THEN
+            CALL twostream (chil,rho,tau,green,lai,sai,&
+                            czen,albg,albv,tran,thermk,extkb,extkd,ssun,ssha)
+
+            albv(:,:) = (1.-wt)*albv(:,:) + wt*albsno(:,:)
+            alb(:,:)  = (1.-fveg)*albg(:,:) + fveg*albv(:,:)
+         ENDIF
+#endif
+
+#if(defined LULC_IGBP)
          CALL twostream (chil,rho,tau,green,lai,sai,&
                          czen,albg,albv,tran,thermk,extkb,extkd,ssun,ssha)
 
          albv(:,:) = (1.-wt)*albv(:,:) + wt*albsno(:,:)
          alb(:,:)  = (1.-fveg)*albg(:,:) + fveg*albv(:,:)
 #endif
+
 
 #ifdef LULC_IGBP_PFT
          CALL twostream_wrap (ipatch, czen, albg, &
@@ -432,11 +444,13 @@ IF (patchtype == 0) THEN
          alb(:,:) = albv(:,:)
 #endif
       ELSE
-         CALL twostream (chil,rho,tau,green,lai,sai,&
-                         czen,albg,albv,tran,thermk,extkb,extkd,ssun,ssha)
+         IF (lai > 1e-6) THEN
+            CALL twostream (chil,rho,tau,green,lai,sai,&
+                            czen,albg,albv,tran,thermk,extkb,extkd,ssun,ssha)
 
-         albv(:,:) = (1.-wt)*albv(:,:) + wt*albsno(:,:)
-         alb(:,:)  = (1.-fveg)*albg(:,:) + fveg*albv(:,:)
+            albv(:,:) = (1.-wt)*albv(:,:) + wt*albsno(:,:)
+            alb(:,:)  = (1.-fveg)*albg(:,:) + fveg*albv(:,:)
+         ENDIF
 ENDIF
       ENDIF
 


### PR DESCRIPTION
-mod(MOD_Albedo.F90):
        modified for lai=0 case for usgs cover by skiping two-stream
        subroutine.