### PR TITLE
Bug fix for unbalanced water and energy in PC and code indent for pretty.

### DIFF
--- a/main/CoLMMAIN.F90
+++ b/main/CoLMMAIN.F90
@@ -1,4 +1,5 @@
 #include <define.h>
+
 SUBROUTINE CoLMMAIN ( &
 
          ! model running information
@@ -106,7 +107,7 @@ SUBROUTINE CoLMMAIN ( &
 !
 !    FLOW DIAGRAM FOR CoLMMAIN
 !
-!    CoLMMAIN ===> netsolar                 |> all surface
+!    CoLMMAIN ===>netsolar                 |> all surface
 !                 rain_snow_temp           !> all surface
 !
 !                 LEAF_interception        |]
@@ -166,31 +167,31 @@ SUBROUTINE CoLMMAIN ( &
 #if(defined CaMa_Flood)
    !get flood depth [mm], flood fraction[0-1], flood evaporation [mm/s], flood inflow [mm/s]
    USE MOD_CaMa_colmCaMa,only:get_fldevp
-   USE YOS_CMF_INPUT,      ONLY: LWINFILT,LWEVAP
+   USE YOS_CMF_INPUT,      only: LWINFILT,LWEVAP
 #endif
 
   IMPLICIT NONE
 
 ! ------------------------ Dummy Argument ------------------------------
-  REAL(r8),intent(in) :: deltim  !seconds in a time step [second]
-  LOGICAL, intent(in) :: doalb   !true if time for surface albedo calculation
-  LOGICAL, intent(in) :: dolai   !true if time for leaf area index calculation
-  LOGICAL, intent(in) :: dosst   !true to update sst/ice/snow before calculation
+  real(r8),intent(in) :: deltim  !seconds in a time step [second]
+  logical, intent(in) :: doalb   !true if time for surface albedo calculation
+  logical, intent(in) :: dolai   !true if time for leaf area index calculation
+  logical, intent(in) :: dosst   !true to update sst/ice/snow before calculation
 
-  INTEGER, intent(in) :: &
+  integer, intent(in) :: &
         ipatch        ! patch index
 
-  REAL(r8), intent(in) :: &
+  real(r8), intent(in) :: &
         patchlonr   ,&! logitude in radians
         patchlatr     ! latitude in radians
 
-  INTEGER, intent(in) :: &
+  integer, intent(in) :: &
         patchclass  ,&! land cover type of USGS classification or others
         patchtype     ! land water type (0=soil, 1=urban and built-up,
                       ! 2=wetland, 3=land ice, 4=land water bodies, 99 = ocean)
 ! Parameters
 ! ----------------------
-  REAL(r8), intent(in) :: &
+  real(r8), intent(in) :: &
         lakedepth        ,&! lake depth (m)
         dz_lake(nl_lake) ,&! lake layer thickness (m)
 
@@ -206,9 +207,9 @@ SUBROUTINE CoLMMAIN ( &
         vf_sand   (nl_soil),  & ! volumetric fraction of sand
         wf_gravels(nl_soil),  & ! gravimetric fraction of gravels
         wf_sand   (nl_soil),  & ! gravimetric fraction of sand
-        porsl(nl_soil)     ,  & ! fraction of soil that is voids [-]
-        psi0(nl_soil)      ,  & ! minimum soil suction [mm]
-        bsw(nl_soil)       ,  & ! clapp and hornbereger "b" parameter [-]
+        porsl     (nl_soil),  & ! fraction of soil that is voids [-]
+        psi0      (nl_soil),  & ! minimum soil suction [mm]
+        bsw       (nl_soil),  & ! clapp and hornbereger "b" parameter [-]
 #ifdef vanGenuchten_Mualem_SOIL_MODEL
         theta_r  (1:nl_soil), & ! residual water content (cm3/cm3) in vanGenuchten_Mualem_SOIL_MODEL
         alpha_vgm(1:nl_soil), & ! the parameter corresponding approximately to the inverse of the air-entry value
@@ -274,7 +275,7 @@ SUBROUTINE CoLMMAIN ( &
 
 ! Forcing
 ! ----------------------
-  REAL(r8), intent(in) :: &
+  real(r8), intent(in) :: &
         forc_pco2m  ,&! partial pressure of CO2 at observational height [pa]
         forc_po2m   ,&! partial pressure of O2 at observational height [pa]
         forc_us     ,&! wind speed in eastward direction [m/s]
@@ -298,18 +299,18 @@ SUBROUTINE CoLMMAIN ( &
         forc_aerdep(14)!atmospheric aerosol deposition data [kg/m/s]
 
 #if(defined CaMa_Flood)
-   REAL(r8), intent(in)    :: fldfrc    !inundation fraction--> allow re-evaporation and infiltrition![0-1]
-   REAL(r8), intent(inout) :: flddepth  !inundation depth--> allow re-evaporation and infiltrition![mm]
-   REAL(r8), intent(out)   :: fevpg_fld !effective evaporation from inundation [mm/s]
-   REAL(r8), intent(out)   :: qinfl_fld !effective re-infiltration from inundation [mm/s]
+   real(r8), intent(in)    :: fldfrc    !inundation fraction--> allow re-evaporation and infiltrition![0-1]
+   real(r8), intent(inout) :: flddepth  !inundation depth--> allow re-evaporation and infiltrition![mm]
+   real(r8), intent(out)   :: fevpg_fld !effective evaporation from inundation [mm/s]
+   real(r8), intent(out)   :: qinfl_fld !effective re-infiltration from inundation [mm/s]
 #endif
 ! Variables required for restart run
 ! ----------------------------------------------------------------------
-  INTEGER, intent(in) :: &
+  integer, intent(in) :: &
         idate(3)      ! next time-step /year/julian day/second in a day/
 
-  REAL(r8), intent(inout) :: oro  ! ocean(0)/seaice(2)/ flag
-  REAL(r8), intent(inout) :: &
+  real(r8), intent(inout) :: oro  ! ocean(0)/seaice(2)/ flag
+  real(r8), intent(inout) :: &
         z_sno      (maxsnl+1:0)       ,&! layer depth (m)
         dz_sno     (maxsnl+1:0)       ,&! layer thickness (m)
         t_soisno   (maxsnl+1:nl_soil) ,&! soil + snow layer temperature [K]
@@ -325,10 +326,10 @@ SUBROUTINE CoLMMAIN ( &
         gs0sun                ,&! working copy of sunlit stomata conductance
         gs0sha                ,&! working copy of shalit stomata conductance
         !Ozone stress variables
-        lai_old    ,&! lai in last time step
-        o3uptakesun,&! Ozone does, sunlit leaf (mmol O3/m^2)
-        o3uptakesha,&! Ozone does, shaded leaf (mmol O3/m^2)
-        forc_ozone ,&
+        lai_old     ,&! lai in last time step
+        o3uptakesun ,&! Ozone does, sunlit leaf (mmol O3/m^2)
+        o3uptakesha ,&! Ozone does, shaded leaf (mmol O3/m^2)
+        forc_ozone  ,&
         !End ozone stress variables
         t_grnd      ,&! ground surface temperature [k]
         tleaf       ,&! leaf temperature [K]
@@ -370,25 +371,25 @@ SUBROUTINE CoLMMAIN ( &
 
 
 ! additional diagnostic variables for output
-  REAL(r8), intent(out) :: &
+  real(r8), intent(out) :: &
         laisun      ,&! sunlit leaf area index
         laisha      ,&! shaded leaf area index
         rstfacsun_out,&! factor of soil water stress
         rstfacsha_out,&! factor of soil water stress
-        gssun_out,    &! sunlit stomata conductance
-        gssha_out,    &! shaded stomata conductance
+        gssun_out   ,&! sunlit stomata conductance
+        gssha_out   ,&! shaded stomata conductance
         wat         ,&! total water storage
         rootr(nl_soil),&! water exchange between soil and root. Positive: soil->root [?]
         h2osoi(nl_soil) ! volumetric soil water in layers [m3/m3]
 
-  REAL(r8), intent(out) :: &
-        assimsun_out           ,&
-        etrsun_out             ,&
-        assimsha_out           ,&
-        etrsha_out             
+  real(r8), intent(out) :: &
+        assimsun_out,&
+        etrsun_out  ,&
+        assimsha_out,&
+        etrsha_out
 ! Fluxes
 ! ----------------------------------------------------------------------
-  REAL(r8), intent(out) :: &
+  real(r8), intent(out) :: &
         taux        ,&! wind stress: E-W [kg/m/s**2]
         tauy        ,&! wind stress: N-S [kg/m/s**2]
         fsena       ,&! sensible heat from canopy height to atmosphere [W/m2]
@@ -454,7 +455,7 @@ SUBROUTINE CoLMMAIN ( &
         fq            ! integral of profile function for moisture
 
 ! ----------------------- Local  Variables -----------------------------
-   REAL(r8) :: &
+   real(r8) :: &
         calday      ,&! Julian cal day (1.xx to 365.xx)
         endwb       ,&! water mass at the end of time step
         errore      ,&! energy balnce errore (Wm-2)
@@ -478,7 +479,7 @@ SUBROUTINE CoLMMAIN ( &
         dz_soisno(maxsnl+1:nl_soil), &! layer thickness (m)
         zi_soisno(maxsnl  :nl_soil)   ! interface level below a "z" level (m)
 
-   REAL(r8) :: &
+   real(r8) :: &
         prc_rain    ,&! convective rainfall [kg/(m2 s)]
         prc_snow    ,&! convective snowfall [kg/(m2 s)]
         prl_rain    ,&! large scale rainfall [kg/(m2 s)]
@@ -491,48 +492,48 @@ SUBROUTINE CoLMMAIN ( &
         qintr_snow  ,&! snowfall interception (mm h2o/s)
         errw_rsub     ! the possible subsurface runoff deficit after PHS is included
 
-  INTEGER snl       ,&! number of snow layers
+  integer snl       ,&! number of snow layers
         imelt(maxsnl+1:nl_soil), &! flag for: melting=1, freezing=2, Nothing happended=0
         lb          , lbsn, &! lower bound of arrays
         j             ! do looping index
 
       ! For SNICAR snow model
       !----------------------------------------------------------------------
-      INTEGER  snl_bef                 !number of snow layers
-      REAL(r8) forc_aer        ( 14 )  !aerosol deposition from atmosphere model (grd,aer) [kg m-1 s-1]
-      REAL(r8) snofrz    (maxsnl+1:0)  !snow freezing rate (col,lyr) [kg m-2 s-1]
-      REAL(r8) t_soisno_ (maxsnl+1:1)  !soil + snow layer temperature [K]
-      REAL(r8) dz_soisno_(maxsnl+1:1)  !layer thickness (m)
-      REAL(r8) sabg_lyr  (maxsnl+1:1)  !snow layer absorption [W/m-2]
+      integer  snl_bef                 !number of snow layers
+      real(r8) forc_aer        ( 14 )  !aerosol deposition from atmosphere model (grd,aer) [kg m-1 s-1]
+      real(r8) snofrz    (maxsnl+1:0)  !snow freezing rate (col,lyr) [kg m-2 s-1]
+      real(r8) t_soisno_ (maxsnl+1:1)  !soil + snow layer temperature [K]
+      real(r8) dz_soisno_(maxsnl+1:1)  !layer thickness (m)
+      real(r8) sabg_lyr  (maxsnl+1:1)  !snow layer absorption [W/m-2]
 
       !----------------------------------------------------------------------
 
-      REAL(r8) :: a, aa
-      INTEGER ps, pe, pc
+      real(r8) :: a, aa
+      integer ps, pe, pc
 
 !======================================================================
 #if(defined CaMa_Flood)
       !add variables for flood evaporation [mm/s] and re-infiltration [mm/s] calculation.
-      REAL(r8) :: kk
-      REAL(r8) :: taux_fld       ! wind stress: E-W [kg/m/s**2]
-      REAL(r8) :: tauy_fld       ! wind stress: N-S [kg/m/s**2]
-      REAL(r8) :: fsena_fld      ! sensible heat from agcm reference height to atmosphere [W/m2]
-      REAL(r8) :: fevpa_fld      ! evaporation from agcm reference height to atmosphere [mm/s]
-      REAL(r8) :: fseng_fld      ! sensible heat flux from ground [W/m2]
-      REAL(r8) :: tref_fld       ! 2 m height air temperature [kelvin]
-      REAL(r8) :: qref_fld       ! 2 m height air humidity
-      REAL(r8) :: z0m_fld        ! effective roughness [m]
-      REAL(r8) :: zol_fld        ! dimensionless height (z/L) used in Monin-Obukhov theory
-      REAL(r8) :: rib_fld        ! bulk Richardson number in surface layer
-      REAL(r8) :: ustar_fld      ! friction velocity [m/s]
-      REAL(r8) :: tstar_fld      ! temperature scaling parameter
-      REAL(r8) :: qstar_fld      ! moisture scaling parameter
-      REAL(r8) :: fm_fld         ! integral of profile function for momentum
-      REAL(r8) :: fh_fld         ! integral of profile function for heat
-      REAL(r8) :: fq_fld         ! integral of profile function for moisture
+      real(r8) :: kk
+      real(r8) :: taux_fld       ! wind stress: E-W [kg/m/s**2]
+      real(r8) :: tauy_fld       ! wind stress: N-S [kg/m/s**2]
+      real(r8) :: fsena_fld      ! sensible heat from agcm reference height to atmosphere [W/m2]
+      real(r8) :: fevpa_fld      ! evaporation from agcm reference height to atmosphere [mm/s]
+      real(r8) :: fseng_fld      ! sensible heat flux from ground [W/m2]
+      real(r8) :: tref_fld       ! 2 m height air temperature [kelvin]
+      real(r8) :: qref_fld       ! 2 m height air humidity
+      real(r8) :: z0m_fld        ! effective roughness [m]
+      real(r8) :: zol_fld        ! dimensionless height (z/L) used in Monin-Obukhov theory
+      real(r8) :: rib_fld        ! bulk Richardson number in surface layer
+      real(r8) :: ustar_fld      ! friction velocity [m/s]
+      real(r8) :: tstar_fld      ! temperature scaling parameter
+      real(r8) :: qstar_fld      ! moisture scaling parameter
+      real(r8) :: fm_fld         ! integral of profile function for momentum
+      real(r8) :: fh_fld         ! integral of profile function for heat
+      real(r8) :: fq_fld         ! integral of profile function for moisture
 #endif
 
-      ! 09/2022, yuan: move from CoLMDRIVER to SAVE memory
+      ! 09/2022, yuan: move from CoLMDRIVER to avoid using stack memory
       z_soisno (maxsnl+1:0) = z_sno (maxsnl+1:0)
       z_soisno (1:nl_soil ) = z_soi (1:nl_soil )
       dz_soisno(maxsnl+1:0) = dz_sno(maxsnl+1:0)
@@ -618,8 +619,8 @@ IF (patchtype == 0) THEN
 
 #if(defined LULC_USGS || defined LULC_IGBP)
       CALL LEAF_interception_wrap (deltim,dewmx,forc_us,forc_vs,chil,sigf,lai,sai,tref, tleaf,&
-      prc_rain,prc_snow,prl_rain,prl_snow,&
-      ldew,ldew_rain,ldew_snow,z0m,forc_hgt_u,pg_rain,pg_snow,qintr,qintr_rain,qintr_snow)
+                              prc_rain,prc_snow,prl_rain,prl_snow,&
+                              ldew,ldew_rain,ldew_snow,z0m,forc_hgt_u,pg_rain,pg_snow,qintr,qintr_rain,qintr_snow)
 
 #endif
 
@@ -638,10 +639,8 @@ IF (patchtype == 0) THEN
 
 ELSE
       CALL LEAF_interception_wrap (deltim,dewmx,forc_us,forc_vs,chil,sigf,lai,sai,tref, tleaf,&
-      prc_rain,prc_snow,prl_rain,prl_snow,&
-      ldew,ldew_rain,ldew_snow,z0m,forc_hgt_u,pg_rain,pg_snow,qintr,qintr_rain,qintr_snow)
-     
-
+                              prc_rain,prc_snow,prl_rain,prl_snow,&
+                              ldew,ldew_rain,ldew_snow,z0m,forc_hgt_u,pg_rain,pg_snow,qintr,qintr_rain,qintr_snow)
 ENDIF
 
       qdrip = pg_rain + pg_snow
@@ -694,7 +693,7 @@ ENDIF
            psi50_sun         ,psi50_sha         ,psi50_xyl         ,psi50_root        ,&
            ck                ,vegwp             ,gs0sun            ,gs0sha            ,&
         !Ozone stress variables
-           lai_old           ,o3uptakesun       ,o3uptakesha       ,forc_ozone        , &
+           lai_old           ,o3uptakesun       ,o3uptakesha       ,forc_ozone        ,&
         !End ozone stress variables
            slti              ,hlti              ,shti              ,hhti              ,&
            trda              ,trdm              ,trop              ,gradm             ,&
@@ -707,7 +706,7 @@ ENDIF
            extkb             ,extkd             ,thermk            ,fsno              ,&
            sigf              ,dz_soisno(lb:)    ,z_soisno(lb:)     ,zi_soisno(lb-1:)  ,&
            tleaf             ,t_soisno(lb:)     ,wice_soisno(lb:)  ,wliq_soisno(lb:)  ,&
-           ldew, ldew_rain, ldew_snow,    scv         ,snowdp      ,imelt(lb:)      ,&
+           ldew,ldew_rain,ldew_snow,scv         ,snowdp            ,imelt(lb:)        ,&
            taux              ,tauy              ,fsena             ,fevpa             ,&
            lfevpa            ,fsenl             ,fevpl             ,etr               ,&
            fseng             ,fevpg             ,olrg              ,fgrnd             ,&
@@ -747,7 +746,7 @@ ENDIF
          CALL WATER_VSF (ipatch ,patchtype         ,lb                ,nl_soil           ,&
               deltim            ,z_soisno(lb:)     ,dz_soisno(lb:)    ,zi_soisno(lb-1:)  ,&
 #ifdef Campbell_SOIL_MODEL
-              bsw               ,                                                         &
+              bsw               ,&
 #endif
 #ifdef vanGenuchten_Mualem_SOIL_MODEL
               theta_r           ,alpha_vgm         ,n_vgm             ,L_vgm             ,&
@@ -845,8 +844,8 @@ ENDIF
          endwb = endwb + wdsrf
       ENDIF
 #if(defined CaMa_Flood)
-   if (LWINFILT) then
-       if (patchtype == 0) then
+   IF (LWINFILT) THEN
+       IF (patchtype == 0) THEN
             endwb=endwb - qinfl_fld*deltim
        ENDIF
    ENDIF
@@ -865,11 +864,11 @@ ENDIF
 #if(defined CoLMDEBUG)
       IF (abs(errorw) > 1.e-3) THEN
          write(6,*) 'Warning: water balance violation', errorw,patchclass
-         !stop
+         !STOP
       ENDIF
-      if(abs(errw_rsub*deltim)>1.e-3) then
+      IF(abs(errw_rsub*deltim)>1.e-3) THEN
          write(6,*) 'Subsurface runoff deficit due to PHS', errw_rsub*deltim
-      end if
+      END IF
 #endif
 
 !======================================================================
@@ -1145,15 +1144,15 @@ ELSE                     ! <=== is OCEAN (patchtype >= 99)
 
 ENDIF
 #if(defined CaMa_Flood)
-if (LWEVAP) then
-   if ((flddepth .GT. 1.e-6).and.(fldfrc .GT. 0.05).and.patchtype == 0)then
-         call get_fldevp (forc_hgt_u,forc_hgt_t,forc_hgt_q,&
+IF (LWEVAP) THEN
+   IF ((flddepth .gt. 1.e-6).and.(fldfrc .gt. 0.05).and.patchtype == 0)THEN
+         CALL get_fldevp (forc_hgt_u,forc_hgt_t,forc_hgt_q,&
             forc_us,forc_vs,forc_t,forc_q,forc_rhoair,forc_psrf,t_grnd,&
             forc_hpbl, &
             taux_fld,tauy_fld,fseng_fld,fevpg_fld,tref_fld,qref_fld,&
             z0m_fld,zol_fld,rib_fld,ustar_fld,qstar_fld,tstar_fld,fm_fld,fh_fld,fq_fld)
-      if (fevpg_fld<0.0) fevpg_fld=0.0d0
-      if ((flddepth-deltim*fevpg_fld .GT. 0.0) .and. (fevpg_fld.GT.0.0)) then
+      IF (fevpg_fld<0.0) fevpg_fld=0.0d0
+      IF ((flddepth-deltim*fevpg_fld .gt. 0.0) .and. (fevpg_fld.gt.0.0)) THEN
          flddepth=flddepth-deltim*fevpg_fld
          !taux= taux_fld*fldfrc+(1.0-fldfrc)*taux
          !tauy= tauy_fld*fldfrc+(1.0-fldfrc)*tauy
@@ -1171,15 +1170,15 @@ if (LWEVAP) then
          !fm=fm_fld*fldfrc+(1.0-fldfrc)*fm! integral of profile function for momentum
          !fh=fh_fld*fldfrc+(1.0-fldfrc)*fh! integral of profile function for heat
          !fq=fq_fld*fldfrc+(1.0-fldfrc)*fq!,       &! integral of profile function for moisture
-      else
+      ELSE
          fevpg_fld=0.0d0
-      endif
-   else
+      ENDIF
+   ELSE
       fevpg_fld=0.0d0
-   endif
-else
+   ENDIF
+ELSE
    fevpg_fld=0.0d0
-endif
+ENDIF
 
 #endif
 
@@ -1204,7 +1203,7 @@ endif
        ENDIF
 #endif
 
-! ONLY for soil patches
+! only for soil patches
 !NOTE: lai from remote sensing has already considered snow coverage
 IF (patchtype == 0) THEN
 
@@ -1310,47 +1309,47 @@ ENDIF
 
     ! zero-filling set for glacier/ice-sheet/land water bodies/ocean components
     IF (patchtype > 2) THEN
-       lai = 0.0
-       sai = 0.0
-       laisun = 0.0
-       laisha = 0.0
-       green = 0.0
-       fveg = 0.0
-       sigf = 0.0
+       lai           = 0.0
+       sai           = 0.0
+       laisun        = 0.0
+       laisha        = 0.0
+       green         = 0.0
+       fveg          = 0.0
+       sigf          = 0.0
 
-       ssun(:,:) = 0.0
-       ssha(:,:) = 0.0
-       thermk = 0.0
-       extkb = 0.0
-       extkd = 0.0
+       ssun(:,:)     = 0.0
+       ssha(:,:)     = 0.0
+       thermk        = 0.0
+       extkb         = 0.0
+       extkd         = 0.0
 
-       tleaf = forc_t
-       ldew_rain  = 0.0
-       ldew_snow  = 0.0
-       ldew  = 0.0
-       fsenl = 0.0
-       fevpl = 0.0
-       etr   = 0.0
-       assim = 0.0
-       respc = 0.0
+       tleaf         = forc_t
+       ldew_rain     = 0.0
+       ldew_snow     = 0.0
+       ldew          = 0.0
+       fsenl         = 0.0
+       fevpl         = 0.0
+       etr           = 0.0
+       assim         = 0.0
+       respc         = 0.0
 
-       zerr=0.
-       xerr=0.
+       zerr          = 0.
+       xerr          = 0.
 
-       qinfl = 0.
-       qdrip = forc_rain + forc_snow
-       qintr = 0.
-       h2osoi = 0.
+       qinfl         = 0.
+       qdrip         = forc_rain + forc_snow
+       qintr         = 0.
+       h2osoi        = 0.
        rstfacsun_out = 0.
        rstfacsha_out = 0.
-       gssun_out = 0.
-       gssha_out = 0.
-       assimsun_out           =0.
-       etrsun_out             =0.
-       assimsha_out           =0.
-       etrsha_out             =0.
-       rootr = 0.
-       zwt = 0.
+       gssun_out     = 0.
+       gssha_out     = 0.
+       assimsun_out  = 0.
+       etrsun_out    = 0.
+       assimsha_out  = 0.
+       etrsha_out    = 0.
+       rootr         = 0.
+       zwt           = 0.
 
        IF (DEF_USE_VARIABLY_SATURATED_FLOW) THEN
           wa = 0.
@@ -1359,9 +1358,9 @@ ENDIF
        ENDIF
 
        qcharge = 0.
-       if (DEF_USE_PLANTHYDRAULICS)then
+       IF (DEF_USE_PLANTHYDRAULICS)THEN
           vegwp = -2.5e4
-       end if
+       END IF
     ENDIF
 
     h2osoi = wliq_soisno(1:)/(dz_soisno(1:)*denh2o) + wice_soisno(1:)/(dz_soisno(1:)*denice)
@@ -1372,7 +1371,7 @@ ENDIF
        wat = sum(wice_soisno(1:)+wliq_soisno(1:))+ldew+scv + wa
     ENDIF
 
-    ! 09/2022, yuan: move from CoLMDRIVER to SAVE memory
+    ! 09/2022, yuan: move from CoLMDRIVER to avoid using stack memory
     z_sno (maxsnl+1:0) = z_soisno (maxsnl+1:0)
     dz_sno(maxsnl+1:0) = dz_soisno(maxsnl+1:0)
 

--- a/main/MOD_Albedo.F90
+++ b/main/MOD_Albedo.F90
@@ -239,7 +239,8 @@ MODULE MOD_Albedo
       albv(:,:) = 0.   ! vegetation
       ssun(:,:) = 0.
       ssha(:,:) = 0.
-      thermk    = 1.e-3
+      ! 07/06/2023, yuan: use the values of previous timestep.
+      !thermk    = 1.e-3
       extkb     = 1.
       extkd     = 0.718
 
@@ -257,7 +258,8 @@ IF (patchtype == 0) THEN
       pe = patch_pft_e(ipatch)
       ssun_p(:,:,ps:pe) = 0.
       ssha_p(:,:,ps:pe) = 0.
-      thermk_p(ps:pe)   = 1.e-3
+      ! 07/06/2023, yuan: use the values of previous timestep.
+      !thermk_p(ps:pe)   = 1.e-3
       extkb_p(ps:pe)    = 1.
       extkd_p(ps:pe)    = 0.718
 #endif
@@ -266,9 +268,10 @@ IF (patchtype == 0) THEN
       pc = patch2pc(ipatch)
       ssun_c(:,:,:,pc) = 0.
       ssha_c(:,:,:,pc) = 0.
-      thermk_c(:,pc)   = 1.e-3
-      fshade_c(:,pc)   = pcfrac(:,pc)
-      fshade_c(0,pc)   = 0.
+      ! 07/06/2023, yuan: use the values of previous timestep.
+      !thermk_c(:,pc)   = 1.e-3
+      !fshade_c(:,pc)   = pcfrac(:,pc)
+      !fshade_c(0,pc)   = 0.
       extkb_c(:,pc)    = 1.
       extkd_c(:,pc)    = 0.718
 #endif

--- a/main/MOD_LeafInterception.F90
+++ b/main/MOD_LeafInterception.F90
@@ -1376,12 +1376,12 @@ contains
 
 
       if (DEF_Interception_scheme==1) then
- 
+
          CALL LEAF_interception_CoLM2014 (  deltim,dewmx,forc_us,forc_vs,chil,sigf,lai,sai,tair,tleaf, &
                                              prc_rain,prc_snow,prl_rain,prl_snow,&
                                               ldew,ldew_rain,ldew_snow,z0m,hu,pg_rain,&
                                           pg_snow,qintr,qintr_rain,qintr_snow)
-      
+
       ELSEIF (DEF_Interception_scheme==2) then
          CALL LEAF_interception_CLM4 (  deltim,dewmx,forc_us,forc_vs,chil,sigf,lai,sai,tair,tleaf, &
                                                  prc_rain,prc_snow,prl_rain,prl_snow,&
@@ -1408,7 +1408,7 @@ contains
                                                  prc_rain,prc_snow,prl_rain,prl_snow,&
                                                 ldew,ldew_rain,ldew_snow,z0m,hu,pg_rain,&
                                              pg_snow,qintr,qintr_rain,qintr_snow)
-      
+
       ELSEIF  (DEF_Interception_scheme==7) then
 
          CALL LEAF_interception_colm202x (   deltim,dewmx,forc_us,forc_vs,chil,sigf,lai,sai,tair,tleaf, &
@@ -1714,10 +1714,10 @@ contains
 
      pg_rain = pg_rain_tmp
      pg_snow = pg_snow_tmp
-     ldew  = sum( ldew_c(:,pc) * pcfrac(:,pc))
-     qintr = sum(qintr_c(:,pc) * pcfrac(:,pc))
-     qintr = sum(qintr_rain_c(:,pc) * pcfrac(:,pc))
-     qintr = sum(qintr_snow_c(:,pc) * pcfrac(:,pc))
+     ldew    = sum( ldew_c(:,pc) * pcfrac(:,pc))
+     qintr   = sum(qintr_c(:,pc) * pcfrac(:,pc))
+     qintr_rain = sum(qintr_rain_c(:,pc) * pcfrac(:,pc))
+     qintr_snow = sum(qintr_snow_c(:,pc) * pcfrac(:,pc))
 
  END SUBROUTINE LEAF_interception_pcwrap
 #endif

--- a/main/MOD_LeafTemperaturePC.F90
+++ b/main/MOD_LeafTemperaturePC.F90
@@ -28,10 +28,12 @@ MODULE MOD_LeafTemperaturePC
               extkn   ,extkb   ,extkd   ,hu      ,ht      ,hq      ,&
               us      ,vs      ,thm     ,th      ,thv     ,qm      ,&
               psrf    ,rhoair  ,parsun  ,parsha  ,fsun    ,sabv    ,&
-              frl     ,thermk  ,fshade  ,rstfacsun,rstfacsha,gssun,gssha,po2m  ,pco2m   ,&
+              frl     ,thermk  ,fshade  ,rstfacsun,       rstfacsha,&
+              gssun   ,gssha   ,po2m    ,pco2m   ,&
               z0h_g   ,obug    ,ustarg  ,zlnd    ,zsno    ,fsno    ,&
               sigf    ,etrc    ,tg      ,qg      ,dqgdT   ,emg     ,&
-               z0mpc   ,tl      ,ldew, ldew_rain,ldew_snow    ,taux    ,tauy    ,fseng   ,&
+              z0mpc   ,tl      ,ldew    ,ldew_rain       ,ldew_snow,&
+              taux    ,tauy    ,fseng   ,&
               fevpg   ,cgrnd   ,cgrndl  ,cgrnds  ,tref    ,qref    ,&
               rst     ,assim   ,respc   ,fsenl   ,fevpl   ,etr     ,&
               dlrad   ,ulrad   ,z0m     ,zol     ,rib     ,ustar   ,&
@@ -43,7 +45,7 @@ MODULE MOD_LeafTemperaturePC
 !Ozone stress variables
               o3coefv_sun ,o3coefv_sha ,o3coefg_sun ,o3coefg_sha, &
               lai_old, o3uptakesun, o3uptakesha, forc_ozone,&
-!End ozone stress variables              
+!End ozone stress variables
               hpbl, &
               qintr_rain,qintr_snow,t_precip,hprl,smp     ,hk      ,&
               hksati  ,rootr                                       )
@@ -86,24 +88,24 @@ MODULE MOD_LeafTemperaturePC
   USE MOD_Qsadv
   USE MOD_AssimStomataConductance
   USE MOD_PlantHydraulic, only : PlantHydraulicStress_twoleaf
-  use MOD_Ozone, only: CalcOzoneStress
+  USE MOD_Ozone, only: CalcOzoneStress
   IMPLICIT NONE
 
 !-----------------------Arguments---------------------------------------
 
-  INTEGER,  intent(in) :: ipatch
-  INTEGER , intent(in) :: &
+  integer,  intent(in) :: ipatch
+  integer , intent(in) :: &
         npft,       &! potential PFT number in a column
         canlev(npft) ! potential canopy layer in a column
 
-  REAL(r8), intent(in) :: &
+  real(r8), intent(in) :: &
         deltim,     &! seconds in a time step [second]
         csoilc,     &! drag coefficient for soil under canopy [-]
         dewmx,      &! maximum dew
         htvp         ! latent heat of evaporation (/sublimation) [J/kg]
 
 ! vegetation parameters
-  REAL(r8), dimension(npft), intent(in) :: &
+  real(r8), dimension(npft), intent(in) :: &
         fcover,     &! PFT fractiona coverage [-]
         htop,       &! PFT crown top height [m]
         hbot,       &! PFT crown bottom height [m]
@@ -125,7 +127,7 @@ MODULE MOD_LeafTemperaturePC
         binter,     &! conductance-photosynthesis intercept
         extkn        ! coefficient of leaf nitrogen allocation
 
-  REAL(r8), dimension(npft), intent(in), optional :: &
+  real(r8), dimension(npft), intent(in), optional :: &
         kmax_sun,   &
         kmax_sha,   &
         kmax_xyl,   &
@@ -136,13 +138,13 @@ MODULE MOD_LeafTemperaturePC
         psi50_root, &! water potential at 50% loss of root tissue conductance (mmH2O)
         ck           ! shape-fitting parameter for vulnerability curve (-)
 
-  REAL(r8), intent(inout) :: &
+  real(r8), intent(inout) :: &
         vegwp(1:nvegwcs,npft),  &! vegetation water potential
         gs0sun(npft),           &!
         gs0sha(npft)
 
 ! input variables
-  REAL(r8), intent(in) :: &
+  real(r8), intent(in) :: &
         hu,         &! observational height of wind [m]
         ht,         &! observational height of temperature [m]
         hq,         &! observational height of humidity [m]
@@ -183,7 +185,7 @@ MODULE MOD_LeafTemperaturePC
         dqgdT,      &! temperature derivative of "qg"
         emg          ! vegetation emissivity
 
-  REAL(r8), intent(in) :: &
+  real(r8), intent(in) :: &
         t_precip,            &! snowfall/rainfall temperature [kelvin]
         qintr_rain(npft),    &! rainfall interception (mm h2o/s)
         qintr_snow(npft),    &! snowfall interception (mm h2o/s)
@@ -192,15 +194,15 @@ MODULE MOD_LeafTemperaturePC
         hksati  (1:nl_soil), &! hydraulic conductivity at saturation [mm h2o/s]
         hk      (1:nl_soil)   ! soil hydraulic conducatance
 
-  REAL(r8), intent(in) :: &
+  real(r8), intent(in) :: &
         hpbl        ! atmospheric boundary layer height [m]
 
-  REAL(r8), dimension(npft), intent(inout) :: &
+  real(r8), dimension(npft), intent(inout) :: &
         tl,         &! leaf temperature [K]
         ldew,       &! depth of water on foliage [mm]
-        ldew_rain,       &! depth of rain on foliage [mm]
-        ldew_snow,       &! depth of snow on foliage [mm]
-!Ozone stress variables              
+        ldew_rain,  &! depth of rain on foliage [mm]
+        ldew_snow,  &! depth of snow on foliage [mm]
+!Ozone stress variables
         lai_old    ,&! lai in last time step
         o3uptakesun,&! Ozone does, sunlit leaf (mmol O3/m^2)
         o3uptakesha,&! Ozone does, shaded leaf (mmol O3/m^2)
@@ -208,23 +210,23 @@ MODULE MOD_LeafTemperaturePC
         o3coefv_sha,&! Ozone stress factor for photosynthesis on sunlit leaf
         o3coefg_sun,&! Ozone stress factor for stomata on shaded leaf
         o3coefg_sha,&! Ozone stress factor for stomata on shaded leaf
-!End ozone stress variables              
+!End ozone stress variables
         rstfacsun,  &! factor of soil water stress to transpiration on sunlit leaf
         rstfacsha,  &! factor of soil water stress to transpiration on shaded leaf
         gssun,      &
         gssha
 
-  REAL(r8), dimension(npft), intent(inout) :: &
+  real(r8), dimension(npft), intent(inout) :: &
         assimsun,   &! sunlit leaf assimilation rate [umol co2 /m**2/ s] [+]
         etrsun,     &
         assimsha,   &! shaded leaf assimilation rate [umol co2 /m**2/ s] [+]
         etrsha
 
-!Ozone stress variables              
-  REAL(r8), intent(inout) :: forc_ozone
-!End ozone stress variables              
+!Ozone stress variables
+  real(r8), intent(inout) :: forc_ozone
+!End ozone stress variables
 
-  REAL(r8), intent(inout) :: &
+  real(r8), intent(inout) :: &
         dlrad,      &! downward longwave radiation blow the canopy [W/m2]
         ulrad,      &! upward longwave radiation above the canopy [W/m2]
         taux,       &! wind stress: E-W [kg/m/s**2]
@@ -235,7 +237,7 @@ MODULE MOD_LeafTemperaturePC
         qref,       &! 2 m height air specific humidity
         rootr(nl_soil,npft)    ! fraction of root water uptake from different layers
 
-  REAL(r8), dimension(npft), intent(out) :: &
+  real(r8), dimension(npft), intent(out) :: &
         z0mpc,      &! z0m for individual PFT
         rst,        &! stomatal resistance
         assim,      &! rate of assimilation
@@ -245,7 +247,7 @@ MODULE MOD_LeafTemperaturePC
         etr,        &! transpiration rate [mm/s]
         hprl         ! precipitation sensible heat from canopy
 
-  REAL(r8), intent(inout) :: &
+  real(r8), intent(inout) :: &
         z0m,        &! effective roughness [m]
         zol,        &! dimensionless height (z/L) used in Monin-Obukhov theory
         rib,        &! bulk Richardson number in surface layer
@@ -256,22 +258,22 @@ MODULE MOD_LeafTemperaturePC
         fh,         &! integral of profile function for heat
         fq           ! integral of profile function for moisture
 
-  REAL(r8), intent(inout) :: &
+  real(r8), intent(inout) :: &
         cgrnd,      &! deriv. of soil energy flux wrt to soil temp [w/m2/k]
         cgrndl,     &! deriv, of soil latent heat flux wrt soil temp [w/m2/k]
         cgrnds       ! deriv of soil sensible heat flux wrt soil temp [w/m**2/k]
 
 !-----------------------Local Variables---------------------------------
 ! assign iteration parameters
-   INTEGER, parameter :: itmax  = 40   !maximum number of iteration
-   INTEGER, parameter :: itmin  = 6    !minimum number of iteration
-   REAL(r8),parameter :: delmax = 3.0  !maximum change in leaf temperature [K]
-   REAL(r8),parameter :: dtmin  = 0.01 !max limit for temperature convergence [K]
-   REAL(r8),parameter :: dlemin = 0.1  !max limit for energy flux convergence [w/m2]
+   integer, parameter :: itmax  = 40   !maximum number of iteration
+   integer, parameter :: itmin  = 6    !minimum number of iteration
+   real(r8),parameter :: delmax = 3.0  !maximum change in leaf temperature [K]
+   real(r8),parameter :: dtmin  = 0.01 !max limit for temperature convergence [K]
+   real(r8),parameter :: dlemin = 0.1  !max limit for energy flux convergence [w/m2]
 
-   REAL(r8) dtl(0:itmax+1,npft)     !difference of tl between two iterative step
+   real(r8) dtl(0:itmax+1,npft)     !difference of tl between two iterative step
 
-   REAL(r8) :: &
+   real(r8) :: &
         zldis,      &! reference height "minus" zero displacement heght [m]
         zii,        &! convective boundary layer height [m]
         z0mv,       &! roughness length, momentum [m]
@@ -346,13 +348,13 @@ MODULE MOD_LeafTemperaturePC
         phih         ! phi(h), similarity function for sensible heat
 
 
-   INTEGER it, nmozsgn
+   integer it, nmozsgn
 
-   REAL(r8) delta(npft), fac(npft), etr0(npft)
-   REAL(r8) evplwet(npft), evplwet_dtl(npft), etr_dtl(npft), elwmax, elwdif
-   REAL(r8) irab(npft), dirab_dtl(npft), fsenl_dtl(npft), fevpl_dtl(npft)
-   REAL(r8) w, csoilcn, z0mg, z0hg, z0qg, cintsun(3, npft), cintsha(3, npft)
-   REAL(r8), dimension(npft) :: fevpl_bef, fevpl_noadj, dtl_noadj, erre
+   real(r8) delta(npft), fac(npft), etr0(npft)
+   real(r8) evplwet(npft), evplwet_dtl(npft), etr_dtl(npft), elwmax, elwdif
+   real(r8) irab(npft), dirab_dtl(npft), fsenl_dtl(npft), fevpl_dtl(npft)
+   real(r8) w, csoilcn, z0mg, z0hg, z0qg, cintsun(3, npft), cintsha(3, npft)
+   real(r8), dimension(npft) :: fevpl_bef, fevpl_noadj, dtl_noadj, erre
    real(r8),dimension(npft) :: gb_mol_sun,gb_mol_sha
    real(r8),dimension(nl_soil) :: k_soil_root    ! radial root and soil conductance
    real(r8),dimension(nl_soil) :: k_ax_root      ! axial root conductance
@@ -361,9 +363,9 @@ MODULE MOD_LeafTemperaturePC
    ! defination for 3d run
    ! .................................................................
 
-   INTEGER , parameter :: nlay = 3
+   integer , parameter :: nlay = 3
 
-   REAL(r8), parameter :: &
+   real(r8), parameter :: &
         c1   = 0.320,  &! parameter to calculate drag coefficients of Massman's method
         c2   = 0.264,  &! parameter to calculate drag coefficients of Massman's method
         c3   = 15.1,   &! parameter to calculate drag coefficients of Massman's method
@@ -372,21 +374,21 @@ MODULE MOD_LeafTemperaturePC
         cd1  = 7.5,    &! a free parameter for d/h calculation, Raupach 1992, 1994
         psih = 0.193    ! psih = ln(cw) - 1 + cw^-1, cw = 2, Raupach 1994
 
-   REAL(r8) :: sqrtdragc! sqrt(drag coefficient)
-   REAL(r8) :: lm       ! mix length within canopy
-   REAL(r8) :: fai      ! canopy frontal area index
+   real(r8) :: sqrtdragc! sqrt(drag coefficient)
+   real(r8) :: lm       ! mix length within canopy
+   real(r8) :: fai      ! canopy frontal area index
 
-   REAL(r8), dimension(0:nlay) :: &
+   real(r8), dimension(0:nlay) :: &
         z0m_lays,      &! roughness length for momentum for the layer and below
         z0h_lays,      &! roughness length for SH for the layer and below
         z0q_lays,      &! roughness length for LH for the layer and below
         displa_lays,   &! displacement height for the layer and below
         fcover_lays     ! vegetation fractional cover for this layer and above
 
-   REAL(r8), dimension(npft) :: &
+   real(r8), dimension(npft) :: &
         lsai            ! lai + sai
 
-   REAL(r8), dimension(nlay) :: &
+   real(r8), dimension(nlay) :: &
         htop_lay,      &! canopy crown top for each layer
         hbot_lay,      &! canopy crown bottom for each layer
         fcover_lay,    &! vegetation fractional coverage for each layer
@@ -421,30 +423,30 @@ MODULE MOD_LeafTemperaturePC
         wtll,          &! sum of normalized heat conductance for air and leaf
         wtlql           ! sum of normalized heat conductance for air and leaf
 
-   REAL(r8) :: ktop, utop, fmtop, bee, tmpw1, tmpw2, fact, facq
+   real(r8) :: ktop, utop, fmtop, bee, tmpw1, tmpw2, fact, facq
 
-   INTEGER i, clev
-   INTEGER toplay, botlay, upplay, numlay
-   INTEGER d_opt, rb_opt, rd_opt
+   integer i, clev
+   integer toplay, botlay, upplay, numlay
+   integer d_opt, rb_opt, rd_opt
 
-   REAL(r8) :: displa
+   real(r8) :: displa
 
    ! variables for longwave transfer calculation
    ! .................................................................
-   REAL(r8) :: tdn(0:4,0:4)     !downward transfer coefficient matrix for LW
-   REAL(r8) :: tup(0:4,0:4)     !upward transfer coefficient matrix for LW
-   REAL(r8) :: thermk_lay(nlay) !transmittance of longwave radiation for each layer
-   REAL(r8) :: fshade_lay(nlay) !shadow of each layer
-   REAL(r8) :: L(nlay)          !longwave radiation emitted by canopy layer
-   REAL(r8) :: Ltd(nlay)        !trasmitted downward longwave radiation from canopy layer
-   REAL(r8) :: Ltu(nlay)        !trasmitted upward longwave radiation from canopy layer
-   REAL(r8) :: Lin(0:4)         !incomming longwave radiation for each layer
-   REAL(r8) :: Ld(0:4)          !total downward longwave radiation for each layer
-   REAL(r8) :: Lu(0:4)          !total upward longwave radiation for each layer
-   REAL(r8) :: Lg               !emitted longwave radiation from ground
-   REAL(r8) :: Lv(npft)         !absorbed longwave raidation for each pft
-   REAL(r8) :: dLv(npft)        !LW change due to temperature change
-   REAL(r8) :: dLvpar(nlay)     !temporal variable for calcualting dLv
+   real(r8) :: tdn(0:4,0:4)     !downward transfer coefficient matrix for LW
+   real(r8) :: tup(0:4,0:4)     !upward transfer coefficient matrix for LW
+   real(r8) :: thermk_lay(nlay) !transmittance of longwave radiation for each layer
+   real(r8) :: fshade_lay(nlay) !shadow of each layer
+   real(r8) :: L(nlay)          !longwave radiation emitted by canopy layer
+   real(r8) :: Ltd(nlay)        !trasmitted downward longwave radiation from canopy layer
+   real(r8) :: Ltu(nlay)        !trasmitted upward longwave radiation from canopy layer
+   real(r8) :: Lin(0:4)         !incomming longwave radiation for each layer
+   real(r8) :: Ld(0:4)          !total downward longwave radiation for each layer
+   real(r8) :: Lu(0:4)          !total upward longwave radiation for each layer
+   real(r8) :: Lg               !emitted longwave radiation from ground
+   real(r8) :: Lv(npft)         !absorbed longwave raidation for each pft
+   real(r8) :: dLv(npft)        !LW change due to temperature change
+   real(r8) :: dLvpar(nlay)     !temporal variable for calcualting dLv
 
 !-----------------------End Variable List-------------------------------
 
@@ -497,8 +499,7 @@ MODULE MOD_LeafTemperaturePC
 
        DO i = 1, npft
           IF (fcover(i)>0 .and. lsai(i)>1.e-6) THEN
-      CALL dewfraction (sigf(i),lai(i),sai(i),dewmx,ldew(i),ldew_rain(i),ldew_snow(i),fwet(i),fdry(i))
-
+             CALL dewfraction (sigf(i),lai(i),sai(i),dewmx,ldew(i),ldew_rain(i),ldew_snow(i),fwet(i),fdry(i))
              CALL qsadv(tl(i),psrf,ei(i),deiDT(i),qsatl(i),qsatlDT(i))
           ENDIF
        ENDDO
@@ -817,16 +818,16 @@ MODULE MOD_LeafTemperaturePC
 !-----------------------------------------------------------------------
 ! Evaluate stability-dependent variables using moz from prior iteration
 
-          if (DEF_USE_CBL_HEIGHT) then	
+          IF (DEF_USE_CBL_HEIGHT) THEN
              CALL moninobukm_leddy(hu,ht,hq,displa_lays(toplay),z0mv,z0hv,z0qv,obu,um, &
                                   displa_lay(toplay),z0m_lay(toplay), hpbl, ustar,fh2m,fq2m, &
                                   htop_lay(toplay),fmtop,fm,fh,fq,fht,fqt,phih)
-          else
+          ELSE
              CALL moninobukm(hu,ht,hq,displa_lays(toplay),z0mv,z0hv,z0qv,obu,um, &
                             displa_lay(toplay),z0m_lay(toplay),ustar,fh2m,fq2m, &
                             htop_lay(toplay),fmtop,fm,fh,fq,fht,fqt,phih)
-          endif
- 
+          ENDIF
+
 ! Aerodynamic resistance
           ! 09/16/2017:
           ! note that for ram, it is the resistance from Href to z0mv+displa
@@ -957,7 +958,7 @@ MODULE MOD_LeafTemperaturePC
              ENDIF
           ENDDO
 
-          ! 10/01/2017, back to 1D case, for test ONLY
+          ! 10/01/2017, back to 1D case, for test only
           IF (rb_opt == 1) THEN
              uaf   = ustar
              cf    = 0.01*sqrtdi(2)/sqrt(uaf)
@@ -969,7 +970,7 @@ MODULE MOD_LeafTemperaturePC
 !         csoilc = ( 1.-w + w*um/uaf)/rah      ! "rah" here is the resistance over
 !         rd = 1./(csoilc*uaf)                 ! bare ground fraction
 
-          ! 10/01/2017, back to 1D case, for test ONLY
+          ! 10/01/2017, back to 1D case, for test only
           IF (rd_opt == 1 ) THEN
 ! modified by Xubin Zeng's suggestion at 08-07-2002
              uaf   = ustar
@@ -992,14 +993,14 @@ MODULE MOD_LeafTemperaturePC
                 eah = qaf(clev) * psrf / ( 0.622 + 0.378 * qaf(clev) )    !pa
 
                 IF(DEF_USE_OZONESTRESS)THEN
-                   call CalcOzoneStress(o3coefv_sun(i),o3coefg_sun(i),forc_ozone,psrf,th,ram,&
+                   CALL CalcOzoneStress(o3coefv_sun(i),o3coefg_sun(i),forc_ozone,psrf,th,ram,&
                                         rssun(i),rbsun,lai(i),lai_old(i),i,o3uptakesun(i),deltim)
-                   call CalcOzoneStress(o3coefv_sha(i),o3coefg_sha(i),forc_ozone,psrf,th,ram,&
+                   CALL CalcOzoneStress(o3coefv_sha(i),o3coefg_sha(i),forc_ozone,psrf,th,ram,&
                                         rssha(i),rbsha,lai(i),lai_old(i),i,o3uptakesha(i),deltim)
                    lai_old(i) = lai(i)
-                END IF
-                if(DEF_USE_PLANTHYDRAULICS)then
-                   call PlantHydraulicStress_twoleaf (nl_soil   ,nvegwcs   ,z_soi    ,&
+                ENDIF
+                IF(DEF_USE_PLANTHYDRAULICS)THEN
+                   CALL PlantHydraulicStress_twoleaf (nl_soil   ,nvegwcs   ,z_soi    ,&
                          dz_soi    ,rootfr(:,i),psrf      ,qsatl(i)   ,qsatl(i)   ,&
                          qaf(clev) ,tl(i)     ,tl(i)      ,rbsun      ,rbsha      ,&
                          raw       ,rd(clev)  ,rstfacsun(i),rstfacsha(i),cintsun(:,i),&
@@ -1010,7 +1011,7 @@ MODULE MOD_LeafTemperaturePC
                          etrsun(i) ,etrsha(i) ,rootr(:,i) ,sigf(i)    ,qg         ,&
                          qm        ,gs0sun(i) ,gs0sha(i)  ,k_soil_root,k_ax_root  )
                    etr(i) = etrsun(i) + etrsha(i)
-                end if
+                END IF
 
 ! note: calculate resistance for sunlit/shaded leaves
 !-----------------------------------------------------------------------
@@ -1018,9 +1019,9 @@ MODULE MOD_LeafTemperaturePC
                     shti(i)    ,hhti(i)    ,trda(i)   ,trdm(i)   ,trop(i)   ,&
                     gradm(i)   ,binter(i)  ,thm       ,psrf      ,po2m      ,&
                     pco2m      ,pco2a      ,eah       ,ei(i)     ,tl(i)     , parsun(i)  ,&
-!Ozone stress variables              
+!Ozone stress variables
                     o3coefv_sun(i), o3coefg_sun(i), &
-!End ozone stress variables              
+!End ozone stress variables
                     rbsun      ,raw       ,rstfacsun(i),cintsun(:,i),&
                     assimsun(i),respcsun(i),rssun(i)  &
                     )
@@ -1029,14 +1030,14 @@ MODULE MOD_LeafTemperaturePC
                     shti(i)    ,hhti(i)    ,trda(i)   ,trdm(i)   ,trop(i)   ,&
                     gradm(i)   ,binter(i)  ,thm       ,psrf      ,po2m      ,&
                     pco2m      ,pco2a      ,eah       ,ei(i)     ,tl(i)     ,parsha(i) ,&
-!Ozone stress variables              
+!Ozone stress variables
                     o3coefv_sun(i), o3coefg_sun(i), &
-!End ozone stress variables              
+!End ozone stress variables
                     rbsha      ,raw       ,rstfacsha(i) ,cintsha(:,i),&
                     assimsha(i),respcsha(i),rssha(i) &
                     )
 
-                if(DEF_USE_PLANTHYDRAULICS)then
+                IF(DEF_USE_PLANTHYDRAULICS)THEN
                    gssun(i) = min( 1.e6, 1./(rssun(i)*tl(i)/tprcor) ) / cintsun(3,i) * 1.e6
                    gssha(i) = min( 1.e6, 1./(rssha(i)*tl(i)/tprcor) ) / cintsha(3,i) * 1.e6
                    gs0sun(i)  = gssun(i)/amax1(rstfacsun(i),1.e-2)
@@ -1044,15 +1045,15 @@ MODULE MOD_LeafTemperaturePC
 
                    gb_mol_sun(i) = 1./rbsun * tprcor/tl(i) / cintsun(3,i) * 1.e6  ! leaf to canopy
                    gb_mol_sha(i) = 1./rbsha * tprcor/tl(i) / cintsha(3,i) * 1.e6  ! leaf to canopy
-                end if
+                END IF
 
              ELSE
                 rssun(i) = 2.e4; assimsun(i) = 0.; respcsun(i) = 0.
                 rssha(i) = 2.e4; assimsha(i) = 0.; respcsha(i) = 0.
-                if(DEF_USE_PLANTHYDRAULICS)then
+                IF(DEF_USE_PLANTHYDRAULICS)THEN
                    etr(i) = 0.
                    rootr(:,i) = 0.
-                end if
+                END IF
              ENDIF
           ENDDO
 
@@ -1319,12 +1320,12 @@ MODULE MOD_LeafTemperaturePC
                    ENDIF
                 ENDIF
 
-                if(.not. DEF_USE_PLANTHYDRAULICS)then
+                IF(.not. DEF_USE_PLANTHYDRAULICS)THEN
                    IF(etr(i).ge.etrc(i))THEN
                       etr(i) = etrc(i)
                       etr_dtl(i) = 0.
                    ENDIF
-                end if
+                END IF
 
                 evplwet(i) = rhoair * (1.-delta(i)*(1.-fwet(i))) * lsai(i)/rb(i) &
                            * ( qsatl(i) - qaf(clev) )
@@ -1393,7 +1394,7 @@ MODULE MOD_LeafTemperaturePC
                 tl(i) = tlbef(i) + dtl(it,i)
 
 !-----------------------------------------------------------------------
-! square roots differences of temperatures and fluxes for use as the condition of convergences
+! square roots differences of temperatures and fluxes for USE as the condition of convergences
 !-----------------------------------------------------------------------
 
                 del(i)  = sqrt( dtl(it,i)*dtl(it,i) )
@@ -1409,7 +1410,7 @@ MODULE MOD_LeafTemperaturePC
                 CALL qsadv(tl(i),psrf,ei(i),deiDT(i),qsatl(i),qsatlDT(i))
 
              ENDIF
-          ENDDO !end pft loop
+          ENDDO !END pft loop
 
 ! update vegetation/ground surface temperature, canopy air temperature,
 ! canopy air humidity
@@ -1503,9 +1504,9 @@ MODULE MOD_LeafTemperaturePC
           IF(zeta .ge. 0.)THEN
              um = max(ur,.1)
           ELSE
-             if (DEF_USE_CBL_HEIGHT) then !//TODO: Shaofeng, 2023.05.18
+             IF (DEF_USE_CBL_HEIGHT) THEN !//TODO: Shaofeng, 2023.05.18
                zii = max(5.*hu,hpbl)
-             endif !//TODO: Shaofeng, 2023.05.18
+             ENDIF !//TODO: Shaofeng, 2023.05.18
              wc = (-grav*ustar*thvstar*zii/thv)**(1./3.)
              wc2 = beta*beta*(wc*wc)
              um = sqrt(ur*ur+wc2)
@@ -1566,45 +1567,45 @@ MODULE MOD_LeafTemperaturePC
 
              etr0(i)    = etr(i)
              etr(i)     = etr(i)     +     etr_dtl(i)*dtl(it-1,i)
-             if(DEF_USE_PLANTHYDRAULICS)then
-                if(abs(etr0(i)) .ge. 1.e-15)then
+             IF(DEF_USE_PLANTHYDRAULICS)THEN
+                IF(abs(etr0(i)) .ge. 1.e-15)THEN
                    rootr(:,i) = rootr(:,i) * etr(i) / etr0(i)
-                else
+                ELSE
                    rootr(:,i) = rootr(:,i) + dz_soi / sum(dz_soi) * etr_dtl(i)* dtl(it-1,i)
-                end if
-             end if
+                END IF
+             END IF
              evplwet(i) = evplwet(i) + evplwet_dtl(i)*dtl(it-1,i)
              fevpl(i)   = fevpl_noadj(i)
              fevpl(i)   = fevpl(i)   +   fevpl_dtl(i)*dtl(it-1,i)
 
              elwmax  = ldew(i)/deltim
 
-             ! 03/02/2018: convert fc to whole area
+             ! 03/02/2018, yuan: convert fc to whole area
              ! because ldew now is for the whole area
              ! may need to change to canopy covered area
-             ! 09/14/2019: change back to canopy area
+             ! 09/14/2019, yuan: change back to canopy area
              elwdif  = max(0., evplwet(i)-elwmax)
              evplwet(i) = min(evplwet(i), elwmax)
 
              fevpl(i) = fevpl(i) - elwdif
              fsenl(i) = fsenl(i) + hvap*elwdif
-             hprl(i) = cpliq*qintr_rain(i)*(t_precip-tl(i)) + cpice*qintr_snow(i)*(t_precip-tl(i))
+             hprl(i)  = cpliq*qintr_rain(i)*(t_precip-tl(i)) + cpice*qintr_snow(i)*(t_precip-tl(i))
 
 !-----------------------------------------------------------------------
 ! Update dew accumulation (kg/m2)
 !-----------------------------------------------------------------------
 !#ifdef CLM5_INTERCEPTION
-   if (ldew_rain(i).gt.evplwet(i)*deltim) then
-      ldew_rain(i) = ldew_rain(i)-evplwet(i)*deltim
-      ldew_snow(i) = ldew_snow(i)
-      ldew=ldew_rain(i)+ldew_snow(i)
-   else
-      ldew_rain(i) = 0.0
-      ldew_snow(i) = max(0., ldew(i)-evplwet(i)*deltim)
-      ldew(i)      = ldew_snow(i)
-   endif
+!            IF (ldew_rain(i).gt.evplwet(i)*deltim) THEN
+!               ldew_rain(i) = ldew_rain(i)-evplwet(i)*deltim
+!               ldew_snow(i) = ldew_snow(i)
+!               ldew=ldew_rain(i)+ldew_snow(i)
+!            ELSE
+!               ldew_rain(i) = 0.0
+!               ldew_snow(i) = max(0., ldew(i)-evplwet(i)*deltim)
+!               ldew(i)      = ldew_snow(i)
+!            ENDIF
 !#else
-!       ldew(i) = max(0., ldew(i)-evplwet(i)*deltim)
+             ldew(i) = max(0., ldew(i)-evplwet(i)*deltim)
 !#endif
 
 !-----------------------------------------------------------------------
@@ -1683,19 +1684,19 @@ MODULE MOD_LeafTemperaturePC
  USE MOD_Precision
  IMPLICIT NONE
 
-  REAL(r8), intent(in) :: sigf   !fraction of veg cover, excluding snow-covered veg [-]
-  REAL(r8), intent(in) :: lai    !leaf area index  [-]
-  REAL(r8), intent(in) :: sai    !stem area index  [-]
-  REAL(r8), intent(in) :: dewmx  !maximum allowed dew [0.1 mm]
-  REAL(r8), intent(in) :: ldew   !depth of water on foliage [kg/m2/s]
-  REAL(r8), intent(in) :: ldew_rain   !depth of rain on foliage [kg/m2/s]
-  REAL(r8), intent(in) :: ldew_snow   !depth of snow on foliage [kg/m2/s]
-  REAL(r8), intent(out) :: fwet  !fraction of foliage covered by water [-]
-  REAL(r8), intent(out) :: fdry  !fraction of foliage that is green and dry [-]
+  real(r8), intent(in) :: sigf   !fraction of veg cover, excluding snow-covered veg [-]
+  real(r8), intent(in) :: lai    !leaf area index  [-]
+  real(r8), intent(in) :: sai    !stem area index  [-]
+  real(r8), intent(in) :: dewmx  !maximum allowed dew [0.1 mm]
+  real(r8), intent(in) :: ldew   !depth of water on foliage [kg/m2/s]
+  real(r8), intent(in) :: ldew_rain   !depth of rain on foliage [kg/m2/s]
+  real(r8), intent(in) :: ldew_snow   !depth of snow on foliage [kg/m2/s]
+  real(r8), intent(out) :: fwet  !fraction of foliage covered by water [-]
+  real(r8), intent(out) :: fdry  !fraction of foliage that is green and dry [-]
 
-  REAL(r8) lsai                  !lai + sai
-  REAL(r8) dewmxi                !inverse of maximum allowed dew [1/mm]
-  REAL(r8) vegt                  !sigf*lsai, NOTE: remove sigf
+  real(r8) lsai                  !lai + sai
+  real(r8) dewmxi                !inverse of maximum allowed dew [1/mm]
+  real(r8) vegt                  !sigf*lsai, NOTE: remove sigf
 !
 !-----------------------------------------------------------------------
 ! Fwet is the fraction of all vegetation surfaces which are wet
@@ -1722,22 +1723,22 @@ MODULE MOD_LeafTemperaturePC
   END SUBROUTINE dewfraction
 !----------------------------------------------------------------------
 
-  REAL(r8) FUNCTION uprofile(utop, fc, bee, alpha, z0mg, htop, hbot, z)
+  real(r8) FUNCTION uprofile(utop, fc, bee, alpha, z0mg, htop, hbot, z)
 
      USE MOD_Precision
      USE MOD_FrictionVelocity
      IMPLICIT NONE
 
-     REAL(r8), intent(in) :: utop
-     REAL(r8), intent(in) :: fc
-     REAL(r8), intent(in) :: bee
-     REAL(r8), intent(in) :: alpha
-     REAL(r8), intent(in) :: z0mg
-     REAL(r8), intent(in) :: htop
-     REAL(r8), intent(in) :: hbot
-     REAL(r8), intent(in) :: z
+     real(r8), intent(in) :: utop
+     real(r8), intent(in) :: fc
+     real(r8), intent(in) :: bee
+     real(r8), intent(in) :: alpha
+     real(r8), intent(in) :: z0mg
+     real(r8), intent(in) :: htop
+     real(r8), intent(in) :: hbot
+     real(r8), intent(in) :: z
 
-     REAL(r8) :: ulog,uexp
+     real(r8) :: ulog,uexp
 
      ! when canopy LAI->0, z0->zs, fac->1, u->umoninobuk
      ! canopy LAI->large, fac->0 or=0, u->log profile
@@ -1749,29 +1750,29 @@ MODULE MOD_LeafTemperaturePC
      RETURN
   END FUNCTION uprofile
 
-  REAL(r8) FUNCTION kprofile(ktop, fc, bee, alpha, &
+  real(r8) FUNCTION kprofile(ktop, fc, bee, alpha, &
                     displah, htop, hbot, obu, ustar, z)
 
      USE MOD_Precision
      USE MOD_FrictionVelocity
      IMPLICIT NONE
 
-     REAL(r8), parameter :: com1 = 0.4
-     REAL(r8), parameter :: com2 = 0.08
+     real(r8), parameter :: com1 = 0.4
+     real(r8), parameter :: com2 = 0.08
 
-     REAL(r8), intent(in) :: ktop
-     REAL(r8), intent(in) :: fc
-     REAL(r8), intent(in) :: bee
-     REAL(r8), intent(in) :: alpha
-     REAL(r8), intent(in) :: displah
-     REAL(r8), intent(in) :: htop
-     REAL(r8), intent(in) :: hbot
-     REAL(r8), intent(in) :: obu
-     REAL(r8), intent(in) :: ustar
-     REAL(r8), intent(in) :: z
+     real(r8), intent(in) :: ktop
+     real(r8), intent(in) :: fc
+     real(r8), intent(in) :: bee
+     real(r8), intent(in) :: alpha
+     real(r8), intent(in) :: displah
+     real(r8), intent(in) :: htop
+     real(r8), intent(in) :: hbot
+     real(r8), intent(in) :: obu
+     real(r8), intent(in) :: ustar
+     real(r8), intent(in) :: z
 
-     REAL(r8) :: fac
-     REAL(r8) :: kcob, klin, kexp
+     real(r8) :: fac
+     real(r8) :: kcob, klin, kexp
 
      klin = ktop*z/htop
 
@@ -1785,21 +1786,21 @@ MODULE MOD_LeafTemperaturePC
      RETURN
   END FUNCTION kprofile
 
-  REAL(r8) FUNCTION uintegral(utop, fc, bee, alpha, z0mg, htop, hbot)
+  real(r8) FUNCTION uintegral(utop, fc, bee, alpha, z0mg, htop, hbot)
 
      USE MOD_Precision
      IMPLICIT NONE
 
-     REAL(r8), intent(in) :: utop
-     REAL(r8), intent(in) :: fc
-     REAL(r8), intent(in) :: bee
-     REAL(r8), intent(in) :: alpha
-     REAL(r8), intent(in) :: z0mg
-     REAL(r8), intent(in) :: htop
-     REAL(r8), intent(in) :: hbot
+     real(r8), intent(in) :: utop
+     real(r8), intent(in) :: fc
+     real(r8), intent(in) :: bee
+     real(r8), intent(in) :: alpha
+     real(r8), intent(in) :: z0mg
+     real(r8), intent(in) :: htop
+     real(r8), intent(in) :: hbot
 
-     INTEGER  :: i, n
-     REAL(r8) :: dz, z, u
+     integer  :: i, n
+     real(r8) :: dz, z, u
 
      ! 09/26/2017: change fixed n -> fixed dz
      dz = 0.01
@@ -1832,21 +1833,21 @@ MODULE MOD_LeafTemperaturePC
   END FUNCTION uintegral
 
 
-  REAL(r8) FUNCTION ueffect(utop, htop, hbot, &
+  real(r8) FUNCTION ueffect(utop, htop, hbot, &
                             z0mg, alpha, bee, fc)
      USE MOD_Precision
      IMPLICIT NONE
 
-     REAL(r8), intent(in) :: utop
-     REAL(r8), intent(in) :: htop
-     REAL(r8), intent(in) :: hbot
-     REAL(r8), intent(in) :: z0mg
-     REAL(r8), intent(in) :: alpha
-     REAL(r8), intent(in) :: bee
-     REAL(r8), intent(in) :: fc
+     real(r8), intent(in) :: utop
+     real(r8), intent(in) :: htop
+     real(r8), intent(in) :: hbot
+     real(r8), intent(in) :: z0mg
+     real(r8), intent(in) :: alpha
+     real(r8), intent(in) :: bee
+     real(r8), intent(in) :: fc
 
-     REAL(r8) :: roots(2), uint
-     INTEGER  :: rootn
+     real(r8) :: roots(2), uint
+     integer  :: rootn
 
      rootn = 0
      uint  = 0.
@@ -1881,19 +1882,19 @@ MODULE MOD_LeafTemperaturePC
   END FUNCTION ueffect
 
 
-  REAL(r8) FUNCTION fuint(utop, ztop, zbot, &
+  real(r8) FUNCTION fuint(utop, ztop, zbot, &
         htop, hbot, z0mg, alpha, bee, fc)
 
      USE MOD_Precision
      IMPLICIT NONE
 
-     REAL(r8), intent(in) :: utop, ztop, zbot
-     REAL(r8), intent(in) :: htop, hbot
-     REAL(r8), intent(in) :: z0mg, alpha
-     REAL(r8), intent(in) :: bee, fc
+     real(r8), intent(in) :: utop, ztop, zbot
+     real(r8), intent(in) :: htop, hbot
+     real(r8), intent(in) :: z0mg, alpha
+     real(r8), intent(in) :: bee, fc
 
      ! local variables
-     REAL(r8) :: fuexpint, fulogint
+     real(r8) :: fuexpint, fulogint
 
      fulogint = utop/log(htop/z0mg) *&
         (ztop*log(ztop/z0mg) - zbot*log(zbot/z0mg) + zbot - ztop)
@@ -1920,15 +1921,15 @@ MODULE MOD_LeafTemperaturePC
      USE MOD_Precision
      IMPLICIT NONE
 
-     REAL(r8), intent(in) :: ztop, zbot, zmid
-     REAL(r8), intent(in) :: utop, htop, hbot
-     REAL(r8), intent(in) :: z0mg, alpha
+     real(r8), intent(in) :: ztop, zbot, zmid
+     real(r8), intent(in) :: utop, htop, hbot
+     real(r8), intent(in) :: z0mg, alpha
 
-     REAL(r8), intent(inout) :: roots(2)
-     INTEGER,  intent(inout) :: rootn
+     real(r8), intent(inout) :: roots(2)
+     integer,  intent(inout) :: rootn
 
      ! local variables
-     REAL(r8) :: udif_ub, udif_lb
+     real(r8) :: udif_ub, udif_lb
 
      udif_ub = udif(ztop,utop,htop,hbot,z0mg,alpha)
      udif_lb = udif(zmid,utop,htop,hbot,z0mg,alpha)
@@ -1985,15 +1986,15 @@ MODULE MOD_LeafTemperaturePC
   END SUBROUTINE ufindroots
 
 
-  REAL(r8) FUNCTION udif(z, utop, htop, hbot, z0mg, alpha)
+  real(r8) FUNCTION udif(z, utop, htop, hbot, z0mg, alpha)
 
      USE MOD_Precision
      IMPLICIT NONE
 
-     REAL(r8), intent(in) :: z, utop, htop, hbot
-     REAL(r8), intent(in) :: z0mg, alpha
+     real(r8), intent(in) :: z, utop, htop, hbot
+     real(r8), intent(in) :: z0mg, alpha
 
-     REAL(r8) :: uexp, ulog
+     real(r8) :: uexp, ulog
 
      uexp = utop*exp(-alpha*(1-(z-hbot)/(htop-hbot)))
      ulog = utop*log(z/z0mg)/log(htop/z0mg)
@@ -2004,26 +2005,26 @@ MODULE MOD_LeafTemperaturePC
   END FUNCTION udif
 
 
-  REAL(r8) FUNCTION kintegral(ktop, fc, bee, alpha, z0mg, &
+  real(r8) FUNCTION kintegral(ktop, fc, bee, alpha, z0mg, &
                     displah, htop, hbot, obu, ustar, ztop, zbot)
      USE MOD_Precision
      IMPLICIT NONE
 
-     REAL(r8), intent(in) :: ktop
-     REAL(r8), intent(in) :: fc
-     REAL(r8), intent(in) :: bee
-     REAL(r8), intent(in) :: alpha
-     REAL(r8), intent(in) :: z0mg
-     REAL(r8), intent(in) :: displah
-     REAL(r8), intent(in) :: htop
-     REAL(r8), intent(in) :: hbot
-     REAL(r8), intent(in) :: obu
-     REAL(r8), intent(in) :: ustar
-     REAL(r8), intent(in) :: ztop
-     REAL(r8), intent(in) :: zbot
+     real(r8), intent(in) :: ktop
+     real(r8), intent(in) :: fc
+     real(r8), intent(in) :: bee
+     real(r8), intent(in) :: alpha
+     real(r8), intent(in) :: z0mg
+     real(r8), intent(in) :: displah
+     real(r8), intent(in) :: htop
+     real(r8), intent(in) :: hbot
+     real(r8), intent(in) :: obu
+     real(r8), intent(in) :: ustar
+     real(r8), intent(in) :: ztop
+     real(r8), intent(in) :: zbot
 
-     INTEGER  :: i, n
-     REAL(r8) :: dz, z, k
+     integer  :: i, n
+     real(r8) :: dz, z, k
 
      kintegral = 0.
 
@@ -2053,24 +2054,24 @@ MODULE MOD_LeafTemperaturePC
      RETURN
   END FUNCTION kintegral
 
-  REAL(r8) FUNCTION frd(ktop, htop, hbot, &
+  real(r8) FUNCTION frd(ktop, htop, hbot, &
         ztop, zbot, displah, z0h, obu, ustar, &
         z0mg, alpha, bee, fc)
 
      USE MOD_Precision
      IMPLICIT NONE
 
-     REAL(r8), intent(in) :: ktop, htop, hbot
-     REAL(r8), intent(in) :: ztop, zbot
-     REAL(r8), intent(in) :: displah, z0h, obu, ustar
-     REAL(r8), intent(in) :: z0mg, alpha, bee, fc
+     real(r8), intent(in) :: ktop, htop, hbot
+     real(r8), intent(in) :: ztop, zbot
+     real(r8), intent(in) :: displah, z0h, obu, ustar
+     real(r8), intent(in) :: z0mg, alpha, bee, fc
 
      ! local parameters
-     REAL(r8), parameter :: com1 = 0.4
-     REAL(r8), parameter :: com2 = 0.08
+     real(r8), parameter :: com1 = 0.4
+     real(r8), parameter :: com2 = 0.08
 
-     REAL(r8) :: roots(2), fac, kint
-     INTEGER  :: rootn
+     real(r8) :: roots(2), fac, kint
+     integer  :: rootn
 
      rootn = 0
      kint  = 0.
@@ -2109,20 +2110,20 @@ MODULE MOD_LeafTemperaturePC
   END FUNCTION frd
 
 
-  REAL(r8) FUNCTION fkint(ktop, ztop, zbot, htop, hbot, &
+  real(r8) FUNCTION fkint(ktop, ztop, zbot, htop, hbot, &
         z0h, obu, ustar, fac, alpha, bee, fc)
 
      USE MOD_Precision
      USE MOD_FrictionVelocity
      IMPLICIT NONE
 
-     REAL(r8), intent(in) :: ktop, ztop, zbot
-     REAL(r8), intent(in) :: htop, hbot
-     REAL(r8), intent(in) :: z0h, obu, ustar, fac, alpha
-     REAL(r8), intent(in) :: bee, fc
+     real(r8), intent(in) :: ktop, ztop, zbot
+     real(r8), intent(in) :: htop, hbot
+     real(r8), intent(in) :: z0h, obu, ustar, fac, alpha
+     real(r8), intent(in) :: bee, fc
 
      ! local variables
-     REAL(r8) :: fkexpint, fkcobint
+     real(r8) :: fkexpint, fkcobint
 
      !NOTE:
      ! klin = ktop*z/htop
@@ -2156,15 +2157,15 @@ MODULE MOD_LeafTemperaturePC
      USE MOD_Precision
      IMPLICIT NONE
 
-     REAL(r8), intent(in) :: ztop, zbot, zmid
-     REAL(r8), intent(in) :: ktop, htop, hbot
-     REAL(r8), intent(in) :: obu, ustar, fac, alpha
+     real(r8), intent(in) :: ztop, zbot, zmid
+     real(r8), intent(in) :: ktop, htop, hbot
+     real(r8), intent(in) :: obu, ustar, fac, alpha
 
-     REAL(r8), intent(inout) :: roots(2)
-     INTEGER,  intent(inout) :: rootn
+     real(r8), intent(inout) :: roots(2)
+     integer,  intent(inout) :: rootn
 
      ! local variables
-     REAL(r8) :: kdif_ub, kdif_lb
+     real(r8) :: kdif_ub, kdif_lb
 
      !print *, "*** CALL recursive SUBROUTINE kfindroots!!"
      kdif_ub = kdif(ztop,ktop,htop,hbot,obu,ustar,fac,alpha)
@@ -2222,17 +2223,17 @@ MODULE MOD_LeafTemperaturePC
   END SUBROUTINE kfindroots
 
 
-  REAL(r8) FUNCTION kdif(z, ktop, htop, hbot, &
+  real(r8) FUNCTION kdif(z, ktop, htop, hbot, &
         obu, ustar, fac, alpha)
 
      USE MOD_Precision
      USE MOD_FrictionVelocity
      IMPLICIT NONE
 
-     REAL(r8), intent(in) :: z, ktop, htop, hbot
-     REAL(r8), intent(in) :: obu, ustar, fac, alpha
+     real(r8), intent(in) :: z, ktop, htop, hbot
+     real(r8), intent(in) :: obu, ustar, fac, alpha
 
-     REAL(r8) :: kexp, klin, kcob
+     real(r8) :: kexp, klin, kcob
 
      kexp = ktop*exp(-alpha*(1-(z-hbot)/(htop-hbot)))
 
@@ -2250,18 +2251,18 @@ MODULE MOD_LeafTemperaturePC
      USE MOD_Const_Physical, only: vonkar
      IMPLICIT NONE
 
-     REAL(r8), intent(in)  :: lai
-     REAL(r8), intent(in)  :: h
-     REAL(r8), intent(in)  :: fc
-     REAL(r8), intent(out) :: z0
-     REAL(r8), intent(out) :: displa
+     real(r8), intent(in)  :: lai
+     real(r8), intent(in)  :: h
+     real(r8), intent(in)  :: fc
+     real(r8), intent(out) :: z0
+     real(r8), intent(out) :: displa
 
-     REAL(r8), parameter :: Cd   = 0.2   !leaf drag coefficient
-     REAL(r8), parameter :: cd1  = 7.5   !a free parameter for d/h calculation, Raupach 1992, 1994
-     REAL(r8), parameter :: psih = 0.193 !psih = ln(cw) - 1 + cw^-1, cw = 2, Raupach 1994
+     real(r8), parameter :: Cd   = 0.2   !leaf drag coefficient
+     real(r8), parameter :: cd1  = 7.5   !a free parameter for d/h calculation, Raupach 1992, 1994
+     real(r8), parameter :: psih = 0.193 !psih = ln(cw) - 1 + cw^-1, cw = 2, Raupach 1994
 
      ! local variables
-     REAL(r8) :: fai, sqrtdragc, temp1, delta , lai0
+     real(r8) :: fai, sqrtdragc, temp1, delta , lai0
 
      ! when assume z0=0.01, displa=0
      ! to calculate lai0, delta displa
@@ -2284,7 +2285,7 @@ MODULE MOD_LeafTemperaturePC
 
      ! calculate z0m, displa
      !----------------------------------------------------
-     ! NOTE: potential bug below, ONLY apply for spheric
+     ! NOTE: potential bug below, only apply for spheric
      ! crowns. For other cases, fc*(...) ==> a*fc*(...)
      fai   = fc*(1. - exp(-0.5*lai))
      sqrtdragc = min( (0.003+0.3*fai)**0.5, 0.3 )

--- a/main/MOD_Thermal.F90
+++ b/main/MOD_Thermal.F90
@@ -37,12 +37,12 @@ MODULE MOD_Thermal
                       rootfr      ,rstfacsun_out   ,rstfacsha_out       ,&
                       gssun_out   ,gssha_out   ,&
                       assimsun_out,etrsun_out  ,assimsha_out,etrsha_out ,&
-! photosynthesis and plant hydraulic variables                      
-                      effcon      ,vmax25      ,hksati      ,smp        ,hk,&
+! photosynthesis and plant hydraulic variables
+                      effcon      ,vmax25      ,hksati      ,smp     ,hk,&
                       kmax_sun    ,kmax_sha    ,kmax_xyl    ,kmax_root  ,&
                       psi50_sun   ,psi50_sha   ,psi50_xyl   ,psi50_root ,&
                       ck          ,vegwp       ,gs0sun      ,gs0sha     ,&
-!Ozone stress variables                      
+!Ozone stress variables
                       lai_old     ,o3uptakesun ,o3uptakesha ,forc_ozone, &
 !end ozone stress variables
                       slti        ,hlti        ,shti        ,hhti       ,&
@@ -56,7 +56,7 @@ MODULE MOD_Thermal
                       extkb       ,extkd       ,thermk      ,fsno       ,&
                       sigf        ,dz_soisno   ,z_soisno    ,zi_soisno  ,&
                       tleaf       ,t_soisno    ,wice_soisno ,wliq_soisno,&
-                      ldew, ldew_rain, ldew_snow,    scv         ,snowdp      ,imelt      ,&
+                      ldew,ldew_rain,ldew_snow ,scv,snowdp  ,imelt      ,&
                       taux        ,tauy        ,fsena       ,fevpa      ,&
                       lfevpa      ,fsenl       ,fevpl       ,etr        ,&
                       fseng       ,fevpg       ,olrg        ,fgrnd      ,&
@@ -99,7 +99,7 @@ MODULE MOD_Thermal
   USE MOD_Vars_Global
   USE MOD_Const_PFT
   USE MOD_Const_Physical, only: denh2o,roverg,hvap,hsub,rgas,cpair,&
-                                  stefnc,denice,tfrz,vonkar,grav,cpliq,cpice
+                                stefnc,denice,tfrz,vonkar,grav,cpliq,cpice
   USE MOD_FrictionVelocity
   USE MOD_Eroot
   USE MOD_GroundFluxes
@@ -122,20 +122,20 @@ MODULE MOD_Thermal
 #ifdef vanGenuchten_Mualem_SOIL_MODEL
   USE MOD_Hydro_SoilFunction, only : soil_psi_from_vliq
 #endif
-use MOD_SPMD_Task
+USE MOD_SPMD_Task
   USE MOD_Namelist, only: DEF_USE_PLANTHYDRAULICS
 
   IMPLICIT NONE
 
 !---------------------Argument------------------------------------------
 
-  INTEGER, intent(in) :: &
+  integer, intent(in) :: &
         ipatch,      &! patch index
         lb,          &! lower bound of array
-        patchtype     ! land water TYPE (0=soil, 1=urban or built-up, 2=wetland,
+        patchtype     ! land water type (0=soil, 1=urban or built-up, 2=wetland,
                       !                  3=glacier/ice sheet, 4=land water bodies)
 
-  REAL(r8), intent(in) :: &
+  real(r8), intent(in) :: &
         deltim,      &! model time step [second]
         trsmx0,      &! max transpiration for moist soil+100% veg.  [mm/s]
         zlnd,        &! roughness length for soil [m]
@@ -159,12 +159,12 @@ use MOD_SPMD_Task
         bsw(1:nl_soil),    &! clapp and hornbereger "b" parameter [-]
 #endif
 #ifdef vanGenuchten_Mualem_SOIL_MODEL
-        theta_r  (1:nl_soil), &
-        alpha_vgm(1:nl_soil), &
-        n_vgm    (1:nl_soil), &
-        L_vgm    (1:nl_soil), &
-        sc_vgm   (1:nl_soil), &
-        fc_vgm   (1:nl_soil), &
+        theta_r  (1:nl_soil),  &
+        alpha_vgm(1:nl_soil),  &
+        n_vgm    (1:nl_soil),  &
+        L_vgm    (1:nl_soil),  &
+        sc_vgm   (1:nl_soil),  &
+        fc_vgm   (1:nl_soil),  &
 #endif
         k_solids  (1:nl_soil), &! thermal conductivity of minerals soil [W/m-K]
         dkdry     (1:nl_soil), &! thermal conductivity of dry soil [W/m-K]
@@ -184,15 +184,15 @@ use MOD_SPMD_Task
 
         effcon,      &! quantum efficiency of RuBP regeneration (mol CO2/mol quanta)
         vmax25,      &! maximum carboxylation rate at 25 C at canopy top
-        kmax_sun,   &
-        kmax_sha,   &
-        kmax_xyl,   &
-        kmax_root,  &
-        psi50_sun,  &! water potential at 50% loss of sunlit leaf tissue conductance (mmH2O)
-        psi50_sha,  &! water potential at 50% loss of shaded leaf tissue conductance (mmH2O)
-        psi50_xyl,  &! water potential at 50% loss of xylem tissue conductance (mmH2O)
-        psi50_root, &! water potential at 50% loss of root tissue conductance (mmH2O)
-        ck,         &! shape-fitting parameter for vulnerability curve (-)
+        kmax_sun,    &
+        kmax_sha,    &
+        kmax_xyl,    &
+        kmax_root,   &
+        psi50_sun,   &! water potential at 50% loss of sunlit leaf tissue conductance (mmH2O)
+        psi50_sha,   &! water potential at 50% loss of shaded leaf tissue conductance (mmH2O)
+        psi50_xyl,   &! water potential at 50% loss of xylem tissue conductance (mmH2O)
+        psi50_root,  &! water potential at 50% loss of root tissue conductance (mmH2O)
+        ck,          &! shape-fitting parameter for vulnerability curve (-)
         slti,        &! slope of low temperature inhibition function      [s3]
         hlti,        &! 1/2 point of low temperature inhibition function  [s4]
         shti,        &! slope of high temperature inhibition function     [s1]
@@ -242,19 +242,19 @@ use MOD_SPMD_Task
         z_soisno (lb:nl_soil),  &! node depth [m]
         zi_soisno(lb-1:nl_soil)  ! interface depth [m]
 
-  REAL(r8), intent(in) :: &
+  real(r8), intent(in) :: &
         sabg_lyr(lb:1)           ! snow layer aborption
 
         ! state variables (2)
-  REAL(r8), intent(inout) :: &
+  real(r8), intent(inout) :: &
         vegwp(1:nvegwcs),&! vegetation water potential
         gs0sun,      &!
         gs0sha,      &!
-!Ozone stress variables        
-        lai_old    ,& ! lai in last time step
-        o3uptakesun,& ! Ozone does, sunlit leaf (mmol O3/m^2)
-        o3uptakesha,& ! Ozone does, shaded leaf (mmol O3/m^2)
-        forc_ozone ,& ! Ozone
+!Ozone stress variables
+        lai_old    , & ! lai in last time step
+        o3uptakesun, & ! Ozone does, sunlit leaf (mmol O3/m^2)
+        o3uptakesha, & ! Ozone does, shaded leaf (mmol O3/m^2)
+        forc_ozone , & ! Ozone
 !end ozone stress variables
         tleaf,       &! shaded leaf temperature [K]
         t_soisno(lb:nl_soil),   &! soil temperature [K]
@@ -264,32 +264,32 @@ use MOD_SPMD_Task
         hk(1:nl_soil)          ,&! hydraulic conductivity [mm h2o/s]
 
         ldew,        &! depth of water on foliage [kg/(m2 s)]
-        ldew_rain,        &! depth of rain on foliage [kg/(m2 s)]
-        ldew_snow,        &! depth of rain on foliage [kg/(m2 s)]
+        ldew_rain,   &! depth of rain on foliage [kg/(m2 s)]
+        ldew_snow,   &! depth of rain on foliage [kg/(m2 s)]
         scv,         &! snow cover, water equivalent [mm, kg/m2]
         snowdp        ! snow depth [m]
 
-  REAL(r8), intent(out) :: &
+  real(r8), intent(out) :: &
         snofrz (lb:0) !snow freezing rate (col,lyr) [kg m-2 s-1]
 
-  INTEGER, intent(out) :: &
+  integer, intent(out) :: &
        imelt(lb:nl_soil) ! flag for melting or freezing [-]
 
-  REAL(r8), intent(out) :: &
+  real(r8), intent(out) :: &
        laisun,       &! sunlit leaf area index
        laisha,       &! shaded leaf area index
        gssun_out,    &! sunlit stomata conductance
        gssha_out,    &! shaded stomata conductance
        rstfacsun_out,&! factor of soil water stress on sunlit leaf
        rstfacsha_out  ! factor of soil water stress on shaded leaf
-  REAL(r8), intent(out) :: &
-       assimsun_out           ,&
-       etrsun_out             ,&
-       assimsha_out           ,&
-       etrsha_out            
+  real(r8), intent(out) :: &
+       assimsun_out ,&
+       etrsun_out   ,&
+       assimsha_out ,&
+       etrsha_out
 
         ! Output fluxes
-  REAL(r8), intent(out) :: &
+  real(r8), intent(out) :: &
         taux,        &! wind stress: E-W [kg/m/s**2]
         tauy,        &! wind stress: N-S [kg/m/s**2]
         fsena,       &! sensible heat from canopy height to atmosphere [W/m2]
@@ -332,9 +332,9 @@ use MOD_SPMD_Task
 
 !---------------------Local Variables-----------------------------------
 
-  INTEGER i,j
+  integer i,j
 
-  REAL(r8) :: &
+  real(r8) :: &
        cgrnd,        &! deriv. of soil energy flux wrt to soil temp [w/m2/k]
        cgrndl,       &! deriv, of soil sensible heat flux wrt soil temp [w/m2/k]
        cgrnds,       &! deriv of soil latent heat flux wrt soil temp [w/m**2/k]
@@ -377,61 +377,61 @@ use MOD_SPMD_Task
        xmf,          &! total latent heat of phase change of ground water
        hprl           ! precipitation sensible heat from canopy
 
-  REAL(r8) :: z0m_g,z0h_g,zol_g,obu_g,rib_g,ustar_g,qstar_g,tstar_g
-  REAL(r8) :: fm10m,fm_g,fh_g,fq_g,fh2m,fq2m,um,obu
+  real(r8) :: z0m_g,z0h_g,zol_g,obu_g,rib_g,ustar_g,qstar_g,tstar_g
+  real(r8) :: fm10m,fm_g,fh_g,fq_g,fh2m,fq2m,um,obu
 !Ozone stress variables
-  REAL(r8) :: o3coefv_sun, o3coefv_sha, o3coefg_sun, o3coefg_sha
+  real(r8) :: o3coefv_sun, o3coefv_sha, o3coefg_sun, o3coefg_sha
 !end ozone stress variables
 
-  INTEGER p, ps, pe, pc
+  integer p, ps, pe, pc
 
 #ifdef LULC_IGBP_PFT
-  REAL(r8), allocatable :: rootr_p (:,:)
-  REAL(r8), allocatable :: etrc_p  (:)
-  REAL(r8), allocatable :: rstfac_p(:)
-  REAL(r8), allocatable :: rstfacsun_p(:)
-  REAL(r8), allocatable :: rstfacsha_p(:)
-  REAL(r8), allocatable :: gssun_p(:)
-  REAL(r8), allocatable :: gssha_p(:)
-  REAL(r8), allocatable :: fsun_p  (:)
-  REAL(r8), allocatable :: sabv_p  (:)
-  REAL(r8), allocatable :: cgrnd_p (:)
-  REAL(r8), allocatable :: cgrnds_p(:)
-  REAL(r8), allocatable :: cgrndl_p(:)
-  REAL(r8), allocatable :: dlrad_p (:)
-  REAL(r8), allocatable :: ulrad_p (:)
-  REAL(r8), allocatable :: zol_p   (:)
-  REAL(r8), allocatable :: rib_p   (:)
-  REAL(r8), allocatable :: ustar_p (:)
-  REAL(r8), allocatable :: qstar_p (:)
-  REAL(r8), allocatable :: tstar_p (:)
-  REAL(r8), allocatable :: fm_p    (:)
-  REAL(r8), allocatable :: fh_p    (:)
-  REAL(r8), allocatable :: fq_p    (:)
-  REAL(r8), allocatable :: hprl_p  (:)
-  REAL(r8), allocatable :: assimsun_p          (:)
-  REAL(r8), allocatable :: etrsun_p            (:)
-  REAL(r8), allocatable :: assimsha_p          (:)
-  REAL(r8), allocatable :: etrsha_p            (:)
+  real(r8), allocatable :: rootr_p     (:,:)
+  real(r8), allocatable :: etrc_p        (:)
+  real(r8), allocatable :: rstfac_p      (:)
+  real(r8), allocatable :: rstfacsun_p   (:)
+  real(r8), allocatable :: rstfacsha_p   (:)
+  real(r8), allocatable :: gssun_p       (:)
+  real(r8), allocatable :: gssha_p       (:)
+  real(r8), allocatable :: fsun_p        (:)
+  real(r8), allocatable :: sabv_p        (:)
+  real(r8), allocatable :: cgrnd_p       (:)
+  real(r8), allocatable :: cgrnds_p      (:)
+  real(r8), allocatable :: cgrndl_p      (:)
+  real(r8), allocatable :: dlrad_p       (:)
+  real(r8), allocatable :: ulrad_p       (:)
+  real(r8), allocatable :: zol_p         (:)
+  real(r8), allocatable :: rib_p         (:)
+  real(r8), allocatable :: ustar_p       (:)
+  real(r8), allocatable :: qstar_p       (:)
+  real(r8), allocatable :: tstar_p       (:)
+  real(r8), allocatable :: fm_p          (:)
+  real(r8), allocatable :: fh_p          (:)
+  real(r8), allocatable :: fq_p          (:)
+  real(r8), allocatable :: hprl_p        (:)
+  real(r8), allocatable :: assimsun_p    (:)
+  real(r8), allocatable :: etrsun_p      (:)
+  real(r8), allocatable :: assimsha_p    (:)
+  real(r8), allocatable :: etrsha_p      (:)
 #endif
 
 #ifdef LULC_IGBP_PC
-  REAL(r8) :: rootr_c (nl_soil,0:N_PFT-1)
-  REAL(r8) :: etrc_c  (0:N_PFT-1)
-  REAL(r8) :: rstfac_c(0:N_PFT-1)
-  REAL(r8) :: rstfacsun_c(0:N_PFT-1)
-  REAL(r8) :: rstfacsha_c(0:N_PFT-1)
-  REAL(r8) :: gssun_c (0:N_PFT-1)
-  REAL(r8) :: gssha_c (0:N_PFT-1)
-  REAL(r8) :: laisun_c(0:N_PFT-1)
-  REAL(r8) :: laisha_c(0:N_PFT-1)
-  REAL(r8) :: fsun_c  (0:N_PFT-1)
-  REAL(r8) :: sabv_c  (0:N_PFT-1)
-  REAL(r8) :: hprl_c  (0:N_PFT-1)
-  REAL(r8) :: assimsun_c          (0:N_PFT-1)
-  REAL(r8) :: etrsun_c            (0:N_PFT-1)
-  REAL(r8) :: assimsha_c          (0:N_PFT-1)
-  REAL(r8) :: etrsha_c            (0:N_PFT-1)
+  real(r8) :: rootr_c (nl_soil,0:N_PFT-1)
+  real(r8) :: etrc_c          (0:N_PFT-1)
+  real(r8) :: rstfac_c        (0:N_PFT-1)
+  real(r8) :: rstfacsun_c     (0:N_PFT-1)
+  real(r8) :: rstfacsha_c     (0:N_PFT-1)
+  real(r8) :: gssun_c         (0:N_PFT-1)
+  real(r8) :: gssha_c         (0:N_PFT-1)
+  real(r8) :: laisun_c        (0:N_PFT-1)
+  real(r8) :: laisha_c        (0:N_PFT-1)
+  real(r8) :: fsun_c          (0:N_PFT-1)
+  real(r8) :: sabv_c          (0:N_PFT-1)
+  real(r8) :: hprl_c          (0:N_PFT-1)
+  real(r8) :: assimsun_c      (0:N_PFT-1)
+  real(r8) :: etrsun_c        (0:N_PFT-1)
+  real(r8) :: assimsha_c      (0:N_PFT-1)
+  real(r8) :: etrsha_c        (0:N_PFT-1)
 #endif
 
 !=======================================================================
@@ -576,7 +576,8 @@ IF (patchtype == 0) THEN
                  gssun_out  ,gssha_out  ,forc_po2m ,forc_pco2m ,z0h_g      ,&
                  obu_g      ,ustar_g    ,zlnd      ,zsno       ,fsno       ,&
                  sigf       ,etrc       ,t_grnd    ,qg         ,dqgdT      ,&
-                 emg        ,tleaf      ,ldew, ldew_rain, ldew_snow      ,taux       ,tauy       ,&
+                 emg        ,tleaf      ,ldew      ,ldew_rain  ,ldew_snow  ,&
+                 taux       ,tauy       ,&
                  fseng      ,fevpg      ,cgrnd     ,cgrndl     ,cgrnds     ,&
                  tref       ,qref       ,rst       ,assim      ,respc      ,&
                  fsenl      ,fevpl      ,etr       ,dlrad      ,ulrad      ,&
@@ -588,8 +589,8 @@ IF (patchtype == 0) THEN
                  assimsun_out,etrsun_out,assimsha_out          ,etrsha_out ,&
 !Ozone stress variables
                  o3coefv_sun ,o3coefv_sha ,o3coefg_sun ,o3coefg_sha, &
-                 lai_old     ,o3uptakesun ,o3uptakesha ,forc_ozone, &
-!end ozone stress variables                 
+                 lai_old     ,o3uptakesun ,o3uptakesha ,forc_ozone , &
+!end ozone stress variables
                  forc_hpbl                                                 ,&
                  qintr_rain  ,qintr_snow,t_precip  ,hprl       ,smp        ,&
                  hk(1:)      ,hksati(1:),rootr(1:)                         )
@@ -598,17 +599,17 @@ IF (patchtype == 0) THEN
     ! equate canopy temperature to air over bareland.
     ! required as sigf=0 carried over to next time step
       IF (lai+sai <= 1e-6) THEN
-         tleaf  = forc_t
-         laisun = 0.
-         laisha = 0.
-         ldew_rain   = 0.
-         ldew_snow   = 0.
-         ldew   = 0.
+         tleaf         = forc_t
+         laisun        = 0.
+         laisha        = 0.
+         ldew_rain     = 0.
+         ldew_snow     = 0.
+         ldew          = 0.
          rstfacsun_out = 0.
          rstfacsha_out = 0.
-         if(DEF_USE_PLANTHYDRAULICS)then
+         if(DEF_USE_PLANTHYDRAULICS)THEN
             vegwp = -2.5e4
-         end if
+         ENDIF
       ENDIF
 #endif
 
@@ -620,32 +621,32 @@ IF (patchtype == 0) THEN
       pe = patch_pft_e(ipatch)
 
       allocate ( rootr_p (nl_soil, ps:pe) )
-      allocate ( etrc_p  (ps:pe) )
-      allocate ( rstfac_p(ps:pe) )
-      allocate ( rstfacsun_p(ps:pe) )
-      allocate ( rstfacsha_p(ps:pe) )
-      allocate ( gssun_p(ps:pe) )
-      allocate ( gssha_p(ps:pe) )
-      allocate ( fsun_p  (ps:pe) )
-      allocate ( sabv_p  (ps:pe) )
-      allocate ( cgrnd_p (ps:pe) )
-      allocate ( cgrnds_p(ps:pe) )
-      allocate ( cgrndl_p(ps:pe) )
-      allocate ( dlrad_p (ps:pe) )
-      allocate ( ulrad_p (ps:pe) )
-      allocate ( zol_p   (ps:pe) )
-      allocate ( rib_p   (ps:pe) )
-      allocate ( ustar_p (ps:pe) )
-      allocate ( qstar_p (ps:pe) )
-      allocate ( tstar_p (ps:pe) )
-      allocate ( fm_p    (ps:pe) )
-      allocate ( fh_p    (ps:pe) )
-      allocate ( fq_p    (ps:pe) )
-      allocate ( hprl_p  (ps:pe) )
-      allocate ( assimsun_p         (ps:pe) )
-      allocate ( etrsun_p           (ps:pe) )
-      allocate ( assimsha_p         (ps:pe) )
-      allocate ( etrsha_p           (ps:pe) )
+      allocate ( etrc_p           (ps:pe) )
+      allocate ( rstfac_p         (ps:pe) )
+      allocate ( rstfacsun_p      (ps:pe) )
+      allocate ( rstfacsha_p      (ps:pe) )
+      allocate ( gssun_p          (ps:pe) )
+      allocate ( gssha_p          (ps:pe) )
+      allocate ( fsun_p           (ps:pe) )
+      allocate ( sabv_p           (ps:pe) )
+      allocate ( cgrnd_p          (ps:pe) )
+      allocate ( cgrnds_p         (ps:pe) )
+      allocate ( cgrndl_p         (ps:pe) )
+      allocate ( dlrad_p          (ps:pe) )
+      allocate ( ulrad_p          (ps:pe) )
+      allocate ( zol_p            (ps:pe) )
+      allocate ( rib_p            (ps:pe) )
+      allocate ( ustar_p          (ps:pe) )
+      allocate ( qstar_p          (ps:pe) )
+      allocate ( tstar_p          (ps:pe) )
+      allocate ( fm_p             (ps:pe) )
+      allocate ( fh_p             (ps:pe) )
+      allocate ( fq_p             (ps:pe) )
+      allocate ( hprl_p           (ps:pe) )
+      allocate ( assimsun_p       (ps:pe) )
+      allocate ( etrsun_p         (ps:pe) )
+      allocate ( assimsha_p       (ps:pe) )
+      allocate ( etrsha_p         (ps:pe) )
 
       ! always DO CALL groundfluxes
       CALL groundfluxes (zlnd,zsno,forc_hgt_u,forc_hgt_t,forc_hgt_q, &
@@ -702,7 +703,8 @@ IF (patchtype == 0) THEN
                  gssun_p(i) ,gssha_p(i) ,forc_po2m  ,forc_pco2m ,z0h_g      ,&
                  obu_g      ,ustar_g    ,zlnd       ,zsno       ,fsno       ,&
                  sigf_p(i)  ,etrc_p(i)  ,t_grnd     ,qg         ,dqgdT      ,&
-                 emg        ,tleaf_p(i) ,ldew_p(i)  ,ldew_rain_p(i)  ,ldew_snow_p(i)  ,taux_p(i)  ,tauy_p(i)  ,&
+                 emg        ,tleaf_p(i) ,ldew_p(i)  ,ldew_rain_p(i),ldew_snow_p(i),&
+                 taux_p(i)  ,tauy_p(i)  ,&
                  fseng_p(i) ,fevpg_p(i) ,cgrnd_p(i) ,cgrndl_p(i),cgrnds_p(i),&
                  tref_p(i)  ,qref_p(i)  ,rst_p(i)   ,assim_p(i) ,respc_p(i) ,&
                  fsenl_p(i) ,fevpl_p(i) ,etr_p(i)   ,dlrad_p(i) ,ulrad_p(i) ,&
@@ -711,12 +713,12 @@ IF (patchtype == 0) THEN
                  kmax_sun_p(p) ,kmax_sha_p(p) ,kmax_xyl_p(p)  ,kmax_root_p(p) ,psi50_sun_p(p),&
                  psi50_sha_p(p),psi50_xyl_p(p),psi50_root_p(p),ck_p(p)        ,vegwp_p(:,i)  ,&
                  gs0sun_p(i)   ,gs0sha_p(i)                                                  ,&
-                 assimsun_p(i)      , etrsun_p(i) , assimsha_p(i)      ,etrsha_p(i) ,&
-!Ozone stress variables                 
-                 o3coefv_sun_p(i) ,o3coefv_sha_p(i) ,o3coefg_sun_p(i) ,o3coefg_sha_p(i), &
-                 lai_old_p(i), o3uptakesun_p(i) ,o3uptakesha_p(i) ,forc_ozone,  &
-!end ozone stress variables                 
-                 forc_hpbl                                                     ,&
+                 assimsun_p(i) ,etrsun_p(i)   ,assimsha_p(i)  ,etrsha_p(i)    ,&
+!Ozone stress variables
+                 o3coefv_sun_p(i) ,o3coefv_sha_p(i) ,o3coefg_sun_p(i) ,o3coefg_sha_p(i),&
+                 lai_old_p(i), o3uptakesun_p(i) ,o3uptakesha_p(i) ,forc_ozone ,&
+!end ozone stress variables
+                 forc_hpbl                                                  ,&
                  qintr_rain_p(i),qintr_snow_p(i),t_precip,hprl_p(i),smp     ,&
                  hk(1:)      ,hksati(1:),rootr_p(1:,i)                      )
 
@@ -730,71 +732,72 @@ IF (patchtype == 0) THEN
                                taux_p(i),tauy_p(i),fseng_p(i),fevpg_p(i),tref_p(i),qref_p(i), &
             z0m_p(i),z0h_g,zol_p(i),rib_p(i),ustar_p(i),qstar_p(i),tstar_p(i),fm_p(i),fh_p(i),fq_p(i))
 
-            tleaf_p(i)     = forc_t
-            laisun_p(i)    = 0.
-            laisha_p(i)    = 0.
-            ldew_rain_p(i) = 0.
-            ldew_snow_p(i) = 0.
-            ldew_p(i)      = 0.
-            rootr_p(:,i)   = 0.
-            rstfacsun_p(i) = 0.
-            rstfacsha_p(i) = 0.
-            gssun_p(i)     = 0.
-            gssha_p(i)     = 0.
-            assimsun_p          (i) = 0.
-            etrsun_p            (i) = 0.
-            assimsha_p          (i) = 0.
-            etrsha_p            (i) = 0.
-            rst_p(i)     = 2.0e4
-            assim_p(i)   = 0.
-            respc_p(i)   = 0.
-            fsenl_p(i)   = 0.
-            fevpl_p(i)   = 0.
-            etr_p(i)     = 0.
-            dlrad_p(i)   = frl
-            ulrad_p(i)   = frl*(1.-emg) + emg*stefnc*t_grnd**4
-            hprl_p(i)    = 0.
-            if(DEF_USE_PLANTHYDRAULICS)then
+            tleaf_p      (i) = forc_t
+            laisun_p     (i) = 0.
+            laisha_p     (i) = 0.
+            ldew_rain_p  (i) = 0.
+            ldew_snow_p  (i) = 0.
+            ldew_p       (i) = 0.
+            rootr_p    (:,i) = 0.
+            rstfacsun_p  (i) = 0.
+            rstfacsha_p  (i) = 0.
+            gssun_p      (i) = 0.
+            gssha_p      (i) = 0.
+            assimsun_p   (i) = 0.
+            etrsun_p     (i) = 0.
+            assimsha_p   (i) = 0.
+            etrsha_p     (i) = 0.
+            rst_p        (i) = 2.0e4
+            assim_p      (i) = 0.
+            respc_p      (i) = 0.
+            fsenl_p      (i) = 0.
+            fevpl_p      (i) = 0.
+            etr_p        (i) = 0.
+            dlrad_p      (i) = frl
+            ulrad_p      (i) = frl*(1.-emg) + emg*stefnc*t_grnd**4
+            hprl_p       (i) = 0.
+
+            IF(DEF_USE_PLANTHYDRAULICS)THEN
                vegwp_p(:,i) = -2.5e4
-            end if
+            ENDIF
          ENDIF
       ENDDO
 
-      laisun = sum( laisun_p(ps:pe)*pftfrac(ps:pe) )
-      laisha = sum( laisha_p(ps:pe)*pftfrac(ps:pe) )
-      dlrad  = sum( dlrad_p (ps:pe)*pftfrac(ps:pe) )
-      ulrad  = sum( ulrad_p (ps:pe)*pftfrac(ps:pe) )
-      tleaf  = sum( tleaf_p (ps:pe)*pftfrac(ps:pe) )
-      ldew_rain = sum( ldew_rain_p  (ps:pe)*pftfrac(ps:pe) )
-      ldew_snow = sum( ldew_snow_p  (ps:pe)*pftfrac(ps:pe) )
-      ldew   = sum( ldew_p  (ps:pe)*pftfrac(ps:pe) )
-      tref   = sum( tref_p  (ps:pe)*pftfrac(ps:pe) )
-      qref   = sum( qref_p  (ps:pe)*pftfrac(ps:pe) )
+      laisun    = sum( laisun_p    (ps:pe)*pftfrac(ps:pe) )
+      laisha    = sum( laisha_p    (ps:pe)*pftfrac(ps:pe) )
+      dlrad     = sum( dlrad_p     (ps:pe)*pftfrac(ps:pe) )
+      ulrad     = sum( ulrad_p     (ps:pe)*pftfrac(ps:pe) )
+      tleaf     = sum( tleaf_p     (ps:pe)*pftfrac(ps:pe) )
+      ldew_rain = sum( ldew_rain_p (ps:pe)*pftfrac(ps:pe) )
+      ldew_snow = sum( ldew_snow_p (ps:pe)*pftfrac(ps:pe) )
+      ldew      = sum( ldew_p      (ps:pe)*pftfrac(ps:pe) )
+      tref      = sum( tref_p      (ps:pe)*pftfrac(ps:pe) )
+      qref      = sum( qref_p      (ps:pe)*pftfrac(ps:pe) )
       ! may have problem with rst, but the same for LC
-      rst    = sum( rst_p   (ps:pe)*pftfrac(ps:pe) )
-      assim  = sum( assim_p (ps:pe)*pftfrac(ps:pe) )
-      respc  = sum( respc_p (ps:pe)*pftfrac(ps:pe) )
-      taux   = sum( taux_p  (ps:pe)*pftfrac(ps:pe) )
-      tauy   = sum( tauy_p  (ps:pe)*pftfrac(ps:pe) )
-      fseng  = sum( fseng_p (ps:pe)*pftfrac(ps:pe) )
-      fevpg  = sum( fevpg_p (ps:pe)*pftfrac(ps:pe) )
-      cgrnd  = sum( cgrnd_p (ps:pe)*pftfrac(ps:pe) )
-      cgrndl = sum( cgrndl_p(ps:pe)*pftfrac(ps:pe) )
-      cgrnds = sum( cgrnds_p(ps:pe)*pftfrac(ps:pe) )
-      fsenl  = sum( fsenl_p (ps:pe)*pftfrac(ps:pe) )
-      fevpl  = sum( fevpl_p (ps:pe)*pftfrac(ps:pe) )
-      etr    = sum( etr_p   (ps:pe)*pftfrac(ps:pe) )
-      z0m    = sum( z0m_p   (ps:pe)*pftfrac(ps:pe) )
-      zol    = sum( zol_p   (ps:pe)*pftfrac(ps:pe) )
-      rib    = sum( rib_p   (ps:pe)*pftfrac(ps:pe) )
-      ustar  = sum( ustar_p (ps:pe)*pftfrac(ps:pe) )
-      qstar  = sum( qstar_p (ps:pe)*pftfrac(ps:pe) )
-      tstar  = sum( tstar_p (ps:pe)*pftfrac(ps:pe) )
-      fm     = sum( fm_p    (ps:pe)*pftfrac(ps:pe) )
-      fh     = sum( fh_p    (ps:pe)*pftfrac(ps:pe) )
-      fq     = sum( fq_p    (ps:pe)*pftfrac(ps:pe) )
+      rst       = sum( rst_p       (ps:pe)*pftfrac(ps:pe) )
+      assim     = sum( assim_p     (ps:pe)*pftfrac(ps:pe) )
+      respc     = sum( respc_p     (ps:pe)*pftfrac(ps:pe) )
+      taux      = sum( taux_p      (ps:pe)*pftfrac(ps:pe) )
+      tauy      = sum( tauy_p      (ps:pe)*pftfrac(ps:pe) )
+      fseng     = sum( fseng_p     (ps:pe)*pftfrac(ps:pe) )
+      fevpg     = sum( fevpg_p     (ps:pe)*pftfrac(ps:pe) )
+      cgrnd     = sum( cgrnd_p     (ps:pe)*pftfrac(ps:pe) )
+      cgrndl    = sum( cgrndl_p    (ps:pe)*pftfrac(ps:pe) )
+      cgrnds    = sum( cgrnds_p    (ps:pe)*pftfrac(ps:pe) )
+      fsenl     = sum( fsenl_p     (ps:pe)*pftfrac(ps:pe) )
+      fevpl     = sum( fevpl_p     (ps:pe)*pftfrac(ps:pe) )
+      etr       = sum( etr_p       (ps:pe)*pftfrac(ps:pe) )
+      z0m       = sum( z0m_p       (ps:pe)*pftfrac(ps:pe) )
+      zol       = sum( zol_p       (ps:pe)*pftfrac(ps:pe) )
+      rib       = sum( rib_p       (ps:pe)*pftfrac(ps:pe) )
+      ustar     = sum( ustar_p     (ps:pe)*pftfrac(ps:pe) )
+      qstar     = sum( qstar_p     (ps:pe)*pftfrac(ps:pe) )
+      tstar     = sum( tstar_p     (ps:pe)*pftfrac(ps:pe) )
+      fm        = sum( fm_p        (ps:pe)*pftfrac(ps:pe) )
+      fh        = sum( fh_p        (ps:pe)*pftfrac(ps:pe) )
+      fq        = sum( fq_p        (ps:pe)*pftfrac(ps:pe) )
 
-      if(DEF_USE_PLANTHYDRAULICS)then
+      IF(DEF_USE_PLANTHYDRAULICS)THEN
          DO j = 1, nvegwcs
             vegwp(j) = sum( vegwp_p(j,ps:pe)*pftfrac(ps:pe) )
          ENDDO
@@ -804,24 +807,23 @@ IF (patchtype == 0) THEN
                rootr(j) = sum(rootr_p(j,ps:pe)*pftfrac(ps:pe))
             ENDDO
          ENDIF
-      else
+      ELSE
          IF (etr > 0.) THEN
             DO j = 1, nl_soil
                rootr(j) = sum(rootr_p(j,ps:pe)*etr_p(ps:pe)*pftfrac(ps:pe)) / etr
             ENDDO
          ENDIF
-      end if
+      ENDIF
 
-      rstfacsun_out         = sum( rstfacsun_p         (ps:pe) * pftfrac(ps:pe) )
-      rstfacsha_out         = sum( rstfacsha_p         (ps:pe) * pftfrac(ps:pe) )
-      gssun_out             = sum( gssun_p             (ps:pe) * pftfrac(ps:pe) )
-      gssha_out             = sum( gssha_p             (ps:pe) * pftfrac(ps:pe) )
-      assimsun_out          = sum( assimsun_p          (ps:pe) * pftfrac(ps:pe) )
-      etrsun_out            = sum( etrsun_p            (ps:pe) * pftfrac(ps:pe) )
-      assimsha_out          = sum( assimsha_p          (ps:pe) * pftfrac(ps:pe) )
-      etrsha_out            = sum( etrsha_p            (ps:pe) * pftfrac(ps:pe) )
-
-      hprl = sum( hprl_p  (ps:pe)*pftfrac(ps:pe) )
+      rstfacsun_out = sum( rstfacsun_p (ps:pe) * pftfrac(ps:pe) )
+      rstfacsha_out = sum( rstfacsha_p (ps:pe) * pftfrac(ps:pe) )
+      gssun_out     = sum( gssun_p     (ps:pe) * pftfrac(ps:pe) )
+      gssha_out     = sum( gssha_p     (ps:pe) * pftfrac(ps:pe) )
+      assimsun_out  = sum( assimsun_p  (ps:pe) * pftfrac(ps:pe) )
+      etrsun_out    = sum( etrsun_p    (ps:pe) * pftfrac(ps:pe) )
+      assimsha_out  = sum( assimsha_p  (ps:pe) * pftfrac(ps:pe) )
+      etrsha_out    = sum( etrsha_p    (ps:pe) * pftfrac(ps:pe) )
+      hprl          = sum( hprl_p      (ps:pe) * pftfrac(ps:pe) )
 
       deallocate ( rootr_p     )
       deallocate ( etrc_p      )
@@ -871,6 +873,7 @@ IF (patchtype == 0) THEN
 
       sabv_c(:) = sabvsun_c(:,pc) + sabvsha_c(:,pc)
       sabv = sabvsun + sabvsha
+      hprl_c(:) = 0.
 
       DO p = 0, N_PFT-1
 
@@ -889,7 +892,7 @@ IF (patchtype == 0) THEN
 
             ! fraction of sunlit and shaded leaves of canopy
             fsun_c(p) = ( 1. - exp(-min(extkb_c(p,pc)*lai_c(p,pc),40.))) &
-                       / max( min(extkb_c(p,pc)*lai_c(p,pc),40.), 1.e-6 )
+                      / max( min(extkb_c(p,pc)*lai_c(p,pc),40.), 1.e-6 )
 
             ! 01/06/2020, yuan: change to 0.5
             IF (coszen<=0.0 .or. sabv_c(p)<1.) fsun_c(p) = 0.5
@@ -915,79 +918,81 @@ IF (patchtype == 0) THEN
             fsenl_c(p,pc)     = 0.
             fevpl_c(p,pc)     = 0.
             etr_c(p,pc)       = 0.
-            hprl_c(p)         = 0.
-            if(DEF_USE_PLANTHYDRAULICS)then
+
+            IF(DEF_USE_PLANTHYDRAULICS)THEN
                vegwp_c (:,p,pc)  = -2.5e4
-            end if
+            ENDIF
          ENDIF
 
       ENDDO
 
       IF (lai+sai > 1e-6) THEN
 
-         CALL LeafTempPC (ipatch,N_PFT  ,deltim        ,csoilc        ,dewmx         ,&
-           htvp          ,pcfrac(:,pc)  ,canlay(:)     ,htop_c(:,pc)  ,hbot_c(:,pc)  ,&
-           lai_c(:,pc)   ,sai_c(:,pc)   ,sqrtdi_p(:)   ,effcon_p(:)   ,vmax25_p(:)   ,&
-           slti_p(:)     ,hlti_p(:)     ,shti_p(:)     ,hhti_p(:)     ,trda_p(:)     ,&
-           trdm_p(:)     ,trop_p(:)     ,gradm_p(:)    ,binter_p(:)   ,extkn_p(:)    ,&
-           extkb_c(:,pc) ,extkd_c(:,pc) ,forc_hgt_u    ,forc_hgt_t    ,forc_hgt_q    ,&
-           forc_us       ,forc_vs       ,thm           ,th            ,thv           ,&
-           forc_q        ,forc_psrf     ,forc_rhoair   ,parsun_c(:,pc),parsha_c(:,pc),&
-           fsun_c(:)     ,sabv_c(:)     ,frl           ,thermk_c(:,pc),fshade_c(:,pc),&
-           rstfacsun_c(:)            ,rstfacsha_c(:)            ,&
-           gssun_c(:) ,gssha_c(:) ,forc_po2m     ,forc_pco2m    ,z0h_g         ,obu_g,&
-           ustar_g       ,zlnd          ,zsno          ,fsno          ,sigf_c(:,pc)  ,&
-           etrc_c(:)     ,t_grnd        ,qg            ,dqgdT         ,emg           ,&
-           z0m_c(:,pc)   ,tleaf_c(:,pc) ,ldew_c(:,pc)  ,ldew_rain_c(:,pc)  ,ldew_snow_c(:,pc)  ,taux          ,tauy          ,&
-           fseng         ,fevpg         ,cgrnd         ,cgrndl        ,cgrnds        ,&
-           tref          ,qref          ,rst_c(:,pc)   ,assim_c(:,pc) ,respc_c(:,pc) ,&
-           fsenl_c(:,pc) ,fevpl_c(:,pc) ,etr_c(:,pc)   ,dlrad         ,ulrad         ,&
-           z0m           ,zol           ,rib           ,ustar         ,qstar         ,&
-           tstar         ,fm            ,fh            ,fq            ,rootfr_p(:,:) ,&
-           kmax_sun_p(:) ,kmax_sha_p(:) ,kmax_xyl_p(:) ,kmax_root_p(:),psi50_sun_p(:),&
-           psi50_sha_p(:),psi50_xyl_p(:),psi50_root_p(:),ck_p(:)      ,vegwp_c(:,:,pc),&
-           gs0sun_c(:,pc),gs0sha_c(:,pc)                                             ,&
-           assimsun_c(:)             ,etrsun_c(:)      ,assimsha_c(:) ,etrsha_c(:),&
-!Ozone stress variables                 
-           o3coefv_sun_c(:,pc) ,o3coefv_sha_c(:,pc) ,o3coefg_sun_c(:,pc) ,o3coefg_sha_c(:,pc), &
-           lai_old_c(:,pc), o3uptakesun_c(:,pc), o3uptakesha_c(:,pc),forc_ozone,  &
-!End ozone stress variables                 
-           forc_hpbl                                                                  ,&
-           qintr_rain_c(:,pc),qintr_snow_c(:,pc),t_precip,hprl_c(:)   ,smp           ,&
-           hk(1:)        ,hksati(1:)    ,rootr_c(:,:)                                )
+         CALL LeafTempPC ( ipatch,N_PFT  ,deltim        ,csoilc        ,dewmx         ,&
+            htvp          ,pcfrac(:,pc)  ,canlay(:)     ,htop_c(:,pc)  ,hbot_c(:,pc)  ,&
+            lai_c(:,pc)   ,sai_c(:,pc)   ,sqrtdi_p(:)   ,effcon_p(:)   ,vmax25_p(:)   ,&
+            slti_p(:)     ,hlti_p(:)     ,shti_p(:)     ,hhti_p(:)     ,trda_p(:)     ,&
+            trdm_p(:)     ,trop_p(:)     ,gradm_p(:)    ,binter_p(:)   ,extkn_p(:)    ,&
+            extkb_c(:,pc) ,extkd_c(:,pc) ,forc_hgt_u    ,forc_hgt_t    ,forc_hgt_q    ,&
+            forc_us       ,forc_vs       ,thm           ,th            ,thv           ,&
+            forc_q        ,forc_psrf     ,forc_rhoair   ,parsun_c(:,pc),parsha_c(:,pc),&
+            fsun_c(:)     ,sabv_c(:)     ,frl           ,thermk_c(:,pc),fshade_c(:,pc),&
+            rstfacsun_c(:)               ,rstfacsha_c(:)                              ,&
+            gssun_c(:) ,gssha_c(:) ,forc_po2m     ,forc_pco2m    ,z0h_g         ,obu_g,&
+            ustar_g       ,zlnd          ,zsno          ,fsno          ,sigf_c(:,pc)  ,&
+            etrc_c(:)     ,t_grnd        ,qg            ,dqgdT         ,emg           ,&
+            z0m_c(:,pc),tleaf_c(:,pc),ldew_c(:,pc),ldew_rain_c(:,pc),ldew_snow_c(:,pc),&
+            taux          ,tauy          ,&
+            fseng         ,fevpg         ,cgrnd         ,cgrndl        ,cgrnds        ,&
+            tref          ,qref          ,rst_c(:,pc)   ,assim_c(:,pc) ,respc_c(:,pc) ,&
+            fsenl_c(:,pc) ,fevpl_c(:,pc) ,etr_c(:,pc)   ,dlrad         ,ulrad         ,&
+            z0m           ,zol           ,rib           ,ustar         ,qstar         ,&
+            tstar         ,fm            ,fh            ,fq            ,rootfr_p(:,:) ,&
+            kmax_sun_p(:) ,kmax_sha_p(:) ,kmax_xyl_p(:) ,kmax_root_p(:),psi50_sun_p(:),&
+            psi50_sha_p(:),psi50_xyl_p(:),psi50_root_p(:),ck_p(:)     ,vegwp_c(:,:,pc),&
+            gs0sun_c(:,pc),gs0sha_c(:,pc)                                             ,&
+            assimsun_c(:) ,etrsun_c(:)   ,assimsha_c(:) ,etrsha_c(:)                  ,&
+!Ozone stress variables
+            o3coefv_sun_c(:,pc) ,o3coefv_sha_c(:,pc) ,o3coefg_sun_c(:,pc) ,o3coefg_sha_c(:,pc), &
+            lai_old_c(:,pc), o3uptakesun_c(:,pc), o3uptakesha_c(:,pc),forc_ozone,  &
+!End ozone stress variables
+            forc_hpbl                                                                  ,&
+            qintr_rain_c(:,pc),qintr_snow_c(:,pc),t_precip,hprl_c(:)   ,smp            ,&
+            hk(1:)        ,hksati(1:)    ,rootr_c(:,:)                                  )
       ELSE
-         laisun_c(:)    = 0.
-         laisha_c(:)    = 0.
-         tleaf_c (:,pc) = forc_t
+         laisun_c    (:)    = 0.
+         laisha_c    (:)    = 0.
+         tleaf_c     (:,pc) = forc_t
          ldew_rain_c (:,pc) = 0.
          ldew_snow_c (:,pc) = 0.
-         ldew_c  (:,pc) = 0.
-         rst_c   (:,pc) = 2.0e4
-         assim_c (:,pc) = 0.
-         respc_c (:,pc) = 0.
-         fsenl_c (:,pc) = 0.
-         fevpl_c (:,pc) = 0.
-         etr_c   (:,pc) = 0.
-         hprl_c  (:)    = 0.
-         if(DEF_USE_PLANTHYDRAULICS)then
+         ldew_c      (:,pc) = 0.
+         rst_c       (:,pc) = 2.0e4
+         assim_c     (:,pc) = 0.
+         respc_c     (:,pc) = 0.
+         fsenl_c     (:,pc) = 0.
+         fevpl_c     (:,pc) = 0.
+         etr_c       (:,pc) = 0.
+         hprl_c      (:)    = 0.
+
+         IF(DEF_USE_PLANTHYDRAULICS)THEN
             vegwp_c (:,:,pc) = -2.5e4
-         end if
+         ENDIF
       ENDIF
 
-      laisun = sum( laisun_c(:)   *pcfrac(:,pc) )
-      laisha = sum( laisha_c(:)   *pcfrac(:,pc) )
-      tleaf  = sum( tleaf_c (:,pc)*pcfrac(:,pc) )
+      laisun    = sum( laisun_c    (:)   *pcfrac(:,pc) )
+      laisha    = sum( laisha_c    (:)   *pcfrac(:,pc) )
+      tleaf     = sum( tleaf_c     (:,pc)*pcfrac(:,pc) )
       ldew_rain = sum( ldew_rain_c (:,pc)*pcfrac(:,pc) )
       ldew_snow = sum( ldew_snow_c (:,pc)*pcfrac(:,pc) )
-      ldew   = sum( ldew_c  (:,pc)*pcfrac(:,pc) )
-      rst    = sum( rst_c   (:,pc)*pcfrac(:,pc) )
-      assim  = sum( assim_c (:,pc)*pcfrac(:,pc) )
-      respc  = sum( respc_c (:,pc)*pcfrac(:,pc) )
-      fsenl  = sum( fsenl_c (:,pc)*pcfrac(:,pc) )
-      fevpl  = sum( fevpl_c (:,pc)*pcfrac(:,pc) )
-      etr    = sum( etr_c   (:,pc)*pcfrac(:,pc) )
+      ldew      = sum( ldew_c      (:,pc)*pcfrac(:,pc) )
+      rst       = sum( rst_c       (:,pc)*pcfrac(:,pc) )
+      assim     = sum( assim_c     (:,pc)*pcfrac(:,pc) )
+      respc     = sum( respc_c     (:,pc)*pcfrac(:,pc) )
+      fsenl     = sum( fsenl_c     (:,pc)*pcfrac(:,pc) )
+      fevpl     = sum( fevpl_c     (:,pc)*pcfrac(:,pc) )
+      etr       = sum( etr_c       (:,pc)*pcfrac(:,pc) )
 
-      if(DEF_USE_PLANTHYDRAULICS)then
+      IF(DEF_USE_PLANTHYDRAULICS)THEN
          DO j = 1, nvegwcs
             vegwp(j) = sum( vegwp_c(j,:,pc)*pcfrac(:,pc) )
          ENDDO
@@ -998,24 +1003,24 @@ IF (patchtype == 0) THEN
                rootr(j) = sum(rootr_c(j,:)*pcfrac(:,pc))
             ENDDO
          ENDIF
-      else
+      ELSE
       ! loop for each soil layer
          IF (etr > 0.) THEN
             DO j = 1, nl_soil
                rootr(j) = sum(rootr_c(j,:)*etr_c(:,pc)*pcfrac(:,pc)) / etr
             ENDDO
          ENDIF
-      end if
+      ENDIF
 
-      rstfacsun_out          = sum( rstfacsun_c(:)         * pcfrac(:,pc) )
-      rstfacsha_out          = sum( rstfacsha_c(:)         * pcfrac(:,pc) )
-      gssun_out              = sum( gssun_c(:)             * pcfrac(:,pc) )
-      gssha_out              = sum( gssha_c(:)             * pcfrac(:,pc) )
-      assimsun_out           = sum( assimsun_c(:)          * pcfrac(:,pc) )
-      etrsun_out             = sum( etrsun_c(:)            * pcfrac(:,pc) )
-      assimsha_out           = sum( assimsha_c(:)          * pcfrac(:,pc) )
-      etrsha_out             = sum( etrsha_c(:)            * pcfrac(:,pc) )
-      hprl                   = sum( hprl_c  (:)   *pcfrac(:,pc) )
+      rstfacsun_out = sum( rstfacsun_c(:) * pcfrac(:,pc) )
+      rstfacsha_out = sum( rstfacsha_c(:) * pcfrac(:,pc) )
+      gssun_out     = sum( gssun_c    (:) * pcfrac(:,pc) )
+      gssha_out     = sum( gssha_c    (:) * pcfrac(:,pc) )
+      assimsun_out  = sum( assimsun_c (:) * pcfrac(:,pc) )
+      etrsun_out    = sum( etrsun_c   (:) * pcfrac(:,pc) )
+      assimsha_out  = sum( assimsha_c (:) * pcfrac(:,pc) )
+      etrsha_out    = sum( etrsha_c   (:) * pcfrac(:,pc) )
+      hprl          = sum( hprl_c     (:) * pcfrac(:,pc) )
 
 #endif
 
@@ -1072,7 +1077,8 @@ ELSE
                  gssun_out  ,gssha_out  ,forc_po2m ,forc_pco2m ,z0h_g      ,&
                  obu_g      ,ustar_g    ,zlnd      ,zsno       ,fsno       ,&
                  sigf       ,etrc       ,t_grnd    ,qg         ,dqgdT      ,&
-                 emg        ,tleaf      ,ldew,ldew_rain,ldew_snow      ,taux       ,tauy       ,&
+                 emg        ,tleaf      ,ldew      ,ldew_rain  ,ldew_snow  ,&
+                 taux       ,tauy       ,&
                  fseng      ,fevpg      ,cgrnd     ,cgrndl     ,cgrnds     ,&
                  tref       ,qref       ,rst       ,assim      ,respc      ,&
                  fsenl      ,fevpl      ,etr       ,dlrad      ,ulrad      ,&
@@ -1082,10 +1088,10 @@ ELSE
                  psi50_sha   ,psi50_xyl ,psi50_root,ck         ,vegwp      ,&
                  gs0sun      ,gs0sha                                       ,&
                  assimsun_out,etrsun_out,assimsha_out          ,etrsha_out ,&
-! Ozone stress variables                 
-                 o3coefv_sun ,o3coefv_sha ,o3coefg_sun ,o3coefg_sha, &
-                 lai_old     ,o3uptakesun ,o3uptakesha ,forc_ozone, &
-! End ozone stress variables                 
+! Ozone stress variables
+                 o3coefv_sun ,o3coefv_sha ,o3coefg_sun ,o3coefg_sha ,&
+                 lai_old     ,o3uptakesun ,o3uptakesha ,forc_ozone  ,&
+! End ozone stress variables
                  forc_hpbl                                                 ,&
                  qintr_rain  ,qintr_snow,t_precip  ,hprl       ,smp        ,&
                  hk(1:)      ,hksati(1:),rootr(1:)                         )
@@ -1102,9 +1108,9 @@ ELSE
          ldew          = 0.
          rstfacsun_out = 0.
          rstfacsha_out = 0.
-         if(DEF_USE_PLANTHYDRAULICS)then
+         IF(DEF_USE_PLANTHYDRAULICS)THEN
             vegwp = -2.5e4
-         end if
+         ENDIF
       ENDIF
 
 ENDIF
@@ -1226,9 +1232,9 @@ ENDIF
       ! one way to check energy
       errore = sabv + sabg + frl - olrg - fsena - lfevpa - fgrnd
 
-      ! the other way to check energy
+      ! another way to check energy
       errore = sabv + sabg + frl - olrg - fsena - lfevpa - xmf + hprl + &
-             cpliq * pg_rain * (t_precip - t_grnd) + cpice * pg_snow * (t_precip - t_grnd)
+               cpliq * pg_rain * (t_precip - t_grnd) + cpice * pg_snow * (t_precip - t_grnd)
       DO j = lb, nl_soil
          errore = errore - (t_soisno(j)-t_soisno_bef(j))/fact(j)
       ENDDO
@@ -1237,7 +1243,7 @@ ENDIF
       IF (abs(errore) > .5) THEN
       write(6,*) 'THERMAL.F90: energy balance violation'
       write(6,*) ipatch,errore,sabv,sabg,frl,olrg,fsenl,fseng,hvap*fevpl,htvp*fevpg,xmf,hprl
-      stop
+      STOP
       ENDIF
 100   format(10(f15.3))
 #endif

--- a/mkinidata/MOD_IniTimeVariable.F90
+++ b/mkinidata/MOD_IniTimeVariable.F90
@@ -547,7 +547,7 @@ CONTAINS
       snofrz (:) = 0.
       ssw = min(1.,1.e-3*wliq_soisno(1)/dz_soisno(1))
       CALL albland (ipatch,patchtype,1800.,soil_s_v_alb,soil_d_v_alb,soil_s_n_alb,soil_d_n_alb,&
-                    chil,rho,tau,fveg,green,lai,sai,coszen,&
+                    chil,rho,tau,fveg,green,lai,sai,max(0.001,coszen),&
                     wt,fsno,scv,scv,sag,ssw,pg_snow,t_grnd,t_soisno(:1),dz_soisno(:1),&
                     snl,wliq_soisno,wice_soisno,snw_rds,snofrz,&
                     mss_bcpho,mss_bcphi,mss_ocpho,mss_ocphi,&


### PR DESCRIPTION
    -fix(ALBEDO.F90,IniTimeVar.F90):
        Set the thermk and fshade (for PC) only in initialization. use
        previous values for later steps.

    -fix(MOD_LeafInterception.F90):
        qintr => qintr_rain, qintr_snow

    -fix(MOD_LeafTemperaturePC.F90):
        ldew calculation.

    -fix(MOD_Thermal.F90):
        initialization of hprl_c.

    -pretty(MOD_LeafTemperaturePC.F90,MOD_Thermal.F90,CoLMMAIN.F90):
        code indent and character case unified.