### PR TITLE
Update MOD_SPMD_Task.F90 to support coupling

### DIFF
--- a/share/MOD_SPMD_Task.F90
+++ b/share/MOD_SPMD_Task.F90
@@ -108,11 +108,23 @@ CONTAINS
    SUBROUTINE spmd_init ()
 
       IMPLICIT NONE
+      integer, intent(in), optional :: MyComm_r
+      LOGICAL mpi_inited
 
-      CALL mpi_init (p_err) 
+      CALL MPI_INITIALIZED( mpi_inited, p_err )
+
+      IF ( .NOT. mpi_inited ) THEN
+         CALL mpi_init (p_err) 
+      ENDIF
+
+      if (present(MyComm_r)) then
+         ! print *,'set MyComm_r','MyComm_r=',MyComm_r
+         p_comm_glb = MyComm_r
+      else
+         p_comm_glb = MPI_COMM_WORLD
+      endif
 
       ! 1. Constructing global communicator.
-      p_comm_glb = MPI_COMM_WORLD
       CALL mpi_comm_rank (p_comm_glb, p_iam_glb, p_err)  
       CALL mpi_comm_size (p_comm_glb, p_np_glb,  p_err) 
 


### PR DESCRIPTION
to support running CoLM as a component, in which case the mpi_init should be called outside the CoLM. The new global mpi would passes a COMM_WORLD in CoLM.  This modification will not affect the standalone runs, since it uses optional intent(in) for introduced comm_world