### PR TITLE
Initialize state variable with NAN

### DIFF
--- a/main/BGC/MOD_BGC_CNNStateUpdate3.F90
+++ b/main/BGC/MOD_BGC_CNNStateUpdate3.F90
@@ -101,7 +101,7 @@ contains
        ! patch-level wood to column-level CWD (uncombusted wood)
     if(DEF_USE_FIRE)then
        do j = 1, nl_soil
-          decomp_npools_vr(j,i_cwd,i) = decomp_npools_vr(j,i_cwd,i) + &
+          decomp_npools_vr(j,i_cwd,i) = decomp_npools_vr(j,i_cwd,i) &
                                       + fire_mortality_to_cwdn(j,i) * deltim
 
        ! patch-level wood to column-level litter (uncombusted wood)

--- a/main/BGC/MOD_BGC_Vars_PFTimeVariables.F90
+++ b/main/BGC/MOD_BGC_Vars_PFTimeVariables.F90
@@ -377,328 +377,328 @@ CONTAINS
       IF (p_is_worker) THEN
          IF (numpft > 0) THEN
   ! bgc variables
-            allocate (leafc_p                  (numpft))
-            allocate (leafc_storage_p          (numpft))
-            allocate (leafc_xfer_p             (numpft))
-            allocate (frootc_p                 (numpft))
-            allocate (frootc_storage_p         (numpft))
-            allocate (frootc_xfer_p            (numpft))
-            allocate (livestemc_p              (numpft))
-            allocate (livestemc_storage_p      (numpft))
-            allocate (livestemc_xfer_p         (numpft))
-            allocate (deadstemc_p              (numpft))
-            allocate (deadstemc_storage_p      (numpft))
-            allocate (deadstemc_xfer_p         (numpft))
-            allocate (livecrootc_p             (numpft))
-            allocate (livecrootc_storage_p     (numpft))
-            allocate (livecrootc_xfer_p        (numpft))
-            allocate (deadcrootc_p             (numpft))
-            allocate (deadcrootc_storage_p     (numpft))
-            allocate (deadcrootc_xfer_p        (numpft))
-            allocate (grainc_p                 (numpft))
-            allocate (grainc_storage_p         (numpft))
-            allocate (grainc_xfer_p            (numpft))
-            allocate (cropseedc_deficit_p      (numpft))
-            allocate (xsmrpool_p               (numpft))
-            allocate (gresp_storage_p          (numpft))
-            allocate (gresp_xfer_p             (numpft))
-            allocate (cpool_p                  (numpft))
-            allocate (totvegc_p                (numpft))
-            allocate (cropprod1c_p             (numpft))
+            allocate (leafc_p                  (numpft)); leafc_p                  (:) = spval
+            allocate (leafc_storage_p          (numpft)); leafc_storage_p          (:) = spval
+            allocate (leafc_xfer_p             (numpft)); leafc_xfer_p             (:) = spval
+            allocate (frootc_p                 (numpft)); frootc_p                 (:) = spval
+            allocate (frootc_storage_p         (numpft)); frootc_storage_p         (:) = spval
+            allocate (frootc_xfer_p            (numpft)); frootc_xfer_p            (:) = spval
+            allocate (livestemc_p              (numpft)); livestemc_p              (:) = spval
+            allocate (livestemc_storage_p      (numpft)); livestemc_storage_p      (:) = spval
+            allocate (livestemc_xfer_p         (numpft)); livestemc_xfer_p         (:) = spval
+            allocate (deadstemc_p              (numpft)); deadstemc_p              (:) = spval
+            allocate (deadstemc_storage_p      (numpft)); deadstemc_storage_p      (:) = spval
+            allocate (deadstemc_xfer_p         (numpft)); deadstemc_xfer_p         (:) = spval
+            allocate (livecrootc_p             (numpft)); livecrootc_p             (:) = spval
+            allocate (livecrootc_storage_p     (numpft)); livecrootc_storage_p     (:) = spval
+            allocate (livecrootc_xfer_p        (numpft)); livecrootc_xfer_p        (:) = spval
+            allocate (deadcrootc_p             (numpft)); deadcrootc_p             (:) = spval
+            allocate (deadcrootc_storage_p     (numpft)); deadcrootc_storage_p     (:) = spval
+            allocate (deadcrootc_xfer_p        (numpft)); deadcrootc_xfer_p        (:) = spval
+            allocate (grainc_p                 (numpft)); grainc_p                 (:) = spval
+            allocate (grainc_storage_p         (numpft)); grainc_storage_p         (:) = spval
+            allocate (grainc_xfer_p            (numpft)); grainc_xfer_p            (:) = spval
+            allocate (cropseedc_deficit_p      (numpft)); cropseedc_deficit_p      (:) = spval
+            allocate (xsmrpool_p               (numpft)); xsmrpool_p               (:) = spval
+            allocate (gresp_storage_p          (numpft)); gresp_storage_p          (:) = spval
+            allocate (gresp_xfer_p             (numpft)); gresp_xfer_p             (:) = spval
+            allocate (cpool_p                  (numpft)); cpool_p                  (:) = spval
+            allocate (totvegc_p                (numpft)); totvegc_p                (:) = spval
+            allocate (cropprod1c_p             (numpft)); cropprod1c_p             (:) = spval
 
-            allocate (leaf_prof_p              (nl_soil,numpft))
-            allocate (froot_prof_p             (nl_soil,numpft))
-            allocate (croot_prof_p             (nl_soil,numpft))
-            allocate (stem_prof_p              (nl_soil,numpft))
-            allocate (cinput_rootfr_p          (nl_soil,numpft))
+            allocate (leaf_prof_p              (nl_soil,numpft)) ; leaf_prof_p     (:,:) = spval
+            allocate (froot_prof_p             (nl_soil,numpft)) ; froot_prof_p    (:,:) = spval
+            allocate (croot_prof_p             (nl_soil,numpft)) ; croot_prof_p    (:,:) = spval
+            allocate (stem_prof_p              (nl_soil,numpft)) ; stem_prof_p     (:,:) = spval
+            allocate (cinput_rootfr_p          (nl_soil,numpft)) ; cinput_rootfr_p (:,:) = spval
 
-            allocate (leafn_p                  (numpft))
-            allocate (leafn_storage_p          (numpft))
-            allocate (leafn_xfer_p             (numpft))
-            allocate (frootn_p                 (numpft))
-            allocate (frootn_storage_p         (numpft))
-            allocate (frootn_xfer_p            (numpft))
-            allocate (livestemn_p              (numpft))
-            allocate (livestemn_storage_p      (numpft))
-            allocate (livestemn_xfer_p         (numpft))
-            allocate (deadstemn_p              (numpft))
-            allocate (deadstemn_storage_p      (numpft))
-            allocate (deadstemn_xfer_p         (numpft))
-            allocate (livecrootn_p             (numpft))
-            allocate (livecrootn_storage_p     (numpft))
-            allocate (livecrootn_xfer_p        (numpft))
-            allocate (deadcrootn_p             (numpft))
-            allocate (deadcrootn_storage_p     (numpft))
-            allocate (deadcrootn_xfer_p        (numpft))
-            allocate (grainn_p                 (numpft))
-            allocate (grainn_storage_p         (numpft))
-            allocate (grainn_xfer_p            (numpft))
-            allocate (cropseedn_deficit_p      (numpft))
-            allocate (retransn_p               (numpft))
-            allocate (totvegn_p                (numpft))
+            allocate (leafn_p                  (numpft)); leafn_p                  (:) = spval
+            allocate (leafn_storage_p          (numpft)); leafn_storage_p          (:) = spval
+            allocate (leafn_xfer_p             (numpft)); leafn_xfer_p             (:) = spval
+            allocate (frootn_p                 (numpft)); frootn_p                 (:) = spval
+            allocate (frootn_storage_p         (numpft)); frootn_storage_p         (:) = spval
+            allocate (frootn_xfer_p            (numpft)); frootn_xfer_p            (:) = spval
+            allocate (livestemn_p              (numpft)); livestemn_p              (:) = spval
+            allocate (livestemn_storage_p      (numpft)); livestemn_storage_p      (:) = spval
+            allocate (livestemn_xfer_p         (numpft)); livestemn_xfer_p         (:) = spval
+            allocate (deadstemn_p              (numpft)); deadstemn_p              (:) = spval
+            allocate (deadstemn_storage_p      (numpft)); deadstemn_storage_p      (:) = spval
+            allocate (deadstemn_xfer_p         (numpft)); deadstemn_xfer_p         (:) = spval
+            allocate (livecrootn_p             (numpft)); livecrootn_p             (:) = spval
+            allocate (livecrootn_storage_p     (numpft)); livecrootn_storage_p     (:) = spval
+            allocate (livecrootn_xfer_p        (numpft)); livecrootn_xfer_p        (:) = spval
+            allocate (deadcrootn_p             (numpft)); deadcrootn_p             (:) = spval
+            allocate (deadcrootn_storage_p     (numpft)); deadcrootn_storage_p     (:) = spval
+            allocate (deadcrootn_xfer_p        (numpft)); deadcrootn_xfer_p        (:) = spval
+            allocate (grainn_p                 (numpft)); grainn_p                 (:) = spval
+            allocate (grainn_storage_p         (numpft)); grainn_storage_p         (:) = spval
+            allocate (grainn_xfer_p            (numpft)); grainn_xfer_p            (:) = spval
+            allocate (cropseedn_deficit_p      (numpft)); cropseedn_deficit_p      (:) = spval
+            allocate (retransn_p               (numpft)); retransn_p               (:) = spval
+            allocate (totvegn_p                (numpft)); totvegn_p                (:) = spval
 
-            allocate (harvdate_p               (numpft))
+            allocate (harvdate_p               (numpft)); harvdate_p               (:) = spval
 
-            allocate (tempsum_potential_gpp_p  (numpft))
-            allocate (tempmax_retransn_p       (numpft))
-            allocate (tempavg_tref_p           (numpft))
-            allocate (tempsum_npp_p            (numpft))
-            allocate (tempsum_litfall_p        (numpft))
-            allocate (annsum_potential_gpp_p   (numpft))
-            allocate (annmax_retransn_p        (numpft))
-            allocate (annavg_tref_p            (numpft))
-            allocate (annsum_npp_p             (numpft))
-            allocate (annsum_litfall_p         (numpft))
+            allocate (tempsum_potential_gpp_p  (numpft)); tempsum_potential_gpp_p  (:) = spval
+            allocate (tempmax_retransn_p       (numpft)); tempmax_retransn_p       (:) = spval
+            allocate (tempavg_tref_p           (numpft)); tempavg_tref_p           (:) = spval
+            allocate (tempsum_npp_p            (numpft)); tempsum_npp_p            (:) = spval
+            allocate (tempsum_litfall_p        (numpft)); tempsum_litfall_p        (:) = spval
+            allocate (annsum_potential_gpp_p   (numpft)); annsum_potential_gpp_p   (:) = spval
+            allocate (annmax_retransn_p        (numpft)); annmax_retransn_p        (:) = spval
+            allocate (annavg_tref_p            (numpft)); annavg_tref_p            (:) = spval
+            allocate (annsum_npp_p             (numpft)); annsum_npp_p             (:) = spval
+            allocate (annsum_litfall_p         (numpft)); annsum_litfall_p         (:) = spval
 
-            allocate (bglfr_p                  (numpft))
-            allocate (bgtr_p                   (numpft))
-            allocate (lgsf_p                   (numpft))
-            allocate (gdd0_p                   (numpft))
-            allocate (gdd8_p                   (numpft))
-            allocate (gdd10_p                  (numpft))
-            allocate (gdd020_p                 (numpft))
-            allocate (gdd820_p                 (numpft))
-            allocate (gdd1020_p                (numpft))
-            allocate (nyrs_crop_active_p       (numpft))
+            allocate (bglfr_p                  (numpft)); bglfr_p                  (:) = spval
+            allocate (bgtr_p                   (numpft)); bgtr_p                   (:) = spval
+            allocate (lgsf_p                   (numpft)); lgsf_p                   (:) = spval
+            allocate (gdd0_p                   (numpft)); gdd0_p                   (:) = spval
+            allocate (gdd8_p                   (numpft)); gdd8_p                   (:) = spval
+            allocate (gdd10_p                  (numpft)); gdd10_p                  (:) = spval
+            allocate (gdd020_p                 (numpft)); gdd020_p                 (:) = spval
+            allocate (gdd820_p                 (numpft)); gdd820_p                 (:) = spval
+            allocate (gdd1020_p                (numpft)); gdd1020_p                (:) = spval
+            allocate (nyrs_crop_active_p       (numpft)); nyrs_crop_active_p       (:) = spval_i4
 
-            allocate (offset_flag_p            (numpft))
-            allocate (offset_counter_p         (numpft))
-            allocate (onset_flag_p             (numpft))
-            allocate (onset_counter_p          (numpft))
-            allocate (onset_gddflag_p          (numpft))
-            allocate (onset_gdd_p              (numpft))
-            allocate (onset_fdd_p              (numpft))
-            allocate (onset_swi_p              (numpft))
-            allocate (offset_fdd_p             (numpft))
-            allocate (offset_swi_p             (numpft))
-            allocate (dormant_flag_p           (numpft))
-            allocate (prev_leafc_to_litter_p   (numpft))
-            allocate (prev_frootc_to_litter_p  (numpft))
-            allocate (days_active_p            (numpft))
+            allocate (offset_flag_p            (numpft)); offset_flag_p            (:) = spval
+            allocate (offset_counter_p         (numpft)); offset_counter_p         (:) = spval
+            allocate (onset_flag_p             (numpft)); onset_flag_p             (:) = spval
+            allocate (onset_counter_p          (numpft)); onset_counter_p          (:) = spval
+            allocate (onset_gddflag_p          (numpft)); onset_gddflag_p          (:) = spval
+            allocate (onset_gdd_p              (numpft)); onset_gdd_p              (:) = spval
+            allocate (onset_fdd_p              (numpft)); onset_fdd_p              (:) = spval
+            allocate (onset_swi_p              (numpft)); onset_swi_p              (:) = spval
+            allocate (offset_fdd_p             (numpft)); offset_fdd_p             (:) = spval
+            allocate (offset_swi_p             (numpft)); offset_swi_p             (:) = spval
+            allocate (dormant_flag_p           (numpft)); dormant_flag_p           (:) = spval
+            allocate (prev_leafc_to_litter_p   (numpft)); prev_leafc_to_litter_p   (:) = spval
+            allocate (prev_frootc_to_litter_p  (numpft)); prev_frootc_to_litter_p  (:) = spval
+            allocate (days_active_p            (numpft)); days_active_p            (:) = spval
 
-            allocate (burndate_p               (numpft))
+            allocate (burndate_p               (numpft)); burndate_p               (:) = spval
 
-            allocate (c_allometry_p            (numpft))
-            allocate (n_allometry_p            (numpft))
-            allocate (downreg_p                (numpft))
-            allocate (grain_flag_p             (numpft))
+            allocate (c_allometry_p            (numpft)); c_allometry_p            (:) = spval
+            allocate (n_allometry_p            (numpft)); n_allometry_p            (:) = spval
+            allocate (downreg_p                (numpft)); downreg_p                (:) = spval
+            allocate (grain_flag_p             (numpft)); grain_flag_p             (:) = spval
 
-            allocate (ctrunc_p                 (numpft))
-            allocate (ntrunc_p                 (numpft))
-            allocate (npool_p                  (numpft))
+            allocate (ctrunc_p                 (numpft)); ctrunc_p                 (:) = spval
+            allocate (ntrunc_p                 (numpft)); ntrunc_p                 (:) = spval
+            allocate (npool_p                  (numpft)); npool_p                  (:) = spval
 
 #ifdef CROP
 ! crop variables
-            allocate (croplive_p               (numpft))
-            allocate (hui_p                    (numpft))
-            allocate (gddplant_p               (numpft))
-            allocate (peaklai_p                (numpft))
-            allocate (aroot_p                  (numpft))
-            allocate (astem_p                  (numpft))
-            allocate (arepr_p                  (numpft))
-            allocate (aleaf_p                  (numpft))
-            allocate (astemi_p                 (numpft))
-            allocate (aleafi_p                 (numpft))
-            allocate (gddmaturity_p            (numpft))
+            allocate (croplive_p               (numpft)); croplive_p               (:) = .false.
+            allocate (hui_p                    (numpft)); hui_p                    (:) = spval
+            allocate (gddplant_p               (numpft)); gddplant_p               (:) = spval
+            allocate (peaklai_p                (numpft)); peaklai_p                (:) = spval_i4
+            allocate (aroot_p                  (numpft)); aroot_p                  (:) = spval
+            allocate (astem_p                  (numpft)); astem_p                  (:) = spval
+            allocate (arepr_p                  (numpft)); arepr_p                  (:) = spval
+            allocate (aleaf_p                  (numpft)); aleaf_p                  (:) = spval
+            allocate (astemi_p                 (numpft)); astemi_p                 (:) = spval
+            allocate (aleafi_p                 (numpft)); aleafi_p                 (:) = spval
+            allocate (gddmaturity_p            (numpft)); gddmaturity_p            (:) = spval
 
-            allocate (cropplant_p              (numpft))
-            allocate (idop_p                   (numpft))
-            allocate (a5tmin_p                 (numpft))
-            allocate (a10tmin_p                (numpft))
-            allocate (t10_p                    (numpft))
-            allocate (cumvd_p                  (numpft))
-            allocate (vf_p                     (numpft))
-            allocate (cphase_p                 (numpft))
-            allocate (fert_counter_p           (numpft))
-            allocate (tref_min_p               (numpft))
-            allocate (tref_max_p               (numpft))
-            allocate (tref_min_inst_p          (numpft))
-            allocate (tref_max_inst_p          (numpft))
-            allocate (fertnitro_p              (numpft))
-            allocate (latbaset_p               (numpft))
-            allocate (plantdate_p              (numpft))
+            allocate (cropplant_p              (numpft)); cropplant_p              (:) = .false.
+            allocate (idop_p                   (numpft)); idop_p                   (:) = spval_i4
+            allocate (a5tmin_p                 (numpft)); a5tmin_p                 (:) = spval
+            allocate (a10tmin_p                (numpft)); a10tmin_p                (:) = spval
+            allocate (t10_p                    (numpft)); t10_p                    (:) = spval
+            allocate (cumvd_p                  (numpft)); cumvd_p                  (:) = spval
+            allocate (vf_p                     (numpft)); vf_p                     (:) = spval
+            allocate (cphase_p                 (numpft)); cphase_p                 (:) = spval
+            allocate (fert_counter_p           (numpft)); fert_counter_p           (:) = spval
+            allocate (tref_min_p               (numpft)); tref_min_p               (:) = spval
+            allocate (tref_max_p               (numpft)); tref_max_p               (:) = spval
+            allocate (tref_min_inst_p          (numpft)); tref_min_inst_p          (:) = spval
+            allocate (tref_max_inst_p          (numpft)); tref_max_inst_p          (:) = spval
+            allocate (fertnitro_p              (numpft)); fertnitro_p              (:) = spval
+            allocate (latbaset_p               (numpft)); latbaset_p               (:) = spval
+            allocate (plantdate_p              (numpft)); plantdate_p              (:) = spval
 #endif
 
 ! SASU variables
-            allocate (leafc0_p                 (numpft))
-            allocate (leafc0_storage_p         (numpft))
-            allocate (leafc0_xfer_p            (numpft))
-            allocate (frootc0_p                (numpft))
-            allocate (frootc0_storage_p        (numpft))
-            allocate (frootc0_xfer_p           (numpft))
-            allocate (livestemc0_p             (numpft))
-            allocate (livestemc0_storage_p     (numpft))
-            allocate (livestemc0_xfer_p        (numpft))
-            allocate (deadstemc0_p             (numpft))
-            allocate (deadstemc0_storage_p     (numpft))
-            allocate (deadstemc0_xfer_p        (numpft))
-            allocate (livecrootc0_p            (numpft))
-            allocate (livecrootc0_storage_p    (numpft))
-            allocate (livecrootc0_xfer_p       (numpft))
-            allocate (deadcrootc0_p            (numpft))
-            allocate (deadcrootc0_storage_p    (numpft))
-            allocate (deadcrootc0_xfer_p       (numpft))
-            allocate (grainc0_p                (numpft))
-            allocate (grainc0_storage_p        (numpft))
-            allocate (grainc0_xfer_p           (numpft))
+            allocate (leafc0_p                 (numpft)); leafc0_p                 (:) = spval
+            allocate (leafc0_storage_p         (numpft)); leafc0_storage_p         (:) = spval
+            allocate (leafc0_xfer_p            (numpft)); leafc0_xfer_p            (:) = spval
+            allocate (frootc0_p                (numpft)); frootc0_p                (:) = spval
+            allocate (frootc0_storage_p        (numpft)); frootc0_storage_p        (:) = spval
+            allocate (frootc0_xfer_p           (numpft)); frootc0_xfer_p           (:) = spval
+            allocate (livestemc0_p             (numpft)); livestemc0_p             (:) = spval
+            allocate (livestemc0_storage_p     (numpft)); livestemc0_storage_p     (:) = spval
+            allocate (livestemc0_xfer_p        (numpft)); livestemc0_xfer_p        (:) = spval
+            allocate (deadstemc0_p             (numpft)); deadstemc0_p             (:) = spval
+            allocate (deadstemc0_storage_p     (numpft)); deadstemc0_storage_p     (:) = spval
+            allocate (deadstemc0_xfer_p        (numpft)); deadstemc0_xfer_p        (:) = spval
+            allocate (livecrootc0_p            (numpft)); livecrootc0_p            (:) = spval
+            allocate (livecrootc0_storage_p    (numpft)); livecrootc0_storage_p    (:) = spval
+            allocate (livecrootc0_xfer_p       (numpft)); livecrootc0_xfer_p       (:) = spval
+            allocate (deadcrootc0_p            (numpft)); deadcrootc0_p            (:) = spval
+            allocate (deadcrootc0_storage_p    (numpft)); deadcrootc0_storage_p    (:) = spval
+            allocate (deadcrootc0_xfer_p       (numpft)); deadcrootc0_xfer_p       (:) = spval
+            allocate (grainc0_p                (numpft)); grainc0_p                (:) = spval
+            allocate (grainc0_storage_p        (numpft)); grainc0_storage_p        (:) = spval
+            allocate (grainc0_xfer_p           (numpft)); grainc0_xfer_p           (:) = spval
 
-            allocate (leafn0_p                 (numpft))
-            allocate (leafn0_storage_p         (numpft))
-            allocate (leafn0_xfer_p            (numpft))
-            allocate (frootn0_p                (numpft))
-            allocate (frootn0_storage_p        (numpft))
-            allocate (frootn0_xfer_p           (numpft))
-            allocate (livestemn0_p             (numpft))
-            allocate (livestemn0_storage_p     (numpft))
-            allocate (livestemn0_xfer_p        (numpft))
-            allocate (deadstemn0_p             (numpft))
-            allocate (deadstemn0_storage_p     (numpft))
-            allocate (deadstemn0_xfer_p        (numpft))
-            allocate (livecrootn0_p            (numpft))
-            allocate (livecrootn0_storage_p    (numpft))
-            allocate (livecrootn0_xfer_p       (numpft))
-            allocate (deadcrootn0_p            (numpft))
-            allocate (deadcrootn0_storage_p    (numpft))
-            allocate (deadcrootn0_xfer_p       (numpft))
-            allocate (grainn0_p                (numpft))
-            allocate (grainn0_storage_p        (numpft))
-            allocate (grainn0_xfer_p           (numpft))
-            allocate (retransn0_p              (numpft))
+            allocate (leafn0_p                 (numpft)); leafn0_p                 (:) = spval
+            allocate (leafn0_storage_p         (numpft)); leafn0_storage_p         (:) = spval
+            allocate (leafn0_xfer_p            (numpft)); leafn0_xfer_p            (:) = spval
+            allocate (frootn0_p                (numpft)); frootn0_p                (:) = spval
+            allocate (frootn0_storage_p        (numpft)); frootn0_storage_p        (:) = spval
+            allocate (frootn0_xfer_p           (numpft)); frootn0_xfer_p           (:) = spval
+            allocate (livestemn0_p             (numpft)); livestemn0_p             (:) = spval
+            allocate (livestemn0_storage_p     (numpft)); livestemn0_storage_p     (:) = spval
+            allocate (livestemn0_xfer_p        (numpft)); livestemn0_xfer_p        (:) = spval
+            allocate (deadstemn0_p             (numpft)); deadstemn0_p             (:) = spval
+            allocate (deadstemn0_storage_p     (numpft)); deadstemn0_storage_p     (:) = spval
+            allocate (deadstemn0_xfer_p        (numpft)); deadstemn0_xfer_p        (:) = spval
+            allocate (livecrootn0_p            (numpft)); livecrootn0_p            (:) = spval
+            allocate (livecrootn0_storage_p    (numpft)); livecrootn0_storage_p    (:) = spval
+            allocate (livecrootn0_xfer_p       (numpft)); livecrootn0_xfer_p       (:) = spval
+            allocate (deadcrootn0_p            (numpft)); deadcrootn0_p            (:) = spval
+            allocate (deadcrootn0_storage_p    (numpft)); deadcrootn0_storage_p    (:) = spval
+            allocate (deadcrootn0_xfer_p       (numpft)); deadcrootn0_xfer_p       (:) = spval
+            allocate (grainn0_p                (numpft)); grainn0_p                (:) = spval
+            allocate (grainn0_storage_p        (numpft)); grainn0_storage_p        (:) = spval
+            allocate (grainn0_xfer_p           (numpft)); grainn0_xfer_p           (:) = spval
+            allocate (retransn0_p              (numpft)); retransn0_p              (:) = spval
 
-            allocate (I_leafc_p_acc            (numpft))
-            allocate (I_leafc_st_p_acc         (numpft))
-            allocate (I_frootc_p_acc           (numpft))
-            allocate (I_frootc_st_p_acc        (numpft))
-            allocate (I_livestemc_p_acc        (numpft))
-            allocate (I_livestemc_st_p_acc     (numpft))
-            allocate (I_deadstemc_p_acc        (numpft))
-            allocate (I_deadstemc_st_p_acc     (numpft))
-            allocate (I_livecrootc_p_acc       (numpft))
-            allocate (I_livecrootc_st_p_acc    (numpft))
-            allocate (I_deadcrootc_p_acc       (numpft))
-            allocate (I_deadcrootc_st_p_acc    (numpft))
-            allocate (I_grainc_p_acc           (numpft))
-            allocate (I_grainc_st_p_acc        (numpft))
-            allocate (I_leafn_p_acc            (numpft))
-            allocate (I_leafn_st_p_acc         (numpft))
-            allocate (I_frootn_p_acc           (numpft))
-            allocate (I_frootn_st_p_acc        (numpft))
-            allocate (I_livestemn_p_acc        (numpft))
-            allocate (I_livestemn_st_p_acc     (numpft))
-            allocate (I_deadstemn_p_acc        (numpft))
-            allocate (I_deadstemn_st_p_acc     (numpft))
-            allocate (I_livecrootn_p_acc       (numpft))
-            allocate (I_livecrootn_st_p_acc    (numpft))
-            allocate (I_deadcrootn_p_acc       (numpft))
-            allocate (I_deadcrootn_st_p_acc    (numpft))
-            allocate (I_grainn_p_acc           (numpft))
-            allocate (I_grainn_st_p_acc        (numpft))
+            allocate (I_leafc_p_acc            (numpft)); I_leafc_p_acc            (:) = spval
+            allocate (I_leafc_st_p_acc         (numpft)); I_leafc_st_p_acc         (:) = spval
+            allocate (I_frootc_p_acc           (numpft)); I_frootc_p_acc           (:) = spval
+            allocate (I_frootc_st_p_acc        (numpft)); I_frootc_st_p_acc        (:) = spval
+            allocate (I_livestemc_p_acc        (numpft)); I_livestemc_p_acc        (:) = spval
+            allocate (I_livestemc_st_p_acc     (numpft)); I_livestemc_st_p_acc     (:) = spval
+            allocate (I_deadstemc_p_acc        (numpft)); I_deadstemc_p_acc        (:) = spval
+            allocate (I_deadstemc_st_p_acc     (numpft)); I_deadstemc_st_p_acc     (:) = spval
+            allocate (I_livecrootc_p_acc       (numpft)); I_livecrootc_p_acc       (:) = spval
+            allocate (I_livecrootc_st_p_acc    (numpft)); I_livecrootc_st_p_acc    (:) = spval
+            allocate (I_deadcrootc_p_acc       (numpft)); I_deadcrootc_p_acc       (:) = spval
+            allocate (I_deadcrootc_st_p_acc    (numpft)); I_deadcrootc_st_p_acc    (:) = spval
+            allocate (I_grainc_p_acc           (numpft)); I_grainc_p_acc           (:) = spval
+            allocate (I_grainc_st_p_acc        (numpft)); I_grainc_st_p_acc        (:) = spval
+            allocate (I_leafn_p_acc            (numpft)); I_leafn_p_acc            (:) = spval
+            allocate (I_leafn_st_p_acc         (numpft)); I_leafn_st_p_acc         (:) = spval
+            allocate (I_frootn_p_acc           (numpft)); I_frootn_p_acc           (:) = spval
+            allocate (I_frootn_st_p_acc        (numpft)); I_frootn_st_p_acc        (:) = spval
+            allocate (I_livestemn_p_acc        (numpft)); I_livestemn_p_acc        (:) = spval
+            allocate (I_livestemn_st_p_acc     (numpft)); I_livestemn_st_p_acc     (:) = spval
+            allocate (I_deadstemn_p_acc        (numpft)); I_deadstemn_p_acc        (:) = spval
+            allocate (I_deadstemn_st_p_acc     (numpft)); I_deadstemn_st_p_acc     (:) = spval
+            allocate (I_livecrootn_p_acc       (numpft)); I_livecrootn_p_acc       (:) = spval
+            allocate (I_livecrootn_st_p_acc    (numpft)); I_livecrootn_st_p_acc    (:) = spval
+            allocate (I_deadcrootn_p_acc       (numpft)); I_deadcrootn_p_acc       (:) = spval
+            allocate (I_deadcrootn_st_p_acc    (numpft)); I_deadcrootn_st_p_acc    (:) = spval
+            allocate (I_grainn_p_acc           (numpft)); I_grainn_p_acc           (:) = spval
+            allocate (I_grainn_st_p_acc        (numpft)); I_grainn_st_p_acc        (:) = spval
 
-            allocate (AKX_leafc_xf_to_leafc_p_acc                 (numpft))
-            allocate (AKX_frootc_xf_to_frootc_p_acc               (numpft))
-            allocate (AKX_livestemc_xf_to_livestemc_p_acc         (numpft))
-            allocate (AKX_deadstemc_xf_to_deadstemc_p_acc         (numpft))
-            allocate (AKX_livecrootc_xf_to_livecrootc_p_acc       (numpft))
-            allocate (AKX_deadcrootc_xf_to_deadcrootc_p_acc       (numpft))
-            allocate (AKX_grainc_xf_to_grainc_p_acc               (numpft))
-            allocate (AKX_livestemc_to_deadstemc_p_acc            (numpft))
-            allocate (AKX_livecrootc_to_deadcrootc_p_acc          (numpft))
+            allocate (AKX_leafc_xf_to_leafc_p_acc                 (numpft)); AKX_leafc_xf_to_leafc_p_acc                 (:) = spval
+            allocate (AKX_frootc_xf_to_frootc_p_acc               (numpft)); AKX_frootc_xf_to_frootc_p_acc               (:) = spval
+            allocate (AKX_livestemc_xf_to_livestemc_p_acc         (numpft)); AKX_livestemc_xf_to_livestemc_p_acc         (:) = spval
+            allocate (AKX_deadstemc_xf_to_deadstemc_p_acc         (numpft)); AKX_deadstemc_xf_to_deadstemc_p_acc         (:) = spval
+            allocate (AKX_livecrootc_xf_to_livecrootc_p_acc       (numpft)); AKX_livecrootc_xf_to_livecrootc_p_acc       (:) = spval
+            allocate (AKX_deadcrootc_xf_to_deadcrootc_p_acc       (numpft)); AKX_deadcrootc_xf_to_deadcrootc_p_acc       (:) = spval
+            allocate (AKX_grainc_xf_to_grainc_p_acc               (numpft)); AKX_grainc_xf_to_grainc_p_acc               (:) = spval
+            allocate (AKX_livestemc_to_deadstemc_p_acc            (numpft)); AKX_livestemc_to_deadstemc_p_acc            (:) = spval
+            allocate (AKX_livecrootc_to_deadcrootc_p_acc          (numpft)); AKX_livecrootc_to_deadcrootc_p_acc          (:) = spval
 
-            allocate (AKX_leafc_st_to_leafc_xf_p_acc              (numpft))
-            allocate (AKX_frootc_st_to_frootc_xf_p_acc            (numpft))
-            allocate (AKX_livestemc_st_to_livestemc_xf_p_acc      (numpft))
-            allocate (AKX_deadstemc_st_to_deadstemc_xf_p_acc      (numpft))
-            allocate (AKX_livecrootc_st_to_livecrootc_xf_p_acc    (numpft))
-            allocate (AKX_deadcrootc_st_to_deadcrootc_xf_p_acc    (numpft))
-            allocate (AKX_grainc_st_to_grainc_xf_p_acc            (numpft))
+            allocate (AKX_leafc_st_to_leafc_xf_p_acc              (numpft)); AKX_leafc_st_to_leafc_xf_p_acc              (:) = spval
+            allocate (AKX_frootc_st_to_frootc_xf_p_acc            (numpft)); AKX_frootc_st_to_frootc_xf_p_acc            (:) = spval
+            allocate (AKX_livestemc_st_to_livestemc_xf_p_acc      (numpft)); AKX_livestemc_st_to_livestemc_xf_p_acc      (:) = spval
+            allocate (AKX_deadstemc_st_to_deadstemc_xf_p_acc      (numpft)); AKX_deadstemc_st_to_deadstemc_xf_p_acc      (:) = spval
+            allocate (AKX_livecrootc_st_to_livecrootc_xf_p_acc    (numpft)); AKX_livecrootc_st_to_livecrootc_xf_p_acc    (:) = spval
+            allocate (AKX_deadcrootc_st_to_deadcrootc_xf_p_acc    (numpft)); AKX_deadcrootc_st_to_deadcrootc_xf_p_acc    (:) = spval
+            allocate (AKX_grainc_st_to_grainc_xf_p_acc            (numpft)); AKX_grainc_st_to_grainc_xf_p_acc            (:) = spval
 
-            allocate (AKX_leafc_exit_p_acc                        (numpft))
-            allocate (AKX_frootc_exit_p_acc                       (numpft))
-            allocate (AKX_livestemc_exit_p_acc                    (numpft))
-            allocate (AKX_deadstemc_exit_p_acc                    (numpft))
-            allocate (AKX_livecrootc_exit_p_acc                   (numpft))
-            allocate (AKX_deadcrootc_exit_p_acc                   (numpft))
-            allocate (AKX_grainc_exit_p_acc                       (numpft))
+            allocate (AKX_leafc_exit_p_acc                        (numpft)); AKX_leafc_exit_p_acc                        (:) = spval
+            allocate (AKX_frootc_exit_p_acc                       (numpft)); AKX_frootc_exit_p_acc                       (:) = spval
+            allocate (AKX_livestemc_exit_p_acc                    (numpft)); AKX_livestemc_exit_p_acc                    (:) = spval
+            allocate (AKX_deadstemc_exit_p_acc                    (numpft)); AKX_deadstemc_exit_p_acc                    (:) = spval
+            allocate (AKX_livecrootc_exit_p_acc                   (numpft)); AKX_livecrootc_exit_p_acc                   (:) = spval
+            allocate (AKX_deadcrootc_exit_p_acc                   (numpft)); AKX_deadcrootc_exit_p_acc                   (:) = spval
+            allocate (AKX_grainc_exit_p_acc                       (numpft)); AKX_grainc_exit_p_acc                       (:) = spval
 
-            allocate (AKX_leafc_st_exit_p_acc                     (numpft))
-            allocate (AKX_frootc_st_exit_p_acc                    (numpft))
-            allocate (AKX_livestemc_st_exit_p_acc                 (numpft))
-            allocate (AKX_deadstemc_st_exit_p_acc                 (numpft))
-            allocate (AKX_livecrootc_st_exit_p_acc                (numpft))
-            allocate (AKX_deadcrootc_st_exit_p_acc                (numpft))
-            allocate (AKX_grainc_st_exit_p_acc                    (numpft))
+            allocate (AKX_leafc_st_exit_p_acc                     (numpft)); AKX_leafc_st_exit_p_acc                     (:) = spval
+            allocate (AKX_frootc_st_exit_p_acc                    (numpft)); AKX_frootc_st_exit_p_acc                    (:) = spval
+            allocate (AKX_livestemc_st_exit_p_acc                 (numpft)); AKX_livestemc_st_exit_p_acc                 (:) = spval
+            allocate (AKX_deadstemc_st_exit_p_acc                 (numpft)); AKX_deadstemc_st_exit_p_acc                 (:) = spval
+            allocate (AKX_livecrootc_st_exit_p_acc                (numpft)); AKX_livecrootc_st_exit_p_acc                (:) = spval
+            allocate (AKX_deadcrootc_st_exit_p_acc                (numpft)); AKX_deadcrootc_st_exit_p_acc                (:) = spval
+            allocate (AKX_grainc_st_exit_p_acc                    (numpft)); AKX_grainc_st_exit_p_acc                    (:) = spval
 
-            allocate (AKX_leafc_xf_exit_p_acc                     (numpft))
-            allocate (AKX_frootc_xf_exit_p_acc                    (numpft))
-            allocate (AKX_livestemc_xf_exit_p_acc                 (numpft))
-            allocate (AKX_deadstemc_xf_exit_p_acc                 (numpft))
-            allocate (AKX_livecrootc_xf_exit_p_acc                (numpft))
-            allocate (AKX_deadcrootc_xf_exit_p_acc                (numpft))
-            allocate (AKX_grainc_xf_exit_p_acc                    (numpft))
+            allocate (AKX_leafc_xf_exit_p_acc                     (numpft)); AKX_leafc_xf_exit_p_acc                     (:) = spval
+            allocate (AKX_frootc_xf_exit_p_acc                    (numpft)); AKX_frootc_xf_exit_p_acc                    (:) = spval
+            allocate (AKX_livestemc_xf_exit_p_acc                 (numpft)); AKX_livestemc_xf_exit_p_acc                 (:) = spval
+            allocate (AKX_deadstemc_xf_exit_p_acc                 (numpft)); AKX_deadstemc_xf_exit_p_acc                 (:) = spval
+            allocate (AKX_livecrootc_xf_exit_p_acc                (numpft)); AKX_livecrootc_xf_exit_p_acc                (:) = spval
+            allocate (AKX_deadcrootc_xf_exit_p_acc                (numpft)); AKX_deadcrootc_xf_exit_p_acc                (:) = spval
+            allocate (AKX_grainc_xf_exit_p_acc                    (numpft)); AKX_grainc_xf_exit_p_acc                    (:) = spval
 
-            allocate (AKX_leafn_xf_to_leafn_p_acc                 (numpft))
-            allocate (AKX_frootn_xf_to_frootn_p_acc               (numpft))
-            allocate (AKX_livestemn_xf_to_livestemn_p_acc         (numpft))
-            allocate (AKX_deadstemn_xf_to_deadstemn_p_acc         (numpft))
-            allocate (AKX_livecrootn_xf_to_livecrootn_p_acc       (numpft))
-            allocate (AKX_deadcrootn_xf_to_deadcrootn_p_acc       (numpft))
-            allocate (AKX_grainn_xf_to_grainn_p_acc               (numpft))
-            allocate (AKX_livestemn_to_deadstemn_p_acc            (numpft))
-            allocate (AKX_livecrootn_to_deadcrootn_p_acc          (numpft))
+            allocate (AKX_leafn_xf_to_leafn_p_acc                 (numpft)); AKX_leafn_xf_to_leafn_p_acc                 (:) = spval
+            allocate (AKX_frootn_xf_to_frootn_p_acc               (numpft)); AKX_frootn_xf_to_frootn_p_acc               (:) = spval
+            allocate (AKX_livestemn_xf_to_livestemn_p_acc         (numpft)); AKX_livestemn_xf_to_livestemn_p_acc         (:) = spval
+            allocate (AKX_deadstemn_xf_to_deadstemn_p_acc         (numpft)); AKX_deadstemn_xf_to_deadstemn_p_acc         (:) = spval
+            allocate (AKX_livecrootn_xf_to_livecrootn_p_acc       (numpft)); AKX_livecrootn_xf_to_livecrootn_p_acc       (:) = spval
+            allocate (AKX_deadcrootn_xf_to_deadcrootn_p_acc       (numpft)); AKX_deadcrootn_xf_to_deadcrootn_p_acc       (:) = spval
+            allocate (AKX_grainn_xf_to_grainn_p_acc               (numpft)); AKX_grainn_xf_to_grainn_p_acc               (:) = spval
+            allocate (AKX_livestemn_to_deadstemn_p_acc            (numpft)); AKX_livestemn_to_deadstemn_p_acc            (:) = spval
+            allocate (AKX_livecrootn_to_deadcrootn_p_acc          (numpft)); AKX_livecrootn_to_deadcrootn_p_acc          (:) = spval
 
-            allocate (AKX_leafn_st_to_leafn_xf_p_acc              (numpft))
-            allocate (AKX_frootn_st_to_frootn_xf_p_acc            (numpft))
-            allocate (AKX_livestemn_st_to_livestemn_xf_p_acc      (numpft))
-            allocate (AKX_deadstemn_st_to_deadstemn_xf_p_acc      (numpft))
-            allocate (AKX_livecrootn_st_to_livecrootn_xf_p_acc    (numpft))
-            allocate (AKX_deadcrootn_st_to_deadcrootn_xf_p_acc    (numpft))
-            allocate (AKX_grainn_st_to_grainn_xf_p_acc            (numpft))
+            allocate (AKX_leafn_st_to_leafn_xf_p_acc              (numpft)); AKX_leafn_st_to_leafn_xf_p_acc              (:) = spval
+            allocate (AKX_frootn_st_to_frootn_xf_p_acc            (numpft)); AKX_frootn_st_to_frootn_xf_p_acc            (:) = spval
+            allocate (AKX_livestemn_st_to_livestemn_xf_p_acc      (numpft)); AKX_livestemn_st_to_livestemn_xf_p_acc      (:) = spval
+            allocate (AKX_deadstemn_st_to_deadstemn_xf_p_acc      (numpft)); AKX_deadstemn_st_to_deadstemn_xf_p_acc      (:) = spval
+            allocate (AKX_livecrootn_st_to_livecrootn_xf_p_acc    (numpft)); AKX_livecrootn_st_to_livecrootn_xf_p_acc    (:) = spval
+            allocate (AKX_deadcrootn_st_to_deadcrootn_xf_p_acc    (numpft)); AKX_deadcrootn_st_to_deadcrootn_xf_p_acc    (:) = spval
+            allocate (AKX_grainn_st_to_grainn_xf_p_acc            (numpft)); AKX_grainn_st_to_grainn_xf_p_acc            (:) = spval
 
-            allocate (AKX_leafn_to_retransn_p_acc                 (numpft))
-            allocate (AKX_frootn_to_retransn_p_acc                (numpft))
-            allocate (AKX_livestemn_to_retransn_p_acc             (numpft))
-            allocate (AKX_livecrootn_to_retransn_p_acc            (numpft))
+            allocate (AKX_leafn_to_retransn_p_acc                 (numpft)); AKX_leafn_to_retransn_p_acc                 (:) = spval
+            allocate (AKX_frootn_to_retransn_p_acc                (numpft)); AKX_frootn_to_retransn_p_acc                (:) = spval
+            allocate (AKX_livestemn_to_retransn_p_acc             (numpft)); AKX_livestemn_to_retransn_p_acc             (:) = spval
+            allocate (AKX_livecrootn_to_retransn_p_acc            (numpft)); AKX_livecrootn_to_retransn_p_acc            (:) = spval
 
-            allocate (AKX_retransn_to_leafn_p_acc                 (numpft))
-            allocate (AKX_retransn_to_frootn_p_acc                (numpft))
-            allocate (AKX_retransn_to_livestemn_p_acc             (numpft))
-            allocate (AKX_retransn_to_deadstemn_p_acc             (numpft))
-            allocate (AKX_retransn_to_livecrootn_p_acc            (numpft))
-            allocate (AKX_retransn_to_deadcrootn_p_acc            (numpft))
-            allocate (AKX_retransn_to_grainn_p_acc                (numpft))
+            allocate (AKX_retransn_to_leafn_p_acc                 (numpft)); AKX_retransn_to_leafn_p_acc                 (:) = spval
+            allocate (AKX_retransn_to_frootn_p_acc                (numpft)); AKX_retransn_to_frootn_p_acc                (:) = spval
+            allocate (AKX_retransn_to_livestemn_p_acc             (numpft)); AKX_retransn_to_livestemn_p_acc             (:) = spval
+            allocate (AKX_retransn_to_deadstemn_p_acc             (numpft)); AKX_retransn_to_deadstemn_p_acc             (:) = spval
+            allocate (AKX_retransn_to_livecrootn_p_acc            (numpft)); AKX_retransn_to_livecrootn_p_acc            (:) = spval
+            allocate (AKX_retransn_to_deadcrootn_p_acc            (numpft)); AKX_retransn_to_deadcrootn_p_acc            (:) = spval
+            allocate (AKX_retransn_to_grainn_p_acc                (numpft)); AKX_retransn_to_grainn_p_acc                (:) = spval
 
-            allocate (AKX_retransn_to_leafn_st_p_acc              (numpft))
-            allocate (AKX_retransn_to_frootn_st_p_acc             (numpft))
-            allocate (AKX_retransn_to_livestemn_st_p_acc          (numpft))
-            allocate (AKX_retransn_to_deadstemn_st_p_acc          (numpft))
-            allocate (AKX_retransn_to_livecrootn_st_p_acc         (numpft))
-            allocate (AKX_retransn_to_deadcrootn_st_p_acc         (numpft))
-            allocate (AKX_retransn_to_grainn_st_p_acc             (numpft))
+            allocate (AKX_retransn_to_leafn_st_p_acc              (numpft)); AKX_retransn_to_leafn_st_p_acc              (:) = spval
+            allocate (AKX_retransn_to_frootn_st_p_acc             (numpft)); AKX_retransn_to_frootn_st_p_acc             (:) = spval
+            allocate (AKX_retransn_to_livestemn_st_p_acc          (numpft)); AKX_retransn_to_livestemn_st_p_acc          (:) = spval
+            allocate (AKX_retransn_to_deadstemn_st_p_acc          (numpft)); AKX_retransn_to_deadstemn_st_p_acc          (:) = spval
+            allocate (AKX_retransn_to_livecrootn_st_p_acc         (numpft)); AKX_retransn_to_livecrootn_st_p_acc         (:) = spval
+            allocate (AKX_retransn_to_deadcrootn_st_p_acc         (numpft)); AKX_retransn_to_deadcrootn_st_p_acc         (:) = spval
+            allocate (AKX_retransn_to_grainn_st_p_acc             (numpft)); AKX_retransn_to_grainn_st_p_acc             (:) = spval
 
-            allocate (AKX_leafn_exit_p_acc                        (numpft))
-            allocate (AKX_frootn_exit_p_acc                       (numpft))
-            allocate (AKX_livestemn_exit_p_acc                    (numpft))
-            allocate (AKX_deadstemn_exit_p_acc                    (numpft))
-            allocate (AKX_livecrootn_exit_p_acc                   (numpft))
-            allocate (AKX_deadcrootn_exit_p_acc                   (numpft))
-            allocate (AKX_grainn_exit_p_acc                       (numpft))
-            allocate (AKX_retransn_exit_p_acc                     (numpft))
+            allocate (AKX_leafn_exit_p_acc                        (numpft)); AKX_leafn_exit_p_acc                        (:) = spval
+            allocate (AKX_frootn_exit_p_acc                       (numpft)); AKX_frootn_exit_p_acc                       (:) = spval
+            allocate (AKX_livestemn_exit_p_acc                    (numpft)); AKX_livestemn_exit_p_acc                    (:) = spval
+            allocate (AKX_deadstemn_exit_p_acc                    (numpft)); AKX_deadstemn_exit_p_acc                    (:) = spval
+            allocate (AKX_livecrootn_exit_p_acc                   (numpft)); AKX_livecrootn_exit_p_acc                   (:) = spval
+            allocate (AKX_deadcrootn_exit_p_acc                   (numpft)); AKX_deadcrootn_exit_p_acc                   (:) = spval
+            allocate (AKX_grainn_exit_p_acc                       (numpft)); AKX_grainn_exit_p_acc                       (:) = spval
+            allocate (AKX_retransn_exit_p_acc                     (numpft)); AKX_retransn_exit_p_acc                     (:) = spval
 
-            allocate (AKX_leafn_st_exit_p_acc                     (numpft))
-            allocate (AKX_frootn_st_exit_p_acc                    (numpft))
-            allocate (AKX_livestemn_st_exit_p_acc                 (numpft))
-            allocate (AKX_deadstemn_st_exit_p_acc                 (numpft))
-            allocate (AKX_livecrootn_st_exit_p_acc                (numpft))
-            allocate (AKX_deadcrootn_st_exit_p_acc                (numpft))
-            allocate (AKX_grainn_st_exit_p_acc                    (numpft))
+            allocate (AKX_leafn_st_exit_p_acc                     (numpft)); AKX_leafn_st_exit_p_acc                     (:) = spval
+            allocate (AKX_frootn_st_exit_p_acc                    (numpft)); AKX_frootn_st_exit_p_acc                    (:) = spval
+            allocate (AKX_livestemn_st_exit_p_acc                 (numpft)); AKX_livestemn_st_exit_p_acc                 (:) = spval
+            allocate (AKX_deadstemn_st_exit_p_acc                 (numpft)); AKX_deadstemn_st_exit_p_acc                 (:) = spval
+            allocate (AKX_livecrootn_st_exit_p_acc                (numpft)); AKX_livecrootn_st_exit_p_acc                (:) = spval
+            allocate (AKX_deadcrootn_st_exit_p_acc                (numpft)); AKX_deadcrootn_st_exit_p_acc                (:) = spval
+            allocate (AKX_grainn_st_exit_p_acc                    (numpft)); AKX_grainn_st_exit_p_acc                    (:) = spval
 
-            allocate (AKX_leafn_xf_exit_p_acc                     (numpft))
-            allocate (AKX_frootn_xf_exit_p_acc                    (numpft))
-            allocate (AKX_livestemn_xf_exit_p_acc                 (numpft))
-            allocate (AKX_deadstemn_xf_exit_p_acc                 (numpft))
-            allocate (AKX_livecrootn_xf_exit_p_acc                (numpft))
-            allocate (AKX_deadcrootn_xf_exit_p_acc                (numpft))
-            allocate (AKX_grainn_xf_exit_p_acc                    (numpft))
+            allocate (AKX_leafn_xf_exit_p_acc                     (numpft)); AKX_leafn_xf_exit_p_acc                     (:) = spval
+            allocate (AKX_frootn_xf_exit_p_acc                    (numpft)); AKX_frootn_xf_exit_p_acc                    (:) = spval
+            allocate (AKX_livestemn_xf_exit_p_acc                 (numpft)); AKX_livestemn_xf_exit_p_acc                 (:) = spval
+            allocate (AKX_deadstemn_xf_exit_p_acc                 (numpft)); AKX_deadstemn_xf_exit_p_acc                 (:) = spval
+            allocate (AKX_livecrootn_xf_exit_p_acc                (numpft)); AKX_livecrootn_xf_exit_p_acc                (:) = spval
+            allocate (AKX_deadcrootn_xf_exit_p_acc                (numpft)); AKX_deadcrootn_xf_exit_p_acc                (:) = spval
+            allocate (AKX_grainn_xf_exit_p_acc                    (numpft)); AKX_grainn_xf_exit_p_acc                    (:) = spval
          ENDIF
       ENDIF
 

--- a/main/BGC/MOD_BGC_Vars_TimeInvariants.F90
+++ b/main/BGC/MOD_BGC_Vars_TimeInvariants.F90
@@ -142,7 +142,7 @@ SAVE
   ! --------------------------------------------------------------------
 
      use MOD_Precision
-     use MOD_Vars_Global, only: nl_soil, ndecomp_transitions, ndecomp_pools
+     use MOD_Vars_Global, only: nl_soil, ndecomp_transitions, ndecomp_pools, spval_i4, spval
      use MOD_SPMD_Task
      use MOD_LandPatch, only : numpatch
      IMPLICIT NONE
@@ -151,20 +151,20 @@ SAVE
 
      if (numpatch > 0) then
 ! bgc varaibles
-     allocate (donor_pool        (ndecomp_transitions))
-     allocate (receiver_pool     (ndecomp_transitions))
-     allocate (floating_cn_ratio (ndecomp_pools))
-     allocate (initial_cn_ratio  (ndecomp_pools))
-     allocate (rf_decomp         (nl_soil,ndecomp_transitions,numpatch))
-     allocate (pathfrac_decomp   (nl_soil,ndecomp_transitions,numpatch))
-     allocate (is_cwd            (ndecomp_pools)) ! True => is a coarse woody debris pool
-     allocate (is_litter         (ndecomp_pools)) ! True => is a litter pool
-     allocate (is_soil           (ndecomp_pools)) ! True => is a soil pool
-     allocate (gdp_lf            (numpatch))
-     allocate (abm_lf            (numpatch))
-     allocate (peatf_lf          (numpatch))
-     allocate (cmb_cmplt_fact    (2))
-     allocate (rice2pdt          (numpatch))
+     allocate (donor_pool        (ndecomp_transitions))                  ; donor_pool         (:) = spval_i4
+     allocate (receiver_pool     (ndecomp_transitions))                  ; receiver_pool      (:) = spval_i4
+     allocate (floating_cn_ratio (ndecomp_pools))                        ; floating_cn_ratio  (:) = .false.
+     allocate (initial_cn_ratio  (ndecomp_pools))                        ; initial_cn_ratio   (:) = spval
+     allocate (rf_decomp         (nl_soil,ndecomp_transitions,numpatch)) ; rf_decomp      (:,:,:) = spval
+     allocate (pathfrac_decomp   (nl_soil,ndecomp_transitions,numpatch)) ; pathfrac_decomp(:,:,:) = spval
+     allocate (is_cwd            (ndecomp_pools))                        ; is_cwd             (:) = .false. ! True => is a coarse woody debris pool
+     allocate (is_litter         (ndecomp_pools))                        ; is_litter          (:) = .false. ! True => is a litter pool
+     allocate (is_soil           (ndecomp_pools))                        ; is_soil            (:) = .false. ! True => is a soil pool
+     allocate (gdp_lf            (numpatch))                             ; gdp_lf             (:) = spval
+     allocate (abm_lf            (numpatch))                             ; abm_lf             (:) = spval
+     allocate (peatf_lf          (numpatch))                             ; peatf_lf           (:) = spval
+     allocate (cmb_cmplt_fact    (2))                                    ; cmb_cmplt_fact     (:) = spval
+     allocate (rice2pdt          (numpatch))                             ; rice2pdt           (:) = spval_i4
 
 ! end bgc variables
   end if

--- a/main/BGC/MOD_BGC_Vars_TimeVariables.F90
+++ b/main/BGC/MOD_BGC_Vars_TimeVariables.F90
@@ -286,238 +286,238 @@ SAVE
      if (numpatch > 0) then
 
 ! bgc variables
-        allocate (decomp_cpools_vr             (nl_soil_full,ndecomp_pools,numpatch))
-        allocate (decomp_cpools                (ndecomp_pools,numpatch))
-        allocate (ctrunc_vr                    (nl_soil,numpatch))
-        allocate (ctrunc_veg                   (numpatch))
-        allocate (ctrunc_soil                  (numpatch))
-        allocate (decomp_k                     (nl_soil_full,ndecomp_pools,numpatch))
+        allocate (decomp_cpools_vr             (nl_soil_full,ndecomp_pools,numpatch)) ; decomp_cpools_vr  (:,:,:) = spval 
+        allocate (decomp_cpools                (ndecomp_pools,numpatch))              ; decomp_cpools       (:,:) = spval
+        allocate (ctrunc_vr                    (nl_soil,numpatch))                    ; ctrunc_vr           (:,:) = spval
+        allocate (ctrunc_veg                   (numpatch))                            ; ctrunc_veg            (:) = spval
+        allocate (ctrunc_soil                  (numpatch))                            ; ctrunc_soil           (:) = spval
+        allocate (decomp_k                     (nl_soil_full,ndecomp_pools,numpatch)) ; decomp_k          (:,:,:) = spval
 
-        allocate (t_scalar                     (nl_soil,numpatch))
-        allocate (w_scalar                     (nl_soil,numpatch))
-        allocate (o_scalar                     (nl_soil,numpatch))
-        allocate (depth_scalar                 (nl_soil,numpatch))
+        allocate (t_scalar                     (nl_soil,numpatch))                    ; t_scalar            (:,:) = spval
+        allocate (w_scalar                     (nl_soil,numpatch))                    ; w_scalar            (:,:) = spval
+        allocate (o_scalar                     (nl_soil,numpatch))                    ; o_scalar            (:,:) = spval
+        allocate (depth_scalar                 (nl_soil,numpatch))                    ; depth_scalar        (:,:) = spval
 
-        allocate (som_adv_coef                 (nl_soil_full,numpatch))
-        allocate (som_diffus_coef              (nl_soil_full,numpatch))
+        allocate (som_adv_coef                 (nl_soil_full,numpatch))               ; som_adv_coef        (:,:) = spval
+        allocate (som_diffus_coef              (nl_soil_full,numpatch))               ; som_diffus_coef     (:,:) = spval
 
-        allocate (altmax                       (numpatch))
-        allocate (altmax_lastyear              (numpatch))
-        allocate (altmax_lastyear_indx         (numpatch))
+        allocate (altmax                       (numpatch))                            ; altmax                (:) = spval
+        allocate (altmax_lastyear              (numpatch))                            ; altmax_lastyear       (:) = spval
+        allocate (altmax_lastyear_indx         (numpatch))                            ; altmax_lastyear_indx  (:) = spval_i4
 
-        allocate (totlitc                      (numpatch))
-        allocate (totvegc                      (numpatch))
-        allocate (totsomc                      (numpatch))
-        allocate (totcwdc                      (numpatch))
-        allocate (totcolc                      (numpatch))
-        allocate (col_begcb                    (numpatch))
-        allocate (col_endcb                    (numpatch))
-        allocate (col_vegbegcb                 (numpatch))
-        allocate (col_vegendcb                 (numpatch))
-        allocate (col_soilbegcb                (numpatch))
-        allocate (col_soilendcb                (numpatch))
+        allocate (totlitc                      (numpatch))                            ; totlitc               (:) = spval
+        allocate (totvegc                      (numpatch))                            ; totvegc               (:) = spval
+        allocate (totsomc                      (numpatch))                            ; totsomc               (:) = spval
+        allocate (totcwdc                      (numpatch))                            ; totcwdc               (:) = spval
+        allocate (totcolc                      (numpatch))                            ; totcolc               (:) = spval
+        allocate (col_begcb                    (numpatch))                            ; col_begcb             (:) = spval
+        allocate (col_endcb                    (numpatch))                            ; col_endcb             (:) = spval
+        allocate (col_vegbegcb                 (numpatch))                            ; col_vegbegcb          (:) = spval
+        allocate (col_vegendcb                 (numpatch))                            ; col_vegendcb          (:) = spval
+        allocate (col_soilbegcb                (numpatch))                            ; col_soilbegcb         (:) = spval
+        allocate (col_soilendcb                (numpatch))                            ; col_soilendcb         (:) = spval
 
-        allocate (totlitn                      (numpatch))
-        allocate (totvegn                      (numpatch))
-        allocate (totsomn                      (numpatch))
-        allocate (totcwdn                      (numpatch))
-        allocate (totcoln                      (numpatch))
-        allocate (col_begnb                    (numpatch))
-        allocate (col_endnb                    (numpatch))
-        allocate (col_vegbegnb                 (numpatch))
-        allocate (col_vegendnb                 (numpatch))
-        allocate (col_soilbegnb                (numpatch))
-        allocate (col_soilendnb                (numpatch))
-        allocate (col_sminnbegnb               (numpatch))
-        allocate (col_sminnendnb               (numpatch))
+        allocate (totlitn                      (numpatch))                            ; totlitn               (:) = spval
+        allocate (totvegn                      (numpatch))                            ; totvegn               (:) = spval
+        allocate (totsomn                      (numpatch))                            ; totsomn               (:) = spval
+        allocate (totcwdn                      (numpatch))                            ; totcwdn               (:) = spval
+        allocate (totcoln                      (numpatch))                            ; totcoln               (:) = spval
+        allocate (col_begnb                    (numpatch))                            ; col_begnb             (:) = spval
+        allocate (col_endnb                    (numpatch))                            ; col_endnb             (:) = spval
+        allocate (col_vegbegnb                 (numpatch))                            ; col_vegbegnb          (:) = spval
+        allocate (col_vegendnb                 (numpatch))                            ; col_vegendnb          (:) = spval
+        allocate (col_soilbegnb                (numpatch))                            ; col_soilbegnb         (:) = spval
+        allocate (col_soilendnb                (numpatch))                            ; col_soilendnb         (:) = spval
+        allocate (col_sminnbegnb               (numpatch))                            ; col_sminnbegnb        (:) = spval
+        allocate (col_sminnendnb               (numpatch))                            ; col_sminnendnb        (:) = spval
 
-        allocate (leafc                        (numpatch))
-        allocate (leafc_storage                (numpatch))
-        allocate (leafc_xfer                   (numpatch))
-        allocate (frootc                       (numpatch))
-        allocate (frootc_storage               (numpatch))
-        allocate (frootc_xfer                  (numpatch))
-        allocate (livestemc                    (numpatch))
-        allocate (livestemc_storage            (numpatch))
-        allocate (livestemc_xfer               (numpatch))
-        allocate (deadstemc                    (numpatch))
-        allocate (deadstemc_storage            (numpatch))
-        allocate (deadstemc_xfer               (numpatch))
-        allocate (livecrootc                   (numpatch))
-        allocate (livecrootc_storage           (numpatch))
-        allocate (livecrootc_xfer              (numpatch))
-        allocate (deadcrootc                   (numpatch))
-        allocate (deadcrootc_storage           (numpatch))
-        allocate (deadcrootc_xfer              (numpatch))
-        allocate (grainc                       (numpatch))
-        allocate (grainc_storage               (numpatch))
-        allocate (grainc_xfer                  (numpatch))
-        allocate (xsmrpool                     (numpatch))
-        allocate (downreg                      (numpatch))
-        allocate (cropprod1c                   (numpatch))
-        allocate (cropseedc_deficit            (numpatch))
+        allocate (leafc                        (numpatch))                            ; leafc                 (:) = spval
+        allocate (leafc_storage                (numpatch))                            ; leafc_storage         (:) = spval
+        allocate (leafc_xfer                   (numpatch))                            ; leafc_xfer            (:) = spval
+        allocate (frootc                       (numpatch))                            ; frootc                (:) = spval
+        allocate (frootc_storage               (numpatch))                            ; frootc_storage        (:) = spval
+        allocate (frootc_xfer                  (numpatch))                            ; frootc_xfer           (:) = spval
+        allocate (livestemc                    (numpatch))                            ; livestemc             (:) = spval
+        allocate (livestemc_storage            (numpatch))                            ; livestemc_storage     (:) = spval
+        allocate (livestemc_xfer               (numpatch))                            ; livestemc_xfer        (:) = spval
+        allocate (deadstemc                    (numpatch))                            ; deadstemc             (:) = spval
+        allocate (deadstemc_storage            (numpatch))                            ; deadstemc_storage     (:) = spval
+        allocate (deadstemc_xfer               (numpatch))                            ; deadstemc_xfer        (:) = spval
+        allocate (livecrootc                   (numpatch))                            ; livecrootc            (:) = spval
+        allocate (livecrootc_storage           (numpatch))                            ; livecrootc_storage    (:) = spval
+        allocate (livecrootc_xfer              (numpatch))                            ; livecrootc_xfer       (:) = spval
+        allocate (deadcrootc                   (numpatch))                            ; deadcrootc            (:) = spval
+        allocate (deadcrootc_storage           (numpatch))                            ; deadcrootc_storage    (:) = spval
+        allocate (deadcrootc_xfer              (numpatch))                            ; deadcrootc_xfer       (:) = spval
+        allocate (grainc                       (numpatch))                            ; grainc                (:) = spval
+        allocate (grainc_storage               (numpatch))                            ; grainc_storage        (:) = spval
+        allocate (grainc_xfer                  (numpatch))                            ; grainc_xfer           (:) = spval
+        allocate (xsmrpool                     (numpatch))                            ; xsmrpool              (:) = spval
+        allocate (downreg                      (numpatch))                            ; downreg               (:) = spval
+        allocate (cropprod1c                   (numpatch))                            ; cropprod1c            (:) = spval
+        allocate (cropseedc_deficit            (numpatch))                            ; cropseedc_deficit     (:) = spval
 
-        allocate (leafn                        (numpatch))
-        allocate (leafn_storage                (numpatch))
-        allocate (leafn_xfer                   (numpatch))
-        allocate (frootn                       (numpatch))
-        allocate (frootn_storage               (numpatch))
-        allocate (frootn_xfer                  (numpatch))
-        allocate (livestemn                    (numpatch))
-        allocate (livestemn_storage            (numpatch))
-        allocate (livestemn_xfer               (numpatch))
-        allocate (deadstemn                    (numpatch))
-        allocate (deadstemn_storage            (numpatch))
-        allocate (deadstemn_xfer               (numpatch))
-        allocate (livecrootn                   (numpatch))
-        allocate (livecrootn_storage           (numpatch))
-        allocate (livecrootn_xfer              (numpatch))
-        allocate (deadcrootn                   (numpatch))
-        allocate (deadcrootn_storage           (numpatch))
-        allocate (deadcrootn_xfer              (numpatch))
-        allocate (grainn                       (numpatch))
-        allocate (grainn_storage               (numpatch))
-        allocate (grainn_xfer                  (numpatch))
-        allocate (retransn                     (numpatch))
+        allocate (leafn                        (numpatch))                            ; leafn                 (:) = spval
+        allocate (leafn_storage                (numpatch))                            ; leafn_storage         (:) = spval
+        allocate (leafn_xfer                   (numpatch))                            ; leafn_xfer            (:) = spval
+        allocate (frootn                       (numpatch))                            ; frootn                (:) = spval
+        allocate (frootn_storage               (numpatch))                            ; frootn_storage        (:) = spval
+        allocate (frootn_xfer                  (numpatch))                            ; frootn_xfer           (:) = spval
+        allocate (livestemn                    (numpatch))                            ; livestemn             (:) = spval
+        allocate (livestemn_storage            (numpatch))                            ; livestemn_storage     (:) = spval
+        allocate (livestemn_xfer               (numpatch))                            ; livestemn_xfer        (:) = spval
+        allocate (deadstemn                    (numpatch))                            ; deadstemn             (:) = spval
+        allocate (deadstemn_storage            (numpatch))                            ; deadstemn_storage     (:) = spval
+        allocate (deadstemn_xfer               (numpatch))                            ; deadstemn_xfer        (:) = spval
+        allocate (livecrootn                   (numpatch))                            ; livecrootn            (:) = spval
+        allocate (livecrootn_storage           (numpatch))                            ; livecrootn_storage    (:) = spval
+        allocate (livecrootn_xfer              (numpatch))                            ; livecrootn_xfer       (:) = spval
+        allocate (deadcrootn                   (numpatch))                            ; deadcrootn            (:) = spval
+        allocate (deadcrootn_storage           (numpatch))                            ; deadcrootn_storage    (:) = spval
+        allocate (deadcrootn_xfer              (numpatch))                            ; deadcrootn_xfer       (:) = spval
+        allocate (grainn                       (numpatch))                            ; grainn                (:) = spval
+        allocate (grainn_storage               (numpatch))                            ; grainn_storage        (:) = spval
+        allocate (grainn_xfer                  (numpatch))                            ; grainn_xfer           (:) = spval
+        allocate (retransn                     (numpatch))                            ; retransn              (:) = spval
 
-        allocate (decomp_npools_vr             (nl_soil_full,ndecomp_pools,numpatch))
-        allocate (decomp_npools                (ndecomp_pools,numpatch))
-        allocate (ntrunc_vr                    (nl_soil,numpatch))
-        allocate (ntrunc_veg                   (numpatch))
-        allocate (ntrunc_soil                  (numpatch))
-        allocate (sminn_vr                     (nl_soil,numpatch))
-        allocate (smin_no3_vr                  (nl_soil,numpatch))
-        allocate (smin_nh4_vr                  (nl_soil,numpatch))
-        allocate (sminn                        (numpatch))
-        allocate (ndep                         (numpatch))
+        allocate (decomp_npools_vr             (nl_soil_full,ndecomp_pools,numpatch)) ; decomp_npools_vr  (:,:,:) = spval
+        allocate (decomp_npools                (ndecomp_pools,numpatch))              ; decomp_npools       (:,:) = spval
+        allocate (ntrunc_vr                    (nl_soil,numpatch))                    ; ntrunc_vr           (:,:) = spval
+        allocate (ntrunc_veg                   (numpatch))                            ; ntrunc_veg            (:) = spval
+        allocate (ntrunc_soil                  (numpatch))                            ; ntrunc_soil           (:) = spval
+        allocate (sminn_vr                     (nl_soil,numpatch))                    ; sminn_vr            (:,:) = spval
+        allocate (smin_no3_vr                  (nl_soil,numpatch))                    ; smin_no3_vr         (:,:) = spval
+        allocate (smin_nh4_vr                  (nl_soil,numpatch))                    ; smin_nh4_vr         (:,:) = spval
+        allocate (sminn                        (numpatch))                            ; sminn                 (:) = spval
+        allocate (ndep                         (numpatch))                            ; ndep                  (:) = spval
 
-        allocate (to2_decomp_depth_unsat       (nl_soil,numpatch))
-        allocate (tconc_o2_unsat               (nl_soil,numpatch))
+        allocate (to2_decomp_depth_unsat       (nl_soil,numpatch))                    ; to2_decomp_depth_unsat (:,:) = spval
+        allocate (tconc_o2_unsat               (nl_soil,numpatch))                    ; tconc_o2_unsat         (:,:) = spval
 
-        allocate (ndep_prof                    (nl_soil,numpatch))
-        allocate (nfixation_prof               (nl_soil,numpatch))
+        allocate (ndep_prof                    (nl_soil,numpatch))                    ; ndep_prof           (:,:) = spval
+        allocate (nfixation_prof               (nl_soil,numpatch))                    ; nfixation_prof      (:,:) = spval
 
-        allocate (cn_decomp_pools              (nl_soil,ndecomp_pools,numpatch))
-        allocate (fpi_vr                       (nl_soil,numpatch))
-        allocate (fpi                          (numpatch))
-        allocate (fpg                          (numpatch))
+        allocate (cn_decomp_pools              (nl_soil,ndecomp_pools,numpatch))      ; cn_decomp_pools   (:,:,:) = spval
+        allocate (fpi_vr                       (nl_soil,numpatch))                    ; fpi_vr              (:,:) = spval
+        allocate (fpi                          (numpatch))                            ; fpi                   (:) = spval
+        allocate (fpg                          (numpatch))                            ; fpg                   (:) = spval
 
-        allocate (cropf                        (numpatch))
-        allocate (lfwt                         (numpatch))
-        allocate (fuelc                        (numpatch))
-        allocate (fuelc_crop                   (numpatch))
-        allocate (fsr                          (numpatch))
-        allocate (fd                           (numpatch))
-        allocate (rootc                        (numpatch))
-        allocate (lgdp                         (numpatch))
-        allocate (lgdp1                        (numpatch))
-        allocate (lpop                         (numpatch))
-        allocate (wtlf                         (numpatch))
-        allocate (trotr1                       (numpatch))
-        allocate (trotr2                       (numpatch))
-        allocate (hdm_lf                       (numpatch))
-        allocate (lnfm                         (numpatch))
-        allocate (baf_crop                     (numpatch))
-        allocate (baf_peatf                    (numpatch))
-        allocate (farea_burned                 (numpatch))
-        allocate (nfire                        (numpatch))
-        allocate (fsat                         (numpatch))
-        allocate (prec10                       (numpatch)) ! 10-day running mean of total      precipitation [mm/s]
-        allocate (prec60                       (numpatch)) ! 60-day running mean of total      precipitation [mm/s]
-        allocate (prec365                      (numpatch)) ! 365-day running mean of tota     l precipitation [mm/s]
-        allocate (prec_today                   (numpatch)) ! today's daily precipitation      [mm/day]
-        allocate (prec_daily               (365,numpatch)) ! daily total precipitation      [mm/day]
-        allocate (wf2                          (numpatch))
-        allocate (tsoi17                       (numpatch))
-        allocate (rh30                         (numpatch)) ! 30-day running mean of relative humidity
-        allocate (accumnstep                   (numpatch)) ! 30-day running mean of relative humidity
-
-        allocate (dayl                         (numpatch))
-        allocate (prev_dayl                    (numpatch))
+        allocate (cropf                        (numpatch))                            ; cropf                 (:) = spval
+        allocate (lfwt                         (numpatch))                            ; lfwt                  (:) = spval
+        allocate (fuelc                        (numpatch))                            ; fuelc                 (:) = spval
+        allocate (fuelc_crop                   (numpatch))                            ; fuelc_crop            (:) = spval
+        allocate (fsr                          (numpatch))                            ; fsr                   (:) = spval
+        allocate (fd                           (numpatch))                            ; fd                    (:) = spval
+        allocate (rootc                        (numpatch))                            ; rootc                 (:) = spval
+        allocate (lgdp                         (numpatch))                            ; lgdp                  (:) = spval
+        allocate (lgdp1                        (numpatch))                            ; lgdp1                 (:) = spval
+        allocate (lpop                         (numpatch))                            ; lpop                  (:) = spval
+        allocate (wtlf                         (numpatch))                            ; wtlf                  (:) = spval
+        allocate (trotr1                       (numpatch))                            ; trotr1                (:) = spval
+        allocate (trotr2                       (numpatch))                            ; trotr2                (:) = spval
+        allocate (hdm_lf                       (numpatch))                            ; hdm_lf                (:) = spval
+        allocate (lnfm                         (numpatch))                            ; lnfm                  (:) = spval
+        allocate (baf_crop                     (numpatch))                            ; baf_crop              (:) = spval
+        allocate (baf_peatf                    (numpatch))                            ; baf_peatf             (:) = spval
+        allocate (farea_burned                 (numpatch))                            ; farea_burned          (:) = spval
+        allocate (nfire                        (numpatch))                            ; nfire                 (:) = spval
+        allocate (fsat                         (numpatch))                            ; fsat                  (:) = spval
+        allocate (prec10                       (numpatch))                            ; prec10                (:) = spval
+        allocate (prec60                       (numpatch))                            ; prec60                (:) = spval
+        allocate (prec365                      (numpatch))                            ; prec365               (:) = spval
+        allocate (prec_today                   (numpatch))                            ; prec_today            (:) = spval
+        allocate (prec_daily               (365,numpatch))                            ; prec_daily          (:,:) = spval! daily total precipitation      [mm/day]
+        allocate (wf2                          (numpatch))                            ; wf2                   (:) = spval
+        allocate (tsoi17                       (numpatch))                            ; tsoi17                (:) = spval
+        allocate (rh30                         (numpatch))                            ; rh30                  (:) = spval
+        allocate (accumnstep                   (numpatch))                            ; accumnstep            (:) = spval
+                            ; 
+        allocate (dayl                         (numpatch))                            ; dayl                  (:) = spval
+        allocate (prev_dayl                    (numpatch))                            ; prev_dayl             (:) = spval
 
 !---------------------------SASU variables--------------------------------------
-        allocate (decomp0_cpools_vr            (nl_soil,ndecomp_pools,numpatch))
-        allocate (I_met_c_vr_acc               (nl_soil,numpatch))
-        allocate (I_cel_c_vr_acc               (nl_soil,numpatch))
-        allocate (I_lig_c_vr_acc               (nl_soil,numpatch))
-        allocate (I_cwd_c_vr_acc               (nl_soil,numpatch))
-        allocate (AKX_met_to_soil1_c_vr_acc    (nl_soil,numpatch))
-        allocate (AKX_cel_to_soil1_c_vr_acc    (nl_soil,numpatch))
-        allocate (AKX_lig_to_soil2_c_vr_acc    (nl_soil,numpatch))
-        allocate (AKX_soil1_to_soil2_c_vr_acc  (nl_soil,numpatch))
-        allocate (AKX_cwd_to_cel_c_vr_acc      (nl_soil,numpatch))
-        allocate (AKX_cwd_to_lig_c_vr_acc      (nl_soil,numpatch))
-        allocate (AKX_soil1_to_soil3_c_vr_acc  (nl_soil,numpatch))
-        allocate (AKX_soil2_to_soil1_c_vr_acc  (nl_soil,numpatch))
-        allocate (AKX_soil2_to_soil3_c_vr_acc  (nl_soil,numpatch))
-        allocate (AKX_soil3_to_soil1_c_vr_acc  (nl_soil,numpatch))
-        allocate (AKX_met_exit_c_vr_acc        (nl_soil,numpatch))
-        allocate (AKX_cel_exit_c_vr_acc        (nl_soil,numpatch))
-        allocate (AKX_lig_exit_c_vr_acc        (nl_soil,numpatch))
-        allocate (AKX_cwd_exit_c_vr_acc        (nl_soil,numpatch))
-        allocate (AKX_soil1_exit_c_vr_acc      (nl_soil,numpatch))
-        allocate (AKX_soil2_exit_c_vr_acc      (nl_soil,numpatch))
-        allocate (AKX_soil3_exit_c_vr_acc      (nl_soil,numpatch))
+        allocate (decomp0_cpools_vr            (nl_soil,ndecomp_pools,numpatch))      ; decomp0_cpools_vr          (:,:,:) = spval
+        allocate (I_met_c_vr_acc               (nl_soil,numpatch))                    ; I_met_c_vr_acc               (:,:) = spval
+        allocate (I_cel_c_vr_acc               (nl_soil,numpatch))                    ; I_cel_c_vr_acc               (:,:) = spval
+        allocate (I_lig_c_vr_acc               (nl_soil,numpatch))                    ; I_lig_c_vr_acc               (:,:) = spval
+        allocate (I_cwd_c_vr_acc               (nl_soil,numpatch))                    ; I_cwd_c_vr_acc               (:,:) = spval
+        allocate (AKX_met_to_soil1_c_vr_acc    (nl_soil,numpatch))                    ; AKX_met_to_soil1_c_vr_acc    (:,:) = spval
+        allocate (AKX_cel_to_soil1_c_vr_acc    (nl_soil,numpatch))                    ; AKX_cel_to_soil1_c_vr_acc    (:,:) = spval
+        allocate (AKX_lig_to_soil2_c_vr_acc    (nl_soil,numpatch))                    ; AKX_lig_to_soil2_c_vr_acc    (:,:) = spval
+        allocate (AKX_soil1_to_soil2_c_vr_acc  (nl_soil,numpatch))                    ; AKX_soil1_to_soil2_c_vr_acc  (:,:) = spval
+        allocate (AKX_cwd_to_cel_c_vr_acc      (nl_soil,numpatch))                    ; AKX_cwd_to_cel_c_vr_acc      (:,:) = spval
+        allocate (AKX_cwd_to_lig_c_vr_acc      (nl_soil,numpatch))                    ; AKX_cwd_to_lig_c_vr_acc      (:,:) = spval
+        allocate (AKX_soil1_to_soil3_c_vr_acc  (nl_soil,numpatch))                    ; AKX_soil1_to_soil3_c_vr_acc  (:,:) = spval
+        allocate (AKX_soil2_to_soil1_c_vr_acc  (nl_soil,numpatch))                    ; AKX_soil2_to_soil1_c_vr_acc  (:,:) = spval
+        allocate (AKX_soil2_to_soil3_c_vr_acc  (nl_soil,numpatch))                    ; AKX_soil2_to_soil3_c_vr_acc  (:,:) = spval
+        allocate (AKX_soil3_to_soil1_c_vr_acc  (nl_soil,numpatch))                    ; AKX_soil3_to_soil1_c_vr_acc  (:,:) = spval
+        allocate (AKX_met_exit_c_vr_acc        (nl_soil,numpatch))                    ; AKX_met_exit_c_vr_acc        (:,:) = spval
+        allocate (AKX_cel_exit_c_vr_acc        (nl_soil,numpatch))                    ; AKX_cel_exit_c_vr_acc        (:,:) = spval
+        allocate (AKX_lig_exit_c_vr_acc        (nl_soil,numpatch))                    ; AKX_lig_exit_c_vr_acc        (:,:) = spval
+        allocate (AKX_cwd_exit_c_vr_acc        (nl_soil,numpatch))                    ; AKX_cwd_exit_c_vr_acc        (:,:) = spval
+        allocate (AKX_soil1_exit_c_vr_acc      (nl_soil,numpatch))                    ; AKX_soil1_exit_c_vr_acc      (:,:) = spval
+        allocate (AKX_soil2_exit_c_vr_acc      (nl_soil,numpatch))                    ; AKX_soil2_exit_c_vr_acc      (:,:) = spval
+        allocate (AKX_soil3_exit_c_vr_acc      (nl_soil,numpatch))                    ; AKX_soil3_exit_c_vr_acc      (:,:) = spval
 
-        allocate (decomp0_npools_vr            (nl_soil,ndecomp_pools,numpatch))
-        allocate (I_met_n_vr_acc               (nl_soil,numpatch))
-        allocate (I_cel_n_vr_acc               (nl_soil,numpatch))
-        allocate (I_lig_n_vr_acc               (nl_soil,numpatch))
-        allocate (I_cwd_n_vr_acc               (nl_soil,numpatch))
-        allocate (AKX_met_to_soil1_n_vr_acc    (nl_soil,numpatch))
-        allocate (AKX_cel_to_soil1_n_vr_acc    (nl_soil,numpatch))
-        allocate (AKX_lig_to_soil2_n_vr_acc    (nl_soil,numpatch))
-        allocate (AKX_soil1_to_soil2_n_vr_acc  (nl_soil,numpatch))
-        allocate (AKX_cwd_to_cel_n_vr_acc      (nl_soil,numpatch))
-        allocate (AKX_cwd_to_lig_n_vr_acc      (nl_soil,numpatch))
-        allocate (AKX_soil1_to_soil3_n_vr_acc  (nl_soil,numpatch))
-        allocate (AKX_soil2_to_soil1_n_vr_acc  (nl_soil,numpatch))
-        allocate (AKX_soil2_to_soil3_n_vr_acc  (nl_soil,numpatch))
-        allocate (AKX_soil3_to_soil1_n_vr_acc  (nl_soil,numpatch))
-        allocate (AKX_met_exit_n_vr_acc        (nl_soil,numpatch))
-        allocate (AKX_cel_exit_n_vr_acc        (nl_soil,numpatch))
-        allocate (AKX_lig_exit_n_vr_acc        (nl_soil,numpatch))
-        allocate (AKX_cwd_exit_n_vr_acc        (nl_soil,numpatch))
-        allocate (AKX_soil1_exit_n_vr_acc      (nl_soil,numpatch))
-        allocate (AKX_soil2_exit_n_vr_acc      (nl_soil,numpatch))
-        allocate (AKX_soil3_exit_n_vr_acc      (nl_soil,numpatch))
+        allocate (decomp0_npools_vr            (nl_soil,ndecomp_pools,numpatch))      ; decomp0_npools_vr          (:,:,:) = spval
+        allocate (I_met_n_vr_acc               (nl_soil,numpatch))                    ; I_met_n_vr_acc               (:,:) = spval
+        allocate (I_cel_n_vr_acc               (nl_soil,numpatch))                    ; I_cel_n_vr_acc               (:,:) = spval
+        allocate (I_lig_n_vr_acc               (nl_soil,numpatch))                    ; I_lig_n_vr_acc               (:,:) = spval
+        allocate (I_cwd_n_vr_acc               (nl_soil,numpatch))                    ; I_cwd_n_vr_acc               (:,:) = spval
+        allocate (AKX_met_to_soil1_n_vr_acc    (nl_soil,numpatch))                    ; AKX_met_to_soil1_n_vr_acc    (:,:) = spval
+        allocate (AKX_cel_to_soil1_n_vr_acc    (nl_soil,numpatch))                    ; AKX_cel_to_soil1_n_vr_acc    (:,:) = spval
+        allocate (AKX_lig_to_soil2_n_vr_acc    (nl_soil,numpatch))                    ; AKX_lig_to_soil2_n_vr_acc    (:,:) = spval
+        allocate (AKX_soil1_to_soil2_n_vr_acc  (nl_soil,numpatch))                    ; AKX_soil1_to_soil2_n_vr_acc  (:,:) = spval
+        allocate (AKX_cwd_to_cel_n_vr_acc      (nl_soil,numpatch))                    ; AKX_cwd_to_cel_n_vr_acc      (:,:) = spval
+        allocate (AKX_cwd_to_lig_n_vr_acc      (nl_soil,numpatch))                    ; AKX_cwd_to_lig_n_vr_acc      (:,:) = spval
+        allocate (AKX_soil1_to_soil3_n_vr_acc  (nl_soil,numpatch))                    ; AKX_soil1_to_soil3_n_vr_acc  (:,:) = spval
+        allocate (AKX_soil2_to_soil1_n_vr_acc  (nl_soil,numpatch))                    ; AKX_soil2_to_soil1_n_vr_acc  (:,:) = spval
+        allocate (AKX_soil2_to_soil3_n_vr_acc  (nl_soil,numpatch))                    ; AKX_soil2_to_soil3_n_vr_acc  (:,:) = spval
+        allocate (AKX_soil3_to_soil1_n_vr_acc  (nl_soil,numpatch))                    ; AKX_soil3_to_soil1_n_vr_acc  (:,:) = spval
+        allocate (AKX_met_exit_n_vr_acc        (nl_soil,numpatch))                    ; AKX_met_exit_n_vr_acc        (:,:) = spval
+        allocate (AKX_cel_exit_n_vr_acc        (nl_soil,numpatch))                    ; AKX_cel_exit_n_vr_acc        (:,:) = spval
+        allocate (AKX_lig_exit_n_vr_acc        (nl_soil,numpatch))                    ; AKX_lig_exit_n_vr_acc        (:,:) = spval
+        allocate (AKX_cwd_exit_n_vr_acc        (nl_soil,numpatch))                    ; AKX_cwd_exit_n_vr_acc        (:,:) = spval
+        allocate (AKX_soil1_exit_n_vr_acc      (nl_soil,numpatch))                    ; AKX_soil1_exit_n_vr_acc      (:,:) = spval
+        allocate (AKX_soil2_exit_n_vr_acc      (nl_soil,numpatch))                    ; AKX_soil2_exit_n_vr_acc      (:,:) = spval
+        allocate (AKX_soil3_exit_n_vr_acc      (nl_soil,numpatch))                    ; AKX_soil3_exit_n_vr_acc      (:,:) = spval
 
-        allocate (diagVX_c_vr_acc              (nl_soil,ndecomp_pools,numpatch))
-        allocate (upperVX_c_vr_acc             (nl_soil,ndecomp_pools,numpatch))
-        allocate (lowerVX_c_vr_acc             (nl_soil,ndecomp_pools,numpatch))
-        allocate (diagVX_n_vr_acc              (nl_soil,ndecomp_pools,numpatch))
-        allocate (upperVX_n_vr_acc             (nl_soil,ndecomp_pools,numpatch))
-        allocate (lowerVX_n_vr_acc             (nl_soil,ndecomp_pools,numpatch))
+        allocate (diagVX_c_vr_acc              (nl_soil,ndecomp_pools,numpatch))      ; diagVX_c_vr_acc            (:,:,:) = spval
+        allocate (upperVX_c_vr_acc             (nl_soil,ndecomp_pools,numpatch))      ; upperVX_c_vr_acc           (:,:,:) = spval
+        allocate (lowerVX_c_vr_acc             (nl_soil,ndecomp_pools,numpatch))      ; lowerVX_c_vr_acc           (:,:,:) = spval
+        allocate (diagVX_n_vr_acc              (nl_soil,ndecomp_pools,numpatch))      ; diagVX_n_vr_acc            (:,:,:) = spval
+        allocate (upperVX_n_vr_acc             (nl_soil,ndecomp_pools,numpatch))      ; upperVX_n_vr_acc           (:,:,:) = spval
+        allocate (lowerVX_n_vr_acc             (nl_soil,ndecomp_pools,numpatch))      ; lowerVX_n_vr_acc           (:,:,:) = spval
 
 !---------------------------------------------------------------------------
-        allocate (skip_balance_check           (numpatch))
+        allocate (skip_balance_check           (numpatch))                            ; skip_balance_check             (:) = .false.
 
 #ifdef CROP
-        allocate (cphase                       (numpatch)) ! 30-day running mean of relative humidity
-        allocate (vf                    (numpatch))
-        allocate (gddmaturity           (numpatch))
-        allocate (gddplant              (numpatch))
-        allocate (hui                   (numpatch))
-        allocate (huiswheat             (numpatch))
-        allocate (pdcorn                (numpatch))
-        allocate (pdswheat              (numpatch))
-        allocate (pdwwheat              (numpatch))
-        allocate (pdsoybean             (numpatch))
-        allocate (pdcotton              (numpatch))
-        allocate (pdrice1               (numpatch))
-        allocate (pdrice2               (numpatch))
-        allocate (plantdate             (numpatch))
-        allocate (pdsugarcane           (numpatch))
-        allocate (fertnitro_corn        (numpatch))
-        allocate (fertnitro_swheat      (numpatch))
-        allocate (fertnitro_wwheat      (numpatch))
-        allocate (fertnitro_soybean     (numpatch))
-        allocate (fertnitro_cotton      (numpatch))
-        allocate (fertnitro_rice1       (numpatch))
-        allocate (fertnitro_rice2       (numpatch))
-        allocate (fertnitro_sugarcane   (numpatch))
+        allocate (cphase                       (numpatch))                            ; cphase                (:) = spval ! 30-day running mean of relative humidity
+        allocate (vf                           (numpatch))                            ; vf                    (:) = spval
+        allocate (gddmaturity                  (numpatch))                            ; gddmaturity           (:) = spval
+        allocate (gddplant                     (numpatch))                            ; gddplant              (:) = spval
+        allocate (hui                          (numpatch))                            ; hui                   (:) = spval
+        allocate (huiswheat                    (numpatch))                            ; huiswheat             (:) = spval
+        allocate (pdcorn                       (numpatch))                            ; pdcorn                (:) = spval
+        allocate (pdswheat                     (numpatch))                            ; pdswheat              (:) = spval
+        allocate (pdwwheat                     (numpatch))                            ; pdwwheat              (:) = spval
+        allocate (pdsoybean                    (numpatch))                            ; pdsoybean             (:) = spval
+        allocate (pdcotton                     (numpatch))                            ; pdcotton              (:) = spval
+        allocate (pdrice1                      (numpatch))                            ; pdrice1               (:) = spval
+        allocate (pdrice2                      (numpatch))                            ; pdrice2               (:) = spval
+        allocate (plantdate                    (numpatch))                            ; plantdate             (:) = spval
+        allocate (pdsugarcane                  (numpatch))                            ; pdsugarcane           (:) = spval
+        allocate (fertnitro_corn               (numpatch))                            ; fertnitro_corn        (:) = spval
+        allocate (fertnitro_swheat             (numpatch))                            ; fertnitro_swheat      (:) = spval
+        allocate (fertnitro_wwheat             (numpatch))                            ; fertnitro_wwheat      (:) = spval
+        allocate (fertnitro_soybean            (numpatch))                            ; fertnitro_soybean     (:) = spval
+        allocate (fertnitro_cotton             (numpatch))                            ; fertnitro_cotton      (:) = spval
+        allocate (fertnitro_rice1              (numpatch))                            ; fertnitro_rice1       (:) = spval
+        allocate (fertnitro_rice2              (numpatch))                            ; fertnitro_rice2       (:) = spval
+        allocate (fertnitro_sugarcane          (numpatch))                            ; fertnitro_sugarcane   (:) = spval
 #endif
-        allocate (lag_npp               (numpatch))
+        allocate (lag_npp                      (numpatch))                            ; lag_npp               (:) = spval
      end if
   end if
 

--- a/main/MOD_Vars_TimeVariables.F90
+++ b/main/MOD_Vars_TimeVariables.F90
@@ -89,39 +89,39 @@ CONTAINS
 
       IF (p_is_worker) THEN
          IF (numpft > 0) THEN
-            allocate (tleaf_p      (numpft)) !leaf temperature [K]
-            allocate (ldew_p       (numpft)) !depth of water on foliage [mm]
-            allocate (ldew_rain_p  (numpft)) !depth of rain on foliage [mm]
-            allocate (ldew_snow_p  (numpft)) !depth of snow on foliage [mm]
-            allocate (sigf_p       (numpft)) !fraction of veg cover, excluding snow-covered veg [-]
-            allocate (tlai_p       (numpft)) !leaf area index
-            allocate (lai_p        (numpft)) !leaf area index
-            allocate (laisun_p     (numpft)) !leaf area index
-            allocate (laisha_p     (numpft)) !leaf area index
-            allocate (tsai_p       (numpft)) !stem area index
-            allocate (sai_p        (numpft)) !stem area index
-            allocate (ssun_p   (2,2,numpft)) !sunlit canopy absorption for solar radiation (0-1)
-            allocate (ssha_p   (2,2,numpft)) !shaded canopy absorption for solar radiation (0-1)
-            allocate (thermk_p     (numpft)) !canopy gap fraction for tir radiation
-            allocate (extkb_p      (numpft)) !(k, g(mu)/mu) direct solar extinction coefficient
-            allocate (extkd_p      (numpft)) !diffuse and scattered diffuse PAR extinction coefficient
-            allocate (tref_p       (numpft)) !2 m height air temperature [kelvin]
-            allocate (qref_p       (numpft)) !2 m height air specific humidity
-            allocate (rst_p        (numpft)) !canopy stomatal resistance (s/m)
-            allocate (z0m_p        (numpft)) !effective roughness [m]
-! Plant Hydraulic variables
-            allocate (vegwp_p      (1:nvegwcs,numpft))
-            allocate (gs0sun_p     (numpft))
-            allocate (gs0sha_p     (numpft))
+            allocate (tleaf_p      (numpft)) ; tleaf_p      (:) = spval !leaf temperature [K]
+            allocate (ldew_p       (numpft)) ; ldew_p       (:) = spval !depth of water on foliage [mm]
+            allocate (ldew_rain_p  (numpft)) ; ldew_rain_p  (:) = spval !depth of rain on foliage [mm]
+            allocate (ldew_snow_p  (numpft)) ; ldew_snow_p  (:) = spval !depth of snow on foliage [mm]
+            allocate (sigf_p       (numpft)) ; sigf_p       (:) = spval !fraction of veg cover, excluding snow-covered veg [-]
+            allocate (tlai_p       (numpft)) ; tlai_p       (:) = spval !leaf area index
+            allocate (lai_p        (numpft)) ; lai_p        (:) = spval !leaf area index
+            allocate (laisun_p     (numpft)) ; laisun_p     (:) = spval !leaf area index
+            allocate (laisha_p     (numpft)) ; laisha_p     (:) = spval !leaf area index
+            allocate (tsai_p       (numpft)) ; tsai_p       (:) = spval !stem area index
+            allocate (sai_p        (numpft)) ; sai_p        (:) = spval !stem area index
+            allocate (ssun_p   (2,2,numpft)) ; ssun_p   (:,:,:) = spval !sunlit canopy absorption for solar radiation (0-1)
+            allocate (ssha_p   (2,2,numpft)) ; ssha_p   (:,:,:) = spval !shaded canopy absorption for solar radiation (0-1)
+            allocate (thermk_p     (numpft)) ; thermk_p     (:) = spval !canopy gap fraction for tir radiation
+            allocate (extkb_p      (numpft)) ; extkb_p      (:) = spval !(k, g(mu)/mu) direct solar extinction coefficient
+            allocate (extkd_p      (numpft)) ; extkd_p      (:) = spval !diffuse and scattered diffuse PAR extinction coefficient
+            allocate (tref_p       (numpft)) ; tref_p       (:) = spval !2 m height air temperature [kelvin]
+            allocate (qref_p       (numpft)) ; qref_p       (:) = spval !2 m height air specific humidity
+            allocate (rst_p        (numpft)) ; rst_p        (:) = spval !canopy stomatal resistance (s/m)
+            allocate (z0m_p        (numpft)) ; z0m_p        (:) = spval !effective roughness [m]
+! Plant Hydraulic variables; draulic variables
+            allocate (vegwp_p(1:nvegwcs,numpft)); vegwp_p (:,:) = spval
+            allocate (gs0sun_p     (numpft)); gs0sun_p      (:) = spval
+            allocate (gs0sha_p     (numpft)); gs0sha_p      (:) = spval
 ! end plant hydraulic variables
 ! Allocate Ozone Stress Variables
-            allocate (o3coefv_sun_p(numpft)) !Ozone stress factor for photosynthesis on sunlit leaf
-            allocate (o3coefv_sha_p(numpft)) !Ozone stress factor for photosynthesis on shaded leaf
-            allocate (o3coefg_sun_p(numpft)) !Ozone stress factor for stomata on sunlit leaf
-            allocate (o3coefg_sha_p(numpft)) !Ozone stress factor for stomata on shaded leaf
-            allocate (lai_old_p    (numpft)) !lai in last time step
-            allocate (o3uptakesun_p(numpft)) !Ozone does, sunlit leaf (mmol O3/m^2)
-            allocate (o3uptakesha_p(numpft)) !Ozone does, shaded leaf (mmol O3/m^2)
+            allocate (o3coefv_sun_p(numpft)) ; o3coefv_sun_p(:) = spval !Ozone stress factor for photosynthesis on sunlit leaf
+            allocate (o3coefv_sha_p(numpft)) ; o3coefv_sha_p(:) = spval !Ozone stress factor for photosynthesis on shaded leaf
+            allocate (o3coefg_sun_p(numpft)) ; o3coefg_sun_p(:) = spval !Ozone stress factor for stomata on sunlit leaf
+            allocate (o3coefg_sha_p(numpft)) ; o3coefg_sha_p(:) = spval !Ozone stress factor for stomata on shaded leaf
+            allocate (lai_old_p    (numpft)) ; lai_old_p    (:) = spval !lai in last time step
+            allocate (o3uptakesun_p(numpft)) ; o3uptakesun_p(:) = spval !Ozone does, sunlit leaf (mmol O3/m^2)
+            allocate (o3uptakesha_p(numpft)) ; o3uptakesha_p(:) = spval !Ozone does, shaded leaf (mmol O3/m^2)
 ! End allocate Ozone Stress Variables
          ENDIF
       ENDIF
@@ -428,36 +428,36 @@ CONTAINS
 
       IF (p_is_worker) THEN
          IF (numpc > 0) THEN
-            allocate (tleaf_c    (0:N_PFT-1,numpc)) !leaf temperature [K]
-            allocate (ldew_c     (0:N_PFT-1,numpc)) !depth of water on foliage [mm]
-            allocate (ldew_rain_c(0:N_PFT-1,numpc)) !depth of rain on foliage [mm]
-            allocate (ldew_snow_c(0:N_PFT-1,numpc)) !depth of snow on foliage [mm]
-            allocate (sigf_c     (0:N_PFT-1,numpc)) !fraction of veg cover, excluding snow-covered veg [-]
-            allocate (tlai_c     (0:N_PFT-1,numpc)) !leaf area index
-            allocate (lai_c      (0:N_PFT-1,numpc)) !leaf area index
-            allocate (tsai_c     (0:N_PFT-1,numpc)) !stem area index
-            allocate (sai_c      (0:N_PFT-1,numpc)) !stem area index
-            allocate (ssun_c (2,2,0:N_PFT-1,numpc)) !sunlit canopy absorption for solar radiation (0-1)
-            allocate (ssha_c (2,2,0:N_PFT-1,numpc)) !shaded canopy absorption for solar radiation (0-1)
-            allocate (thermk_c   (0:N_PFT-1,numpc)) !canopy gap fraction for tir radiation
-            allocate (fshade_c   (0:N_PFT-1,numpc)) !canopy gap fraction for tir radiation
-            allocate (extkb_c    (0:N_PFT-1,numpc)) !(k, g(mu)/mu) direct solar extinction coefficient
-            allocate (extkd_c    (0:N_PFT-1,numpc)) !diffuse and scattered diffuse PAR extinction coefficient
-            allocate (rst_c      (0:N_PFT-1,numpc)) !canopy stomatal resistance (s/m)
-            allocate (z0m_c      (0:N_PFT-1,numpc)) !effective roughness [m]
-!Plant Hydraulic parameters
-            allocate (vegwp_c    (1:nvegwcs,0:N_PFT-1,numpc))
-            allocate (gs0sun_c   (0:N_PFT-1,numpc))
-            allocate (gs0sha_c   (0:N_PFT-1,numpc))
+            allocate (tleaf_c    (0:N_PFT-1,numpc))   ; tleaf_c      (:,:) = spval      !leaf temperature [K]
+            allocate (ldew_c     (0:N_PFT-1,numpc))   ; ldew_c       (:,:) = spval      !depth of water on foliage [mm]
+            allocate (ldew_rain_c(0:N_PFT-1,numpc))   ; ldew_rain_c  (:,:) = spval      !depth of rain on foliage [mm]
+            allocate (ldew_snow_c(0:N_PFT-1,numpc))   ; ldew_snow_c  (:,:) = spval      !depth of snow on foliage [mm]
+            allocate (sigf_c     (0:N_PFT-1,numpc))   ; sigf_c       (:,:) = spval      !fraction of veg cover, excluding snow-covered veg [-]
+            allocate (tlai_c     (0:N_PFT-1,numpc))   ; tlai_c       (:,:) = spval      !leaf area index
+            allocate (lai_c      (0:N_PFT-1,numpc))   ; lai_c        (:,:) = spval      !leaf area index
+            allocate (tsai_c     (0:N_PFT-1,numpc))   ; tsai_c       (:,:) = spval      !stem area index
+            allocate (sai_c      (0:N_PFT-1,numpc))   ; sai_c        (:,:) = spval      !stem area index
+            allocate (ssun_c (2,2,0:N_PFT-1,numpc))   ; ssun_c     (2,2,:) = spval      !sunlit canopy absorption for solar radiation (0-1)
+            allocate (ssha_c (2,2,0:N_PFT-1,numpc))   ; ssha_c     (2,2,:) = spval      !shaded canopy absorption for solar radiation (0-1)
+            allocate (thermk_c   (0:N_PFT-1,numpc))   ; thermk_c     (:,:) = spval      !canopy gap fraction for tir radiation
+            allocate (fshade_c   (0:N_PFT-1,numpc))   ; fshade_c     (:,:) = spval      !canopy gap fraction for tir radiation
+            allocate (extkb_c    (0:N_PFT-1,numpc))   ; extkb_c      (:,:) = spval      !(k, g(mu)/mu) direct solar extinction coefficient
+            allocate (extkd_c    (0:N_PFT-1,numpc))   ; extkd_c      (:,:) = spval      !diffuse and scattered diffuse PAR extinction coefficient
+            allocate (rst_c      (0:N_PFT-1,numpc))   ; rst_c        (:,:) = spval      !canopy stomatal resistance (s/m)
+            allocate (z0m_c      (0:N_PFT-1,numpc))   ; z0m_c        (:,:) = spval      !effective roughness [m]
+!Plant Hydraulic parameters; raulic parameters
+            allocate (vegwp_c(1:nvegwcs,0:N_PFT-1,numpc)); vegwp_c (:,:,:) = spval
+            allocate (gs0sun_c   (0:N_PFT-1,numpc))   ; gs0sun_c     (:,:) = spval      
+            allocate (gs0sha_c   (0:N_PFT-1,numpc))   ; gs0sha_c     (:,:) = spval      
 !end plant hydraulic parameters
 !Ozone Stress Variables
-            allocate (o3coefv_sun_c(0:N_PFT-1,numpc)) !Ozone stress factor for photosynthesis on sunlit leaf
-            allocate (o3coefv_sha_c(0:N_PFT-1,numpc)) !Ozone stress factor for photosynthesis on shaded leaf
-            allocate (o3coefg_sun_c(0:N_PFT-1,numpc)) !Ozone stress factor for stomata on sunlit leaf
-            allocate (o3coefg_sha_c(0:N_PFT-1,numpc)) !Ozone stress factor for stomata on shaded leaf
-            allocate (lai_old_c    (0:N_PFT-1,numpc)) !lai in last time step
-            allocate (o3uptakesun_c(0:N_PFT-1,numpc)) !Ozone does, sunlit leaf (mmol O3/m^2)
-            allocate (o3uptakesha_c(0:N_PFT-1,numpc)) !Ozone does, shaded leaf (mmol O3/m^2)
+            allocate (o3coefv_sun_c(0:N_PFT-1,numpc)) ; o3coefv_sun_c(:,:) = spval      !Ozone stress factor for photosynthesis on sunlit leaf
+            allocate (o3coefv_sha_c(0:N_PFT-1,numpc)) ; o3coefv_sha_c(:,:) = spval      !Ozone stress factor for photosynthesis on shaded leaf
+            allocate (o3coefg_sun_c(0:N_PFT-1,numpc)) ; o3coefg_sun_c(:,:) = spval      !Ozone stress factor for stomata on sunlit leaf
+            allocate (o3coefg_sha_c(0:N_PFT-1,numpc)) ; o3coefg_sha_c(:,:) = spval      !Ozone stress factor for stomata on shaded leaf
+            allocate (lai_old_c    (0:N_PFT-1,numpc)) ; lai_old_c    (:,:) = spval      !lai in last time step
+            allocate (o3uptakesun_c(0:N_PFT-1,numpc)) ; o3uptakesun_c(:,:) = spval      !Ozone does, sunlit leaf (mmol O3/m^2)
+            allocate (o3uptakesha_c(0:N_PFT-1,numpc)) ; o3uptakesha_c(:,:) = spval      !Ozone does, shaded leaf (mmol O3/m^2)
 !End Ozone Stress Variables
          ENDIF
       ENDIF
@@ -817,98 +817,98 @@ MODULE MOD_Vars_TimeVariables
 
         if (numpatch > 0) then
 
-           allocate (z_sno      (maxsnl+1:0,      numpatch))
-           allocate (dz_sno     (maxsnl+1:0,      numpatch))
-           allocate (t_soisno   (maxsnl+1:nl_soil,numpatch))
-           allocate (wliq_soisno(maxsnl+1:nl_soil,numpatch))
-           allocate (wice_soisno(maxsnl+1:nl_soil,numpatch))
-           allocate (smp               (1:nl_soil,numpatch))
-           allocate (hk                (1:nl_soil,numpatch))
-           allocate (h2osoi            (1:nl_soil,numpatch))
-           allocate (rootr             (1:nl_soil,numpatch))
+           allocate (z_sno      (maxsnl+1:0,      numpatch)); z_sno       (:,:) = spval
+           allocate (dz_sno     (maxsnl+1:0,      numpatch)); dz_sno      (:,:) = spval
+           allocate (t_soisno   (maxsnl+1:nl_soil,numpatch)); t_soisno    (:,:) = spval
+           allocate (wliq_soisno(maxsnl+1:nl_soil,numpatch)); wliq_soisno (:,:) = spval
+           allocate (wice_soisno(maxsnl+1:nl_soil,numpatch)); wice_soisno (:,:) = spval
+           allocate (smp               (1:nl_soil,numpatch)); smp         (:,:) = spval
+           allocate (hk                (1:nl_soil,numpatch)); hk          (:,:) = spval
+           allocate (h2osoi            (1:nl_soil,numpatch)); h2osoi      (:,:) = spval
+           allocate (rootr             (1:nl_soil,numpatch)); rootr       (:,:) = spval
 !Plant Hydraulic variables
-           allocate (vegwp             (1:nvegwcs,numpatch))
-           allocate (gs0sun                      (numpatch))
-           allocate (gs0sha                      (numpatch))
+           allocate (vegwp             (1:nvegwcs,numpatch)); vegwp       (:,:) = spval
+           allocate (gs0sun                      (numpatch)); gs0sun        (:) = spval
+           allocate (gs0sha                      (numpatch)); gs0sha        (:) = spval
 !end plant hydraulic variables
 !Ozone Stress variables
-           allocate (o3coefv_sun                 (numpatch)) ! Ozone stress factor for photosynthesis on sunlit leaf
-           allocate (o3coefv_sha                 (numpatch)) ! Ozone stress factor for photosynthesis on shaded leaf
-           allocate (o3coefg_sun                 (numpatch)) ! Ozone stress factor for stomata on sunlit leaf
-           allocate (o3coefg_sha                 (numpatch)) ! Ozone stress factor for stomata on shaded leaf
-           allocate (lai_old                     (numpatch)) ! lai in last time step
-           allocate (o3uptakesun                 (numpatch)) ! Ozone does, sunlit leaf (mmol O3/m^2)
-           allocate (o3uptakesha                 (numpatch)) ! Ozone does, shaded leaf (mmol O3/m^2)
+           allocate (o3coefv_sun                 (numpatch)); o3coefv_sun   (:) = spval
+           allocate (o3coefv_sha                 (numpatch)); o3coefv_sha   (:) = spval
+           allocate (o3coefg_sun                 (numpatch)); o3coefg_sun   (:) = spval
+           allocate (o3coefg_sha                 (numpatch)); o3coefg_sha   (:) = spval
+           allocate (lai_old                     (numpatch)); lai_old       (:) = spval
+           allocate (o3uptakesun                 (numpatch)); o3uptakesun   (:) = spval
+           allocate (o3uptakesha                 (numpatch)); o3uptakesha   (:) = spval
 !End ozone stress variables
-           allocate (rstfacsun_out               (numpatch))
-           allocate (rstfacsha_out               (numpatch))
-           allocate (gssun_out                   (numpatch))
-           allocate (gssha_out                   (numpatch))
-           allocate (assimsun_out                (numpatch))
-           allocate (assimsha_out                (numpatch))
-           allocate (etrsun_out                  (numpatch))
-           allocate (etrsha_out                  (numpatch))
+           allocate (rstfacsun_out               (numpatch)); rstfacsun_out (:) = spval
+           allocate (rstfacsha_out               (numpatch)); rstfacsha_out (:) = spval
+           allocate (gssun_out                   (numpatch)); gssun_out     (:) = spval
+           allocate (gssha_out                   (numpatch)); gssha_out     (:) = spval
+           allocate (assimsun_out                (numpatch)); assimsun_out  (:) = spval
+           allocate (assimsha_out                (numpatch)); assimsha_out  (:) = spval
+           allocate (etrsun_out                  (numpatch)); etrsun_out    (:) = spval
+           allocate (etrsha_out                  (numpatch)); etrsha_out    (:) = spval
 
-           allocate (t_grnd                      (numpatch))
-           allocate (tleaf                       (numpatch))
-           allocate (ldew                        (numpatch))
-           allocate (ldew_rain                   (numpatch))
-           allocate (ldew_snow                   (numpatch))
-           allocate (sag                         (numpatch))
-           allocate (scv                         (numpatch))
-           allocate (snowdp                      (numpatch))
-           allocate (fveg                        (numpatch))
-           allocate (fsno                        (numpatch))
-           allocate (sigf                        (numpatch))
-           allocate (green                       (numpatch))
-           allocate (tlai                        (numpatch))
-           allocate (lai                         (numpatch))
-           allocate (laisun                      (numpatch))
-           allocate (laisha                      (numpatch))
-           allocate (tsai                        (numpatch))
-           allocate (sai                         (numpatch))
-           allocate (coszen                      (numpatch))
-           allocate (alb                     (2,2,numpatch))
-           allocate (ssun                    (2,2,numpatch))
-           allocate (ssha                    (2,2,numpatch))
-           allocate (thermk                      (numpatch))
-           allocate (extkb                       (numpatch))
-           allocate (extkd                       (numpatch))
-           allocate (zwt                         (numpatch))
-           allocate (wa                          (numpatch))
-           allocate (wat                         (numpatch))
-           allocate (wdsrf                       (numpatch))
+           allocate (t_grnd                      (numpatch)); t_grnd        (:) = spval
+           allocate (tleaf                       (numpatch)); tleaf         (:) = spval
+           allocate (ldew                        (numpatch)); ldew          (:) = spval
+           allocate (ldew_rain                   (numpatch)); ldew_rain     (:) = spval
+           allocate (ldew_snow                   (numpatch)); ldew_snow     (:) = spval
+           allocate (sag                         (numpatch)); sag           (:) = spval
+           allocate (scv                         (numpatch)); scv           (:) = spval
+           allocate (snowdp                      (numpatch)); snowdp        (:) = spval
+           allocate (fveg                        (numpatch)); fveg          (:) = spval
+           allocate (fsno                        (numpatch)); fsno          (:) = spval
+           allocate (sigf                        (numpatch)); sigf          (:) = spval
+           allocate (green                       (numpatch)); green         (:) = spval
+           allocate (tlai                        (numpatch)); tlai          (:) = spval
+           allocate (lai                         (numpatch)); lai           (:) = spval
+           allocate (laisun                      (numpatch)); laisun        (:) = spval
+           allocate (laisha                      (numpatch)); laisha        (:) = spval
+           allocate (tsai                        (numpatch)); tsai          (:) = spval
+           allocate (sai                         (numpatch)); sai           (:) = spval
+           allocate (coszen                      (numpatch)); coszen        (:) = spval
+           allocate (alb                     (2,2,numpatch)); alb       (:,:,:) = spval
+           allocate (ssun                    (2,2,numpatch)); ssun      (:,:,:) = spval
+           allocate (ssha                    (2,2,numpatch)); ssha      (:,:,:) = spval
+           allocate (thermk                      (numpatch)); thermk        (:) = spval
+           allocate (extkb                       (numpatch)); extkb         (:) = spval
+           allocate (extkd                       (numpatch)); extkd         (:) = spval
+           allocate (zwt                         (numpatch)); zwt           (:) = spval
+           allocate (wa                          (numpatch)); wa            (:) = spval
+           allocate (wat                         (numpatch)); wat           (:) = spval
+           allocate (wdsrf                       (numpatch)); wdsrf         (:) = spval
 
-           allocate (t_lake              (nl_lake,numpatch))!new lake scheme
-           allocate (lake_icefrac        (nl_lake,numpatch))!new lake scheme
-           allocate (savedtke1                   (numpatch))!new lake scheme
+           allocate (t_lake              (nl_lake,numpatch)); t_lake      (:,:) = spval
+           allocate (lake_icefrac        (nl_lake,numpatch)); lake_icefrac(:,:) = spval
+           allocate (savedtke1                   (numpatch)); savedtke1     (:) = spval
 
-           allocate (snw_rds          (maxsnl+1:0,numpatch))
-           allocate (mss_bcpho        (maxsnl+1:0,numpatch))
-           allocate (mss_bcphi        (maxsnl+1:0,numpatch))
-           allocate (mss_ocpho        (maxsnl+1:0,numpatch))
-           allocate (mss_ocphi        (maxsnl+1:0,numpatch))
-           allocate (mss_dst1         (maxsnl+1:0,numpatch))
-           allocate (mss_dst2         (maxsnl+1:0,numpatch))
-           allocate (mss_dst3         (maxsnl+1:0,numpatch))
-           allocate (mss_dst4         (maxsnl+1:0,numpatch))
-           allocate (ssno         (2,2,maxsnl+1:1,numpatch))
+           allocate (snw_rds          (maxsnl+1:0,numpatch)); snw_rds     (:,:) = spval
+           allocate (mss_bcpho        (maxsnl+1:0,numpatch)); mss_bcpho   (:,:) = spval
+           allocate (mss_bcphi        (maxsnl+1:0,numpatch)); mss_bcphi   (:,:) = spval
+           allocate (mss_ocpho        (maxsnl+1:0,numpatch)); mss_ocpho   (:,:) = spval
+           allocate (mss_ocphi        (maxsnl+1:0,numpatch)); mss_ocphi   (:,:) = spval
+           allocate (mss_dst1         (maxsnl+1:0,numpatch)); mss_dst1    (:,:) = spval
+           allocate (mss_dst2         (maxsnl+1:0,numpatch)); mss_dst2    (:,:) = spval
+           allocate (mss_dst3         (maxsnl+1:0,numpatch)); mss_dst3    (:,:) = spval
+           allocate (mss_dst4         (maxsnl+1:0,numpatch)); mss_dst4    (:,:) = spval
+           allocate (ssno         (2,2,maxsnl+1:1,numpatch)); ssno    (:,:,:,:) = spval
 
-           allocate (trad                        (numpatch))
-           allocate (tref                        (numpatch))
-           allocate (qref                        (numpatch))
-           allocate (rst                         (numpatch))
-           allocate (emis                        (numpatch))
-           allocate (z0m                         (numpatch))
-           allocate (displa                      (numpatch))
-           allocate (zol                         (numpatch))
-           allocate (rib                         (numpatch))
-           allocate (ustar                       (numpatch))
-           allocate (qstar                       (numpatch))
-           allocate (tstar                       (numpatch))
-           allocate (fm                          (numpatch))
-           allocate (fh                          (numpatch))
-           allocate (fq                          (numpatch))
+           allocate (trad                        (numpatch)); trad          (:) = spval
+           allocate (tref                        (numpatch)); tref          (:) = spval
+           allocate (qref                        (numpatch)); qref          (:) = spval
+           allocate (rst                         (numpatch)); rst           (:) = spval
+           allocate (emis                        (numpatch)); emis          (:) = spval
+           allocate (z0m                         (numpatch)); z0m           (:) = spval
+           allocate (displa                      (numpatch)); displa        (:) = spval
+           allocate (zol                         (numpatch)); zol           (:) = spval
+           allocate (rib                         (numpatch)); rib           (:) = spval
+           allocate (ustar                       (numpatch)); ustar         (:) = spval
+           allocate (qstar                       (numpatch)); qstar         (:) = spval
+           allocate (tstar                       (numpatch)); tstar         (:) = spval
+           allocate (fm                          (numpatch)); fm            (:) = spval
+           allocate (fh                          (numpatch)); fh            (:) = spval
+           allocate (fq                          (numpatch)); fq            (:) = spval
 
         end if
   end if

--- a/mkinidata/MOD_IniTimeVariable.F90
+++ b/mkinidata/MOD_IniTimeVariable.F90
@@ -224,17 +224,17 @@ CONTAINS
         col_sminnbegnb        , &
         decomp_cpools_vr          (nl_soil_full,ndecomp_pools), &
         decomp_cpools             (ndecomp_pools)             , &
-        ctrunc_vr                 (nl_soil_full)              , &
+        ctrunc_vr                 (nl_soil)              , &
         ctrunc_veg            , &
         ctrunc_soil           , &
-        altmax                                                , &
+        altmax                , &
         altmax_lastyear       , &
         lag_npp
    INTEGER, intent(out) :: altmax_lastyear_indx
    REAL(r8),intent(out) ::      &
         decomp_npools_vr          (nl_soil_full,ndecomp_pools), &
         decomp_npools             (ndecomp_pools)             , &
-        ntrunc_vr                 (nl_soil_full)              , &
+        ntrunc_vr                 (nl_soil)              , &
         ntrunc_veg            , &
         ntrunc_soil           , &
         sminn_vr                  (nl_soil)                   , &

--- a/mkinidata/MOD_Initialize.F90
+++ b/mkinidata/MOD_Initialize.F90
@@ -620,8 +620,8 @@ MODULE MOD_Initialize
       if (p_is_worker) then
 
          !TODO: can be removed as CLMDRIVER.F90 yuan@
-         allocate ( z_soisno (maxsnl+1:nl_soil,numpatch) )
-         allocate ( dz_soisno(maxsnl+1:nl_soil,numpatch) )
+         allocate ( z_soisno (maxsnl+1:nl_soil,numpatch) ); z_soisno (:,:) = spval
+         allocate ( dz_soisno(maxsnl+1:nl_soil,numpatch) ); dz_soisno(:,:) = spval
 
          do i = 1, numpatch
             z_soisno (1:nl_soil ,i) = z_soi (1:nl_soil)


### PR DESCRIPTION
1. Initialize main/BGC/MOD_BGC_Vars_PFTimeVariables.F90 main/BGC/MOD_BGC_Vars_TimeInvariants.F90, main/BGC/MOD_BGC_Vars_TimeVariables.F90, main/MOD_Vars_TimeVariables.F90 with NAN. 
2. Fix a bug that deallocate ctrunc_vr and ntrunc_vr with size of nl_soil_full, which actually allocate the size of nl_soil