### PR TITLE
Fix for 1) imbanlanced water, 2) low sun zenith angle, 3) urban displacement height problems when considering vegetations for Urban model.

### DIFF
--- a/main/URBAN/MOD_Urban_Albedo.F90
+++ b/main/URBAN/MOD_Urban_Albedo.F90
@@ -169,7 +169,7 @@ MODULE MOD_Urban_Albedo
          RETURN  !only do albedo when coszen > 0
       ENDIF
 
-      czen=max(coszen,0.001)
+      czen=max(coszen,0.01)
       albsno(:,:)=0.      !set initial snow albedo
       cons = 0.2          !parameter for snow albedo
       conn = 0.5          !parameter for snow albedo

--- a/main/URBAN/MOD_Urban_Flux.F90
+++ b/main/URBAN/MOD_Urban_Flux.F90
@@ -1415,6 +1415,7 @@ MODULE MOD_Urban_Flux
      faiv    = fc(3)*(1. - exp(-0.5*lsai))
      lambda  = fcover(0) + faiv*htop/hroof
      displa  = hroof * (1 + 4.43**(-lambda)*(lambda - 1))
+     displa  = min(0.95*hroof, displa)
      z0m     = (hroof - displa) * &
                exp( -(0.5*1.2/vonkar/vonkar*(1-displa/hroof)*(fai+faiv*htop/hroof))**(-0.5) )
 

--- a/main/URBAN/MOD_Urban_Hydrology.F90
+++ b/main/URBAN/MOD_Urban_Hydrology.F90
@@ -15,7 +15,8 @@ CONTAINS
         ipatch         ,patchtype      ,lbr            ,lbi            ,&
         lbp            ,lbl            ,snll           ,deltim         ,&
         ! forcing
-        pg_rain        ,pgper_rain     ,pg_snow                        ,&
+        pg_rain        ,pgper_rain     ,pgimp_rain     ,pg_snow        ,&
+        pg_rain_lake   ,pg_snow_lake                                   ,&
         ! surface parameters or status
         froof          ,fgper          ,flake          ,bsw            ,&
         porsl          ,psi0           ,hksati         ,wtfact         ,&
@@ -77,8 +78,11 @@ CONTAINS
   REAL(r8), intent(in) :: &
         deltim           ,&! time step (s)
         pg_rain          ,&! rainfall after removal of interception (mm h2o/s)
-        pg_snow          ,&! rainfall after removal of interception (mm h2o/s)
+        pg_snow          ,&! snowfall after removal of interception (mm h2o/s)
         pgper_rain       ,&! rainfall after removal of interception (mm h2o/s)
+        pgimp_rain       ,&! rainfall after removal of interception (mm h2o/s)
+        pg_rain_lake     ,&! rainfall onto lake (mm h2o/s)
+        pg_snow_lake     ,&! snowfall onto lake (mm h2o/s)
         froof            ,&! roof fractional cover [-]
         fgper            ,&! weith of impervious ground [-]
         flake            ,&! lake fractional cover [-]
@@ -265,10 +269,10 @@ CONTAINS
       ! ================================================
 
       IF (lbi >= 1) THEN
-         gwat = pg_rain + sm_gimp - qseva_gimp
+         gwat = pgimp_rain + sm_gimp - qseva_gimp
       ELSE
          CALL snowwater (lbi,deltim,ssi,wimp,&
-                         pg_rain,qseva_gimp,qsdew_gimp,qsubl_gimp,qfros_gimp,&
+                         pgimp_rain,qseva_gimp,qsdew_gimp,qsubl_gimp,qfros_gimp,&
                          dz_gimpsno(lbi:0),wice_gimpsno(lbi:0),wliq_gimpsno(lbi:0),gwat)
       ENDIF
 
@@ -301,8 +305,8 @@ CONTAINS
            ! "in" snowater_lake arguments
            ! ---------------------------
            maxsnl       ,nl_soil      ,nl_lake         ,deltim          ,&
-           ssi          ,wimp         ,porsl           ,pg_rain         ,&
-           pg_snow      ,dz_lake      ,imelt_lake(:0)  ,fioldl(:0)      ,&
+           ssi          ,wimp         ,porsl           ,pg_rain_lake    ,&
+           pg_snow_lake ,dz_lake      ,imelt_lake(:0)  ,fioldl(:0)      ,&
            qseva_lake   ,qsubl_lake   ,qsdew_lake      ,qfros_lake      ,&
 
            ! "inout" snowater_lake arguments
@@ -323,7 +327,7 @@ CONTAINS
       ! this unreasonable assumption should be updated in the future version
       a  = (sum(wliq_lakesno(snll+1:))-w_old)/deltim
       aa = qseva_lake-(qsubl_lake-qsdew_lake)
-      rsur_lake = max(0., pg_rain - aa - a)
+      rsur_lake = max(0., pg_rain_lake - aa - a)
       rnof_lake = rsur_lake
 
       ! Set zero to the empty node

--- a/main/URBAN/MOD_Urban_Thermal.F90
+++ b/main/URBAN/MOD_Urban_Thermal.F90
@@ -1161,11 +1161,12 @@ CONTAINS
       ! because we don't consider water balance for lake currently.
       !fevpa  = fevpa *(1-flake) + fevpa_lake *flake
 
-      fsenl  = fsenl *(1-flake)
-      fevpl  = fevpl *(1-flake)
-      etr    = etr   *(1-flake)
-      assim  = assim *(1-flake)
-      respc  = respc *(1-flake)
+      ! 07/11/2023, yuan: don't not consider lake fraction cover
+      !fsenl  = fsenl *(1-flake)
+      !fevpl  = fevpl *(1-flake)
+      !etr    = etr   *(1-flake)
+      !assim  = assim *(1-flake)
+      !respc  = respc *(1-flake)
 
       ! ground heat flux
       IF ( doveg ) THEN

--- a/main/URBAN/Urban_CoLMMAIN.F90
+++ b/main/URBAN/Urban_CoLMMAIN.F90
@@ -584,8 +584,13 @@ SUBROUTINE UrbanCoLMMAIN ( &
         pg_snow    ,&! snowfall onto ground including canopy runoff [kg/(m2 s)]
         pgper_rain ,&! rainfall onto ground including canopy runoff [kg/(m2 s)]
         pgper_snow ,&! snowfall onto ground including canopy runoff [kg/(m2 s)]
+        pgimp_rain ,&! rainfall onto ground including canopy runoff [kg/(m2 s)]
+        pgimp_snow ,&! snowfall onto ground including canopy runoff [kg/(m2 s)]
+        pg_rain_lake,&!rainfall onto lake [kg/(m2 s)]
+        pg_snow_lake,&!snowfall onto lake [kg/(m2 s)]
         etrgper    ,&! etr for pervious ground
-        fracveg      ! fraction of fveg/fgper
+        fveg_gper  ,&! fraction of fveg/fgper
+        fveg_gimp    ! fraction of fveg/fgimp
 
    REAL(r8) :: &
         errw_rsub    ! the possible subsurface runoff deficit after PHS is included
@@ -790,12 +795,31 @@ SUBROUTINE UrbanCoLMMAIN ( &
       ! without vegetation canopy
       pg_rain = prc_rain + prl_rain
       pg_snow = prc_snow + prl_snow
+      pg_rain_lake = prc_rain + prl_rain
+      pg_snow_lake = prc_snow + prl_snow
 
       ! for urban hydrology input, only for pervious ground
-      fracveg = fveg/((1-froof)*fgper)
-      fracveg = min(fracveg, 1.)
-      pgper_rain = pgper_rain*fracveg + pg_rain*(1-fracveg)
-      pgper_snow = pgper_snow*fracveg + pg_snow*(1-fracveg)
+      IF (fgper > 0) THEN
+         fveg_gper = fveg/((1-froof)*fgper)
+      ELSE
+         fveg_gper = 0.
+      ENDIF
+
+      IF (fgper < 1) THEN
+         fveg_gimp = (fveg-(1-froof)*fgper)/((1-froof)*(1-fgper))
+      ELSE
+         fveg_gimp = 0.
+      ENDIF
+
+      IF (fveg_gper .le. 1) THEN
+         pgper_rain = pgper_rain*fveg_gper + pg_rain*(1-fveg_gper)
+         pgper_snow = pgper_snow*fveg_gper + pg_snow*(1-fveg_gper)
+         pgimp_rain = pg_rain
+         pgimp_snow = pg_snow
+      ELSE
+         pgimp_rain = pgper_rain*fveg_gimp + pg_rain*(1-fveg_gimp)
+         pgimp_snow = pgper_snow*fveg_gimp + pg_snow*(1-fveg_gimp)
+      ENDIF
 
 !----------------------------------------------------------------------
 ! [3] Initilize new snow nodes for snowfall / sleet
@@ -813,7 +837,7 @@ SUBROUTINE UrbanCoLMMAIN ( &
                     wliq_roofsno(:0),wice_roofsno(:0),fioldr(:0),&
                     snlr,sag_roof,scv_roof,snowdp_roof,fsno_roof)
 
-      CALL newsnow (patchtype,maxsnl,deltim,tgimp,pg_rain,pg_snow,bifall,&
+      CALL newsnow (patchtype,maxsnl,deltim,tgimp,pgimp_rain,pgimp_snow,bifall,&
                     t_precip,zi_gimpsno(:0),z_gimpsno(:0),dz_gimpsno(:0),t_gimpsno(:0),&
                     wliq_gimpsno(:0),wice_gimpsno(:0),fioldi(:0),&
                     snli,sag_gimp,scv_gimp,snowdp_gimp,fsno_gimp)
@@ -827,7 +851,7 @@ SUBROUTINE UrbanCoLMMAIN ( &
            ! "in" arguments
            ! ---------------
            maxsnl        ,nl_lake       ,deltim          ,dz_lake         ,&
-           pg_rain       ,pg_snow       ,t_precip        ,bifall          ,&
+           pg_rain_lake  ,pg_snow_lake  ,t_precip        ,bifall          ,&
 
            ! "inout" arguments
            ! ------------------
@@ -944,8 +968,8 @@ SUBROUTINE UrbanCoLMMAIN ( &
         ipatch               ,patchtype            ,lbr                  ,lbi                  ,&
         lbp                  ,lbl                  ,snll                 ,deltim               ,&
         ! forcing
-        pg_rain              ,pgper_rain           ,pg_snow                                    ,&
-        ! surface parameters and status
+        pg_rain              ,pgper_rain           ,pgimp_rain           ,pg_snow              ,&
+        pg_rain_lake         ,pg_snow_lake                                                     ,&
         froof                ,fgper                ,flake                ,bsw                  ,&
         porsl                ,psi0                 ,hksati               ,wtfact               ,&
         pondmx               ,ssi                  ,wimp                 ,smpmin               ,&

--- a/mkinidata/MOD_UrbanIniTimeVariable.F90
+++ b/mkinidata/MOD_UrbanIniTimeVariable.F90
@@ -108,7 +108,7 @@ CONTAINS
      ! urban surface albedo
      CALL alburban (ipatch,froof,fgper,flake,hwr,hroof,&
                     alb_roof,alb_wall,alb_gimp,alb_gper,&
-                    rho,tau,fveg,hveg,lai,sai,coszen,fwsun,tlake,&
+                    rho,tau,fveg,hveg,lai,sai,max(0.01,coszen),fwsun,tlake,&
                     fsno_roof,fsno_gimp,fsno_gper,fsno_lake,&
                     scv_roof,scv_gimp,scv_gper,scv_lake,&
                     sag_roof,sag_gimp,sag_gper,sag_lake,&


### PR DESCRIPTION
    -fix(UrbanCLMMAIN.F90&UrbanHydrology.F90):
        add pg_rain_lake and pg_snow_lake for lakes because lake model could
        change pg_rain and pg_snow. [Bug found and revised by @Wenzong Dong]

    -fix(UrbanCLMMAIN.F90):
        adjust for urban canopy interception to fix urban water imbanlance.
        add urban canopy interception also for impervious ground if fveg is
        large than pervious ground. [Bug found by @Wenzong Dong]

    -fix(UrbanTHERMAL.F90):
        fsenl, fevpl, etr, assim and respc don't product (1-flake) same as
        fevpa.

    -fix(UrbanALBEDO.F90,UrbanIniTimeVar.F90):
        modify limitation for conzen value (0.001->0.01) for urban.

    -fix(UrbanFlux.F90):
        set maximum displa value of urban + vegetation to 0.95*roof_height.