### PR TITLE
1) add option for urban only run and patchmask; 2) change macro URBAN_LCZ to namelist; 3) urban data filename/vars standardization. [by @tungwz]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,10 @@ mkdir_build :
 
 OBJS_SHARED =    \
 				  MOD_Precision.o              \
-				  MOD_Vars_Global.o            \
-				  MOD_Const_Physical.o         \
 				  MOD_SPMD_Task.o              \
 				  MOD_Namelist.o               \
+				  MOD_Vars_Global.o            \
+				  MOD_Const_Physical.o         \
 				  MOD_Const_LC.o               \
 				  MOD_Utils.o                  \
 				  MOD_TimeManager.o            \

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,8 @@ OBJS_SHARED =    \
 				  MOD_SrfdataDiag.o            \
 				  MOD_SrfdataRestart.o         \
 				  MOD_ElmVector.o              \
-				  MOD_HRUVector.o
+				  MOD_HRUVector.o              \
+				  MOD_Urban_Const_LCZ.o
 
 ${OBJS_SHARED} : %.o : %.F90 ${HEADER}
 	${FF} -c ${FOPTS} $(INCLUDE_DIR) -o .bld/$@ $< ${MOD_CMD}.bld
@@ -102,7 +103,6 @@ OBJS_BASIC =    \
 				 MOD_BGC_Vars_PFTimeVariables.o \
 				 MOD_BGC_Vars_TimeInvariants.o  \
 				 MOD_BGC_Vars_TimeVariables.o   \
-				 MOD_Urban_Const_LCZ.o          \
 				 MOD_Urban_Vars_1DFluxes.o      \
 				 MOD_Urban_Vars_TimeVariables.o \
 				 MOD_Urban_Vars_TimeInvariants.o\

--- a/main/CoLMDRIVER.F90
+++ b/main/CoLMDRIVER.F90
@@ -22,7 +22,7 @@ SUBROUTINE CoLMDRIVER (idate,deltim,dolai,doalb,dosst,oro)
  USE MOD_LandPatch, only: numpatch
  USE MOD_LandUrban, only: patch2urban
  USE MOD_Namelist, only: DEF_forcing, DEF_URBAN_RUN
- USE MOD_Forcing, only: forcmask, patchmask
+ USE MOD_Forcing, only: forcmask
  USE omp_lib
 #ifdef CaMa_Flood
  ! get flood variables: inundation depth[mm], inundation fraction [0-1],
@@ -51,16 +51,15 @@ SUBROUTINE CoLMDRIVER (idate,deltim,dolai,doalb,dosst,oro)
 #endif
   DO i = 1, numpatch
 
+     ! Apply forcing mask
      IF (DEF_forcing%has_missing_value) THEN
         IF (.not. forcmask(i)) CYCLE
      ENDIF
 
-     m = patchclass(i)
+     ! Apply patch mask
+     IF (.not. patchmask(i)) CYCLE
 
-     IF (m/=URBAN .and. DEF_URBAN_ONLY) THEN
-        patchmask(i) = .false.
-        CYCLE
-     ENDIF
+     m = patchclass(i)
 
      ! For non urban patch or slab urban
      IF (.not.DEF_URBAN_RUN .or. m.ne.URBAN) THEN

--- a/main/CoLMDRIVER.F90
+++ b/main/CoLMDRIVER.F90
@@ -22,7 +22,7 @@ SUBROUTINE CoLMDRIVER (idate,deltim,dolai,doalb,dosst,oro)
  USE MOD_LandPatch, only: numpatch
  USE MOD_LandUrban, only: patch2urban
  USE MOD_Namelist, only: DEF_forcing, DEF_URBAN_RUN
- USE MOD_Forcing, only: forcmask
+ USE MOD_Forcing, only: forcmask, patchmask
  USE omp_lib
 #ifdef CaMa_Flood
  ! get flood variables: inundation depth[mm], inundation fraction [0-1],
@@ -56,6 +56,11 @@ SUBROUTINE CoLMDRIVER (idate,deltim,dolai,doalb,dosst,oro)
      ENDIF
 
      m = patchclass(i)
+
+     IF (m/=URBAN .and. DEF_URBAN_ONLY) THEN
+        patchmask(i) = .false.
+        CYCLE
+     ENDIF
 
      ! For non urban patch or slab urban
      IF (.not.DEF_URBAN_RUN .or. m.ne.URBAN) THEN

--- a/main/MOD_Hist.F90
+++ b/main/MOD_Hist.F90
@@ -118,7 +118,8 @@ contains
 #if(defined CaMa_Flood)
       use MOD_CaMa_Vars !defination of CaMa variables
 #endif
-      USE MOD_Forcing, only : forcmask
+      USE MOD_Forcing, only : forcmask, patchmask
+
       IMPLICIT NONE
 
       integer,  INTENT(in) :: idate(3)
@@ -250,10 +251,16 @@ contains
          ! ---------------------------------------------------
          if (p_is_worker) then
             if (numpatch > 0) then
+IF (DEF_URBAN_ONLY) THEN
+               filter(:) = patchtype == 1
+ELSE
                filter(:) = patchtype < 99
+ENDIF
                IF (DEF_forcing%has_missing_value) THEN
                   filter = filter .and. forcmask
                ENDIF
+
+               filter = filter .and. patchmask
             end if
          end if
 
@@ -328,10 +335,16 @@ contains
          ! ------------------------------------------------------------------------------------------
          if (p_is_worker) then
             if (numpatch > 0) then
+IF (DEF_URBAN_ONLY) THEN
+               filter(:) = patchtype == 1
+ELSE
                filter(:) = patchtype < 99
+ENDIF
                IF (DEF_forcing%has_missing_value) THEN
                   filter = filter .and. forcmask
                ENDIF
+
+               filter = filter .and. patchmask
             end if
          end if
 
@@ -2943,10 +2956,16 @@ contains
 
          if (p_is_worker) then
             if (numpatch > 0) then
+IF (DEF_URBAN_ONLY) THEN
+               filter(:) = patchtype == 1
+ELSE
                filter(:) = patchtype <= 3
+ENDIF
                IF (DEF_forcing%has_missing_value) THEN
                   filter = filter .and. forcmask
                ENDIF
+
+               filter = filter .and. patchmask
             end if
          end if
 
@@ -2977,10 +2996,16 @@ contains
 
          if (p_is_worker) then
             if (numpatch > 0) then
+IF (DEF_URBAN_ONLY) THEN
+               filter(:) = patchtype == 1
+ELSE
                filter(:) = patchtype <= 2
+ENDIF
                IF (DEF_forcing%has_missing_value) THEN
                   filter = filter .and. forcmask
                ENDIF
+
+               filter = filter .and. patchmask
             end if
          end if
 
@@ -3021,10 +3046,16 @@ contains
          ! --------------------------------------------------------------------
          if (p_is_worker) then
             if (numpatch > 0) then
+IF (DEF_URBAN_ONLY) THEN
+               filter(:) = patchtype == 1
+ELSE
                filter(:) = (patchtype <= 2) .or. (patchtype == 4)
+ENDIF
                IF (DEF_forcing%has_missing_value) THEN
                   filter = filter .and. forcmask
                ENDIF
+
+               filter = filter .and. patchmask
             end if
          end if
 
@@ -3069,10 +3100,16 @@ contains
          ! --------------------------------
          if (p_is_worker) then
             if (numpatch > 0) then
+IF (DEF_URBAN_ONLY) THEN
+               filter(:) = patchtype == 1
+ELSE
                filter(:) = patchtype < 99
+ENDIF
                IF (DEF_forcing%has_missing_value) THEN
                   filter = filter .and. forcmask
                ENDIF
+
+               filter = filter .and. patchmask
             end if
          end if
 

--- a/main/MOD_Hist.F90
+++ b/main/MOD_Hist.F90
@@ -14,11 +14,11 @@ module MOD_Hist
    !
    ! TODO...(need complement)
    !----------------------------------------------------------------------------
-      
+
    use MOD_Vars_1DAccFluxes
    use MOD_Vars_Global, only : spval
    USE MOD_NetCDFSerial
-   
+
    use MOD_HistGridded
 #if (defined UNSTRUCTURED || defined CATCHMENT)
    use MOD_HistVector
@@ -34,7 +34,7 @@ module MOD_Hist
    public :: hist_out
    public :: hist_final
 
-   character(len=10) :: HistForm ! 'Gridded', 'Vector', 'Single' 
+   character(len=10) :: HistForm ! 'Gridded', 'Vector', 'Single'
 
 !--------------------------------------------------------------------------
 contains
@@ -107,18 +107,18 @@ contains
       use MOD_DataType
       use MOD_LandPatch
       use MOD_Mapping_Pset2Grid
-      USE MOD_Vars_TimeInvariants, only : patchtype, patchclass
+      USE MOD_Vars_TimeInvariants, only: patchtype, patchclass, patchmask
 #ifdef URBAN_MODEL
       USE MOD_LandUrban
 #endif
 #ifdef LULC_IGBP_PFT
       USE MOD_Vars_PFTimeInvariants, only: pftclass
-      USE MOD_LandPFT, only : patch_pft_s
+      USE MOD_LandPFT, only: patch_pft_s
 #endif
 #if(defined CaMa_Flood)
       use MOD_CaMa_Vars !defination of CaMa variables
 #endif
-      USE MOD_Forcing, only : forcmask, patchmask
+      USE MOD_Forcing, only: forcmask
 
       IMPLICIT NONE
 
@@ -212,9 +212,9 @@ contains
 #if(defined CaMa_Flood)
          ! add variables to write cama-flood output.
          ! file name of cama-flood output
-         file_hist_cama = trim(dir_hist) // '/' // trim(site) //'_hist_cama_'//trim(cdate)//'.nc' 
+         file_hist_cama = trim(dir_hist) // '/' // trim(site) //'_hist_cama_'//trim(cdate)//'.nc'
          ! write CaMa-Flood output
-         call hist_write_cama_time (file_hist_cama, 'time', idate, itime_in_file_cama)         
+         call hist_write_cama_time (file_hist_cama, 'time', idate, itime_in_file_cama)
 #endif
 
          file_hist = trim(dir_hist) // '/' // trim(site) //'_hist_'//trim(cdate)//'.nc'
@@ -247,15 +247,13 @@ contains
          ENDIF
 
          ! ---------------------------------------------------
-         ! Meteorological forcing
+         ! Meteorological forcing and patch mask filter applying.
          ! ---------------------------------------------------
          if (p_is_worker) then
             if (numpatch > 0) then
-IF (DEF_URBAN_ONLY) THEN
-               filter(:) = patchtype == 1
-ELSE
+
                filter(:) = patchtype < 99
-ENDIF
+
                IF (DEF_forcing%has_missing_value) THEN
                   filter = filter .and. forcmask
                ENDIF
@@ -335,11 +333,9 @@ ENDIF
          ! ------------------------------------------------------------------------------------------
          if (p_is_worker) then
             if (numpatch > 0) then
-IF (DEF_URBAN_ONLY) THEN
-               filter(:) = patchtype == 1
-ELSE
+
                filter(:) = patchtype < 99
-ENDIF
+
                IF (DEF_forcing%has_missing_value) THEN
                   filter = filter .and. forcmask
                ENDIF
@@ -2001,7 +1997,7 @@ ENDIF
                end do
             end if
          end if
-         
+
          IF (HistForm == 'Gridded') THEN
             call mp2g_hist%map (VecOnes, sumarea, spv = spval, msk = filter)
          ENDIF
@@ -2031,7 +2027,7 @@ ENDIF
                end do
             end if
          end if
-         
+
          IF (HistForm == 'Gridded') THEN
             call mp2g_hist%map (VecOnes, sumarea, spv = spval, msk = filter)
          ENDIF
@@ -2572,7 +2568,7 @@ ENDIF
                end do
             end if
          end if
-         
+
          IF (HistForm == 'Gridded') THEN
             call mp2g_hist%map (VecOnes, sumarea, spv = spval, msk = filter)
          ENDIF
@@ -2602,7 +2598,7 @@ ENDIF
                end do
             end if
          end if
-         
+
          IF (HistForm == 'Gridded') THEN
             call mp2g_hist%map (VecOnes, sumarea, spv = spval, msk = filter)
          ENDIF
@@ -2950,17 +2946,15 @@ ENDIF
 #endif
          ! --------------------------------------------------------------------
          ! Temperature and water (excluding land water bodies and ocean patches)
-         ! [soil => 0; urban and built-up => 1; wetland => 2; land ice => 3; 
+         ! [soil => 0; urban and built-up => 1; wetland => 2; land ice => 3;
          !  land water bodies => 4; ocean => 99]
          ! --------------------------------------------------------------------
 
          if (p_is_worker) then
             if (numpatch > 0) then
-IF (DEF_URBAN_ONLY) THEN
-               filter(:) = patchtype == 1
-ELSE
+
                filter(:) = patchtype <= 3
-ENDIF
+
                IF (DEF_forcing%has_missing_value) THEN
                   filter = filter .and. forcmask
                ENDIF
@@ -2990,17 +2984,15 @@ ENDIF
 
          ! --------------------------------------------------------------------
          ! additial diagnostic variables for output (vegetated land only <=2)
-         ! [soil => 0; urban and built-up => 1; wetland => 2; land ice => 3; 
+         ! [soil => 0; urban and built-up => 1; wetland => 2; land ice => 3;
          !  land water bodies => 4; ocean => 99]
          ! --------------------------------------------------------------------
 
          if (p_is_worker) then
             if (numpatch > 0) then
-IF (DEF_URBAN_ONLY) THEN
-               filter(:) = patchtype == 1
-ELSE
+
                filter(:) = patchtype <= 2
-ENDIF
+
                IF (DEF_forcing%has_missing_value) THEN
                   filter = filter .and. forcmask
                ENDIF
@@ -3046,11 +3038,9 @@ ENDIF
          ! --------------------------------------------------------------------
          if (p_is_worker) then
             if (numpatch > 0) then
-IF (DEF_URBAN_ONLY) THEN
-               filter(:) = patchtype == 1
-ELSE
+
                filter(:) = (patchtype <= 2) .or. (patchtype == 4)
-ENDIF
+
                IF (DEF_forcing%has_missing_value) THEN
                   filter = filter .and. forcmask
                ENDIF
@@ -3100,11 +3090,9 @@ ENDIF
          ! --------------------------------
          if (p_is_worker) then
             if (numpatch > 0) then
-IF (DEF_URBAN_ONLY) THEN
-               filter(:) = patchtype == 1
-ELSE
+
                filter(:) = patchtype < 99
-ENDIF
+
                IF (DEF_forcing%has_missing_value) THEN
                   filter = filter .and. forcmask
                ENDIF
@@ -3343,7 +3331,7 @@ ENDIF
          CALL single_write_2d ( &
             acc_vec, file_hist, varname, itime_in_file, longname, units)
 #endif
-      end select 
+      end select
 
    end subroutine write_history_variable_2d
 
@@ -3383,7 +3371,7 @@ ENDIF
          CALL single_write_urb_2d ( &
             acc_vec, file_hist, varname, itime_in_file, longname, units)
 #endif
-      end select 
+      end select
 
    end subroutine write_history_variable_urb_2d
 #endif
@@ -3431,7 +3419,7 @@ ENDIF
          CALL single_write_3d (acc_vec, file_hist, varname, itime_in_file, &
             dim1name, ndim1, longname, units)
 #endif
-      end select 
+      end select
 
    end subroutine write_history_variable_3d
 
@@ -3475,7 +3463,7 @@ ENDIF
          CALL single_write_4d (acc_vec, file_hist, varname, itime_in_file, &
             dim1name, ndim1, dim2name, ndim2, longname, units)
 #endif
-      end select 
+      end select
 
    end subroutine write_history_variable_4d
 
@@ -3513,7 +3501,7 @@ ENDIF
       case ('Single')
          CALL single_write_ln (acc_vec, file_hist, varname, itime_in_file, longname, units)
 #endif
-      end select 
+      end select
 
    end subroutine write_history_variable_ln
 
@@ -3538,7 +3526,7 @@ ENDIF
       case ('Single')
          CALL hist_single_write_time  (filename, dataname, time, itime)
 #endif
-      end select 
+      end select
 
    end subroutine hist_write_time
 

--- a/main/MOD_Vars_1DAccFluxes.F90
+++ b/main/MOD_Vars_1DAccFluxes.F90
@@ -1273,7 +1273,7 @@ contains
 
       use MOD_Precision
       use MOD_SPMD_Task
-      USE mod_forcing, only : forcmask
+      USE mod_forcing, only : forcmask, patchmask
       USE MOD_Mesh,    only : numelm
       USE MOD_LandElm
       use MOD_LandPatch,      only : numpatch, elm_patch
@@ -1311,7 +1311,7 @@ contains
       real(r8), allocatable :: r_vs10m (:)
       real(r8), allocatable :: r_fm10m (:)
 
-      logical,  allocatable :: patchmask (:)
+      logical,  allocatable :: elmmask (:)
 
       !---------------------------------------------------------------------
       integer  ib, jb, i, j, ielm, istt, iend
@@ -1367,7 +1367,9 @@ contains
                   rnet = sabg + sabvsun + sabvsha - olrg + forc_frl
                END WHERE
             ELSE
-               rnet = sabg + sabvsun + sabvsha - olrg + forc_frl
+               WHERE(patchmask)
+                 rnet = sabg + sabvsun + sabvsha - olrg + forc_frl
+               END WHERE
             ENDIF
             call acc1d (rnet    , a_rnet   )
 
@@ -1424,6 +1426,8 @@ contains
                IF (DEF_forcing%has_missing_value) THEN
                   IF (.not. forcmask(i)) cycle
                ENDIF
+
+               IF (.not. patchmask(i)) CYCLE
                r_trad(i) = (olrg(i)/stefnc)**0.25
             end do
             call acc1d (r_trad , a_trad   )
@@ -1710,36 +1714,38 @@ contains
                istt = elm_patch%substt(ielm)
                iend = elm_patch%subend(ielm)
 
-               allocate (patchmask (istt:iend))
-               patchmask(:) = .true.
+               allocate (elmmask (istt:iend))
+               elmmask(:) = .true.
+
+               elmmask(:) = patchmask(istt:iend)
 
                IF (DEF_forcing%has_missing_value) THEN
-                  patchmask = forcmask(istt:iend)
+                  elmmask = forcmask(istt:iend)
                ENDIF
 
-               IF (.not. any(patchmask)) THEN
-                  deallocate(patchmask)
+               IF (.not. any(elmmask)) THEN
+                  deallocate(elmmask)
                   CYCLE
                ENDIF
 
-               sumwt = sum(elm_patch%subfrc(istt:iend), mask = patchmask)
+               sumwt = sum(elm_patch%subfrc(istt:iend), mask = elmmask)
 
                ! Aggregate variables from patches to element (gridcell in latitude-longitude mesh)
-               z0m_av  = sum(z0m        (istt:iend) * elm_patch%subfrc(istt:iend), mask = patchmask) / sumwt
-               hgt_u   = sum(forc_hgt_u (istt:iend) * elm_patch%subfrc(istt:iend), mask = patchmask) / sumwt
-               hgt_t   = sum(forc_hgt_t (istt:iend) * elm_patch%subfrc(istt:iend), mask = patchmask) / sumwt
-               hgt_q   = sum(forc_hgt_q (istt:iend) * elm_patch%subfrc(istt:iend), mask = patchmask) / sumwt
-               us      = sum(forc_us    (istt:iend) * elm_patch%subfrc(istt:iend), mask = patchmask) / sumwt
-               vs      = sum(forc_vs    (istt:iend) * elm_patch%subfrc(istt:iend), mask = patchmask) / sumwt
-               tm      = sum(forc_t     (istt:iend) * elm_patch%subfrc(istt:iend), mask = patchmask) / sumwt
-               qm      = sum(forc_q     (istt:iend) * elm_patch%subfrc(istt:iend), mask = patchmask) / sumwt
-               psrf    = sum(forc_psrf  (istt:iend) * elm_patch%subfrc(istt:iend), mask = patchmask) / sumwt
-               taux_e  = sum(taux       (istt:iend) * elm_patch%subfrc(istt:iend), mask = patchmask) / sumwt
-               tauy_e  = sum(tauy       (istt:iend) * elm_patch%subfrc(istt:iend), mask = patchmask) / sumwt
-               fsena_e = sum(fsena      (istt:iend) * elm_patch%subfrc(istt:iend), mask = patchmask) / sumwt
-               fevpa_e = sum(fevpa      (istt:iend) * elm_patch%subfrc(istt:iend), mask = patchmask) / sumwt
+               z0m_av  = sum(z0m        (istt:iend) * elm_patch%subfrc(istt:iend), mask = elmmask) / sumwt
+               hgt_u   = sum(forc_hgt_u (istt:iend) * elm_patch%subfrc(istt:iend), mask = elmmask) / sumwt
+               hgt_t   = sum(forc_hgt_t (istt:iend) * elm_patch%subfrc(istt:iend), mask = elmmask) / sumwt
+               hgt_q   = sum(forc_hgt_q (istt:iend) * elm_patch%subfrc(istt:iend), mask = elmmask) / sumwt
+               us      = sum(forc_us    (istt:iend) * elm_patch%subfrc(istt:iend), mask = elmmask) / sumwt
+               vs      = sum(forc_vs    (istt:iend) * elm_patch%subfrc(istt:iend), mask = elmmask) / sumwt
+               tm      = sum(forc_t     (istt:iend) * elm_patch%subfrc(istt:iend), mask = elmmask) / sumwt
+               qm      = sum(forc_q     (istt:iend) * elm_patch%subfrc(istt:iend), mask = elmmask) / sumwt
+               psrf    = sum(forc_psrf  (istt:iend) * elm_patch%subfrc(istt:iend), mask = elmmask) / sumwt
+               taux_e  = sum(taux       (istt:iend) * elm_patch%subfrc(istt:iend), mask = elmmask) / sumwt
+               tauy_e  = sum(tauy       (istt:iend) * elm_patch%subfrc(istt:iend), mask = elmmask) / sumwt
+               fsena_e = sum(fsena      (istt:iend) * elm_patch%subfrc(istt:iend), mask = elmmask) / sumwt
+               fevpa_e = sum(fevpa      (istt:iend) * elm_patch%subfrc(istt:iend), mask = elmmask) / sumwt
                if (DEF_USE_CBL_HEIGHT) then !//TODO: Shaofeng, 2023.05.18
-                  hpbl = sum(forc_hpbl(istt:iend) * elm_patch%subfrc(istt:iend), mask = patchmask) / sumwt
+                  hpbl = sum(forc_hpbl(istt:iend) * elm_patch%subfrc(istt:iend), mask = elmmask) / sumwt
                ENDIF
 
                z0h_av = z0m_av
@@ -1819,7 +1825,7 @@ contains
                r_vs10m (istt:iend) = r_vs10m_e
                r_fm10m (istt:iend) = r_fm10m_e
 
-               deallocate(patchmask)
+               deallocate(elmmask)
 
             end do
 

--- a/main/MOD_Vars_1DAccFluxes.F90
+++ b/main/MOD_Vars_1DAccFluxes.F90
@@ -312,7 +312,7 @@ contains
       use MOD_SPMD_Task
       USE MOD_LandElm
       use MOD_LandPatch
-      USE MOD_LandUrban, only : numurban
+      USE MOD_LandUrban, only: numurban
       USE MOD_Vars_Global
       implicit none
 
@@ -1273,12 +1273,12 @@ contains
 
       use MOD_Precision
       use MOD_SPMD_Task
-      USE mod_forcing, only : forcmask, patchmask
-      USE MOD_Mesh,    only : numelm
+      USE mod_forcing, only: forcmask
+      USE MOD_Mesh,    only: numelm
       USE MOD_LandElm
-      use MOD_LandPatch,      only : numpatch, elm_patch
-      USE MOD_LandUrban,      only : numurban
-      use MOD_Const_Physical, only : vonkar, stefnc, cpair, rgas, grav
+      use MOD_LandPatch,      only: numpatch, elm_patch
+      USE MOD_LandUrban,      only: numurban
+      use MOD_Const_Physical, only: vonkar, stefnc, cpair, rgas, grav
       use MOD_Vars_TimeInvariants
       use MOD_Vars_TimeVariables
       use MOD_Vars_1DForcing
@@ -1288,7 +1288,7 @@ contains
       USE MOD_TurbulenceLEddy
       use MOD_Vars_Global
 #ifdef LATERAL_FLOW
-      USE MOD_Hydro_Hist, only : accumulate_fluxes_basin
+      USE MOD_Hydro_Hist, only: accumulate_fluxes_basin
 #endif
 
       IMPLICIT NONE
@@ -1311,7 +1311,7 @@ contains
       real(r8), allocatable :: r_vs10m (:)
       real(r8), allocatable :: r_fm10m (:)
 
-      logical,  allocatable :: elmmask (:)
+      logical,  allocatable :: filter  (:)
 
       !---------------------------------------------------------------------
       integer  ib, jb, i, j, ielm, istt, iend
@@ -1714,38 +1714,39 @@ contains
                istt = elm_patch%substt(ielm)
                iend = elm_patch%subend(ielm)
 
-               allocate (elmmask (istt:iend))
-               elmmask(:) = .true.
+               allocate (filter (istt:iend))
+               filter(:) = .true.
 
-               elmmask(:) = patchmask(istt:iend)
+               filter(:) = patchmask(istt:iend)
 
                IF (DEF_forcing%has_missing_value) THEN
-                  elmmask = forcmask(istt:iend)
+                  WHERE (.not. forcmask(istt:iend)) filter = .false.
+                  filter = filter .and. forcmask(istt:iend)
                ENDIF
 
-               IF (.not. any(elmmask)) THEN
-                  deallocate(elmmask)
+               IF (.not. any(filter)) THEN
+                  deallocate(filter)
                   CYCLE
                ENDIF
 
-               sumwt = sum(elm_patch%subfrc(istt:iend), mask = elmmask)
+               sumwt = sum(elm_patch%subfrc(istt:iend), mask = filter)
 
                ! Aggregate variables from patches to element (gridcell in latitude-longitude mesh)
-               z0m_av  = sum(z0m        (istt:iend) * elm_patch%subfrc(istt:iend), mask = elmmask) / sumwt
-               hgt_u   = sum(forc_hgt_u (istt:iend) * elm_patch%subfrc(istt:iend), mask = elmmask) / sumwt
-               hgt_t   = sum(forc_hgt_t (istt:iend) * elm_patch%subfrc(istt:iend), mask = elmmask) / sumwt
-               hgt_q   = sum(forc_hgt_q (istt:iend) * elm_patch%subfrc(istt:iend), mask = elmmask) / sumwt
-               us      = sum(forc_us    (istt:iend) * elm_patch%subfrc(istt:iend), mask = elmmask) / sumwt
-               vs      = sum(forc_vs    (istt:iend) * elm_patch%subfrc(istt:iend), mask = elmmask) / sumwt
-               tm      = sum(forc_t     (istt:iend) * elm_patch%subfrc(istt:iend), mask = elmmask) / sumwt
-               qm      = sum(forc_q     (istt:iend) * elm_patch%subfrc(istt:iend), mask = elmmask) / sumwt
-               psrf    = sum(forc_psrf  (istt:iend) * elm_patch%subfrc(istt:iend), mask = elmmask) / sumwt
-               taux_e  = sum(taux       (istt:iend) * elm_patch%subfrc(istt:iend), mask = elmmask) / sumwt
-               tauy_e  = sum(tauy       (istt:iend) * elm_patch%subfrc(istt:iend), mask = elmmask) / sumwt
-               fsena_e = sum(fsena      (istt:iend) * elm_patch%subfrc(istt:iend), mask = elmmask) / sumwt
-               fevpa_e = sum(fevpa      (istt:iend) * elm_patch%subfrc(istt:iend), mask = elmmask) / sumwt
+               z0m_av  = sum(z0m        (istt:iend) * elm_patch%subfrc(istt:iend), mask = filter) / sumwt
+               hgt_u   = sum(forc_hgt_u (istt:iend) * elm_patch%subfrc(istt:iend), mask = filter) / sumwt
+               hgt_t   = sum(forc_hgt_t (istt:iend) * elm_patch%subfrc(istt:iend), mask = filter) / sumwt
+               hgt_q   = sum(forc_hgt_q (istt:iend) * elm_patch%subfrc(istt:iend), mask = filter) / sumwt
+               us      = sum(forc_us    (istt:iend) * elm_patch%subfrc(istt:iend), mask = filter) / sumwt
+               vs      = sum(forc_vs    (istt:iend) * elm_patch%subfrc(istt:iend), mask = filter) / sumwt
+               tm      = sum(forc_t     (istt:iend) * elm_patch%subfrc(istt:iend), mask = filter) / sumwt
+               qm      = sum(forc_q     (istt:iend) * elm_patch%subfrc(istt:iend), mask = filter) / sumwt
+               psrf    = sum(forc_psrf  (istt:iend) * elm_patch%subfrc(istt:iend), mask = filter) / sumwt
+               taux_e  = sum(taux       (istt:iend) * elm_patch%subfrc(istt:iend), mask = filter) / sumwt
+               tauy_e  = sum(tauy       (istt:iend) * elm_patch%subfrc(istt:iend), mask = filter) / sumwt
+               fsena_e = sum(fsena      (istt:iend) * elm_patch%subfrc(istt:iend), mask = filter) / sumwt
+               fevpa_e = sum(fevpa      (istt:iend) * elm_patch%subfrc(istt:iend), mask = filter) / sumwt
                if (DEF_USE_CBL_HEIGHT) then !//TODO: Shaofeng, 2023.05.18
-                  hpbl = sum(forc_hpbl(istt:iend) * elm_patch%subfrc(istt:iend), mask = elmmask) / sumwt
+                  hpbl = sum(forc_hpbl(istt:iend) * elm_patch%subfrc(istt:iend), mask = filter) / sumwt
                ENDIF
 
                z0h_av = z0m_av
@@ -1825,7 +1826,7 @@ contains
                r_vs10m (istt:iend) = r_vs10m_e
                r_fm10m (istt:iend) = r_fm10m_e
 
-               deallocate(elmmask)
+               deallocate(filter)
 
             end do
 

--- a/main/MOD_Vars_Global.F90
+++ b/main/MOD_Vars_Global.F90
@@ -43,7 +43,7 @@ MODULE MOD_Vars_Global
 #endif
 
    ! urban type number
-   INTEGER :: N_URB
+   integer :: N_URB
 
    ! vertical layer number
    integer, parameter :: maxsnl    = -5

--- a/main/MOD_Vars_Global.F90
+++ b/main/MOD_Vars_Global.F90
@@ -12,6 +12,7 @@ MODULE MOD_Vars_Global
 !
 ! !USES:
    USE MOD_Precision
+   USE MOD_Namelist
    IMPLICIT NONE
    SAVE
 
@@ -41,11 +42,8 @@ MODULE MOD_Vars_Global
    integer, parameter :: N_CFT     = 64
 #endif
 
-#ifdef URBAN_LCZ
-   integer, parameter :: N_URB     = 10
-#else
-   integer, parameter :: N_URB     = 3
-#endif
+   ! urban type number
+   INTEGER :: N_URB
 
    ! vertical layer number
    integer, parameter :: maxsnl    = -5
@@ -114,6 +112,12 @@ CONTAINS
       IMPLICIT NONE
 
       integer :: nsl
+
+IF (DEF_URBAN_type_scheme == 1) THEN
+      N_URB = 3
+ELSE IF(DEF_URBAN_type_scheme == 2) THEN
+      N_URB = 10
+ENDIF
 
       DO nsl = 1, nl_soil
          z_soi(nsl) = 0.025*(exp(0.5*(nsl-0.5))-1.)  !node depths

--- a/main/MOD_Vars_TimeInvariants.F90
+++ b/main/MOD_Vars_TimeInvariants.F90
@@ -483,13 +483,12 @@ MODULE MOD_Vars_TimeInvariants
      ! Local variables
      character(LEN=256) :: file_restart, cyear
 
-     patchtype(:) = .true.
-
      write(cyear,'(i4.4)') lc_year
      file_restart = trim(dir_restart) // '/' // trim(casename) //'_restart_const' // '_lc' // trim(cyear) // '.nc'
 
      call ncio_read_vector (file_restart, 'patchclass',   landpatch, patchclass)          !
      call ncio_read_vector (file_restart, 'patchtype' ,   landpatch, patchtype )          !
+     call ncio_read_vector (file_restart, 'patchmask' ,   landpatch, patchmask )          !
 
      call ncio_read_vector (file_restart, 'patchlonr' ,   landpatch, patchlonr )          !
      call ncio_read_vector (file_restart, 'patchlatr' ,   landpatch, patchlatr )          !
@@ -534,8 +533,8 @@ MODULE MOD_Vars_TimeInvariants
      call ncio_read_vector (file_restart, 'hbot' ,    landpatch, hbot)                    !
 
      IF(DEF_USE_BEDROCK)THEN
-        call ncio_read_vector (file_restart, 'debdrock' ,    landpatch, dbedrock)            !
-        call ncio_read_vector (file_restart, 'ibedrock' ,    landpatch, ibedrock)            !
+        call ncio_read_vector (file_restart, 'debdrock' ,    landpatch, dbedrock)         !
+        call ncio_read_vector (file_restart, 'ibedrock' ,    landpatch, ibedrock)         !
      ENDIF
 
      call ncio_read_bcast_serial (file_restart, 'zlnd  ', zlnd  ) ! roughness length for soil [m]
@@ -631,6 +630,7 @@ MODULE MOD_Vars_TimeInvariants
 
      call ncio_write_vector (file_restart, 'patchclass', 'patch', landpatch, patchclass)                            !
      call ncio_write_vector (file_restart, 'patchtype' , 'patch', landpatch, patchtype )                            !
+     call ncio_write_vector (file_restart, 'patchmask' , 'patch', landpatch, patchmask )                            !
 
      call ncio_write_vector (file_restart, 'patchlonr' , 'patch', landpatch, patchlonr )                            !
      call ncio_write_vector (file_restart, 'patchlatr' , 'patch', landpatch, patchlatr )                            !
@@ -677,8 +677,8 @@ MODULE MOD_Vars_TimeInvariants
      call ncio_write_vector (file_restart, 'hbot' , 'patch', landpatch, hbot)                                       !
 
      IF(DEF_USE_BEDROCK)THEN
-        call ncio_write_vector (file_restart, 'debdrock' , 'patch', landpatch, dbedrock)                               !
-        call ncio_write_vector (file_restart, 'ibedrock' , 'patch', landpatch, ibedrock)                               !
+        call ncio_write_vector (file_restart, 'debdrock' , 'patch', landpatch, dbedrock)                            !
+        call ncio_write_vector (file_restart, 'ibedrock' , 'patch', landpatch, ibedrock)                            !
      ENDIF
 
      if (p_is_master) then

--- a/main/MOD_Vars_TimeInvariants.F90
+++ b/main/MOD_Vars_TimeInvariants.F90
@@ -29,7 +29,7 @@ MODULE MOD_Vars_PFTimeInvariants
   PUBLIC :: READ_PFTimeInvariants
   PUBLIC :: WRITE_PFTimeInvariants
   PUBLIC :: deallocate_PFTimeInvariants
-#ifdef RangeCheck 
+#ifdef RangeCheck
   PUBLIC :: check_PFTimeInvariants
 #endif
 
@@ -119,7 +119,7 @@ MODULE MOD_Vars_PFTimeInvariants
 
   END SUBROUTINE deallocate_PFTimeInvariants
 
-#ifdef RangeCheck 
+#ifdef RangeCheck
   SUBROUTINE check_PFTimeInvariants ()
 
      use MOD_RangeCheck
@@ -161,7 +161,7 @@ MODULE MOD_Vars_PCTimeInvariants
   PUBLIC :: READ_PCTimeInvariants
   PUBLIC :: WRITE_PCTimeInvariants
   PUBLIC :: deallocate_PCTimeInvariants
-#ifdef RangeCheck 
+#ifdef RangeCheck
   PUBLIC :: check_PCTimeInvariants
 #endif
 
@@ -252,7 +252,7 @@ MODULE MOD_Vars_PCTimeInvariants
 
   END SUBROUTINE deallocate_PCTimeInvariants
 
-#ifdef RangeCheck 
+#ifdef RangeCheck
   SUBROUTINE check_PCTimeInvariants ()
 
      use MOD_RangeCheck
@@ -295,6 +295,7 @@ MODULE MOD_Vars_TimeInvariants
 ! surface classification and soil information
   INTEGER,  allocatable :: patchclass     (:)  !index of land cover type of the patches at the fraction > 0
   INTEGER,  allocatable :: patchtype      (:)  !land water type
+  LOGICAL,  allocatable :: patchmask      (:)  !patch mask
 
   REAL(r8), allocatable :: patchlatr      (:)  !latitude in radians
   REAL(r8), allocatable :: patchlonr      (:)  !longitude in radians
@@ -389,6 +390,7 @@ MODULE MOD_Vars_TimeInvariants
 
            allocate (patchclass           (numpatch))
            allocate (patchtype            (numpatch))
+           allocate (patchmask            (numpatch))
 
            allocate (patchlonr            (numpatch))
            allocate (patchlatr            (numpatch))
@@ -466,7 +468,7 @@ MODULE MOD_Vars_TimeInvariants
      use MOD_SPMD_Task
      use MOD_NetCDFVector
      use MOD_NetCDFSerial
-#ifdef RangeCheck 
+#ifdef RangeCheck
      USE MOD_RangeCheck
 #endif
      USE MOD_LandPatch
@@ -481,6 +483,7 @@ MODULE MOD_Vars_TimeInvariants
      ! Local variables
      character(LEN=256) :: file_restart, cyear
 
+     patchtype(:) = .true.
 
      write(cyear,'(i4.4)') lc_year
      file_restart = trim(dir_restart) // '/' // trim(casename) //'_restart_const' // '_lc' // trim(cyear) // '.nc'
@@ -570,7 +573,7 @@ MODULE MOD_Vars_TimeInvariants
      CALL READ_UrbanTimeInvariants (file_restart)
 #endif
 
-#ifdef RangeCheck 
+#ifdef RangeCheck
      call check_TimeInvariants ()
 #endif
 
@@ -738,6 +741,7 @@ MODULE MOD_Vars_TimeInvariants
 
            deallocate (patchclass     )
            deallocate (patchtype      )
+           deallocate (patchmask      )
 
            deallocate (patchlonr      )
            deallocate (patchlatr      )

--- a/main/URBAN/MOD_Urban_Const_LCZ.F90
+++ b/main/URBAN/MOD_Urban_Const_LCZ.F90
@@ -1,5 +1,4 @@
 #include <define.h>
-#ifdef URBAN_LCZ
 MODULE MOD_Urban_Const_LCZ
 
   ! -----------------------------------------------------------------------
@@ -63,7 +62,7 @@ MODULE MOD_Urban_Const_LCZ
       = (/0.25, 0.2 , 0.2 , 0.25, 0.25, 0.25, 0.2 , 0.25, 0.25, 0.2 /)
 
    ! albeodo of impervious road [-]
-   REAL(r8), parameter, dimension(10)  :: albroad_lcz &
+   REAL(r8), parameter, dimension(10)  :: albimproad_lcz &
       = (/0.15, 0.15, 0.18, 0.20, 0.20, 0.21, 0.24, 0.17, 0.23, 0.21/)
 
    ! albeodo of pervious road [-]
@@ -115,4 +114,3 @@ MODULE MOD_Urban_Const_LCZ
    !TODO:AHE coding
 
 END MODULE MOD_Urban_Const_LCZ
-#endif

--- a/mkinidata/MOD_Initialize.F90
+++ b/mkinidata/MOD_Initialize.F90
@@ -178,9 +178,21 @@ MODULE MOD_Initialize
       if (p_is_worker) then
 
          patchclass = landpatch%settyp
+         patchmask  = .true.
 
          DO ipatch = 1, numpatch
-            patchtype(ipatch) = patchtypes(patchclass(ipatch))
+
+            m = patchclass(ipatch)
+            patchtype(ipatch) = patchtypes(m)
+
+            !     ***** patch mask setting *****
+            ! ---------------------------------------
+
+            IF (DEF_URBAN_ONLY .and. m.ne.URBAN) THEN
+               patchmask(ipatch) = .false.
+               CYCLE
+            ENDIF
+
          ENDDO
 
          call landpatch%get_lonlat_radian (patchlonr, patchlatr)

--- a/mkinidata/MOD_UrbanReadin.F90
+++ b/mkinidata/MOD_UrbanReadin.F90
@@ -37,9 +37,7 @@ MODULE MOD_UrbanReadin
       USE MOD_NetCDFSerial
       USE MOD_LandPatch
       USE MOD_LandUrban
-#ifdef URBAN_LCZ
-      USE UrbanLCZ_Const
-#endif
+      USE MOD_Urban_Const_LCZ
 
       IMPLICIT NONE
 
@@ -74,15 +72,15 @@ MODULE MOD_UrbanReadin
       REAL(r8), allocatable :: thickroof     (:)  ! thickness of roof [m]
       REAL(r8), allocatable :: thickwall     (:)  ! thickness of wall [m]
 
+      write(cyear,'(i4.4)') lc_year
+
       allocate (lucyid    (numurban))
 
-#ifndef URBAN_LCZ
-
+IF (DEF_URBAN_type_scheme == 1) THEN
       allocate (thickroof (numurban))
       allocate (thickwall (numurban))
 
       ! READ in urban data
-      write(cyear,'(i4.4)') lc_year
       lndname = trim(dir_landdata)//'/urban/'//trim(cyear)//'/urban.nc'
       print*,trim(lndname)
       CALL ncio_read_vector (lndname, 'CANYON_HWR  '  , landurban, hwr    ) ! average building height to their distance
@@ -108,7 +106,7 @@ MODULE MOD_UrbanReadin
       CALL ncio_read_vector (lndname, 'TK_ROOF'       , nl_roof, landurban, tk_roof) ! thermal conductivity of roof [W/m-K]
       CALL ncio_read_vector (lndname, 'TK_WALL'       , nl_wall, landurban, tk_wall) ! thermal conductivity of wall [W/m-K]
       CALL ncio_read_vector (lndname, 'TK_IMPROAD'    , nl_soil, landurban, tk_gimp) ! thermal conductivity of impervious road [W/m-K]
-#endif
+ENDIF
 
 !TODO: add point case
 #ifdef SinglePoint
@@ -158,12 +156,12 @@ MODULE MOD_UrbanReadin
       dir_rawdata = DEF_dir_rawdata
       lndname = trim(dir_rawdata)//'/urban/'//'/LUCY_rawdata.nc'
       print*, lndname
-      CALL ncio_read_bcast_serial (lndname,  "vehicle"    , lvehicle     )
-      CALL ncio_read_bcast_serial (lndname,  "weekendday" , lweek_holiday)
-      CALL ncio_read_bcast_serial (lndname,  "weekendhour", lweh_prof    )
-      CALL ncio_read_bcast_serial (lndname,  "weekdayhour", lwdh_prof    )
-      CALL ncio_read_bcast_serial (lndname,  "metabolism" , lhum_prof    )
-      CALL ncio_read_bcast_serial (lndname,  "holiday"    , lfix_holiday )
+      CALL ncio_read_bcast_serial (lndname,  "NUMS_VEHC"             , lvehicle     )
+      CALL ncio_read_bcast_serial (lndname,  "WEEKEND_DAY"           , lweek_holiday)
+      CALL ncio_read_bcast_serial (lndname,  "TraffProf_24hr_holiday", lweh_prof    )
+      CALL ncio_read_bcast_serial (lndname,  "TraffProf_24hr_work"   , lwdh_prof    )
+      CALL ncio_read_bcast_serial (lndname,  "HumMetabolic_24hr"     , lhum_prof    )
+      CALL ncio_read_bcast_serial (lndname,  "FIXED_HOLIDAY"         , lfix_holiday )
 
       IF (p_is_worker) THEN
 
@@ -191,7 +189,7 @@ MODULE MOD_UrbanReadin
                fix_holiday  (:,u) = 0.
             ENDIF
 
-#ifndef URBAN_LCZ
+IF (DEF_URBAN_type_scheme == 1) THEN
             thick_roof = thickroof (u) !thickness of roof [m]
             thick_wall = thickwall (u) !thickness of wall [m]
 
@@ -203,18 +201,18 @@ MODULE MOD_UrbanReadin
                t_roommax(u) = 373.16
                t_roommin(u) = 180.00
             ENDIF
-#else
+ELSE IF (DEF_URBAN_type_scheme == 2) THEN
             ! read in LCZ constants
             hwr  (u) = canyonhwr_lcz (landurban%settyp(u)) !average building height to their distance
             fgper(u) = wtperroad_lcz (landurban%settyp(u)) !pervious fraction to ground area
 
             DO ns = 1,2
-                DO nr = 1,2
-                   alb_roof(ns,nr,u) = albroof_lcz    (landurban%settyp(u)) !albedo of roof
-                   alb_wall(ns,nr,u) = albwall_lcz    (landurban%settyp(u)) !albedo of walls
-                   alb_gimp(ns,nr,u) = albimproad_lcz (landurban%settyp(u)) !albedo of impervious
-                   alb_gper(ns,nr,u) = albperroad_lcz (landurban%settyp(u)) !albedo of pervious road
-                ENDDO
+               DO nr = 1,2
+                  alb_roof(ns,nr,u) = albroof_lcz    (landurban%settyp(u)) !albedo of roof
+                  alb_wall(ns,nr,u) = albwall_lcz    (landurban%settyp(u)) !albedo of walls
+                  alb_gimp(ns,nr,u) = albimproad_lcz (landurban%settyp(u)) !albedo of impervious
+                  alb_gper(ns,nr,u) = albperroad_lcz (landurban%settyp(u)) !albedo of pervious road
+               ENDDO
             ENDDO
 
             em_roof(u) = emroof_lcz    (landurban%settyp(u)) !emissivity of roof
@@ -234,7 +232,7 @@ MODULE MOD_UrbanReadin
 
             DO ulev = 1, nl_soil
                cv_gimp(:,u) = cvimproad_lcz (landurban%settyp(u)) !heat capacity of impervious [J/(m2 K)]
-               tk_gimp(:,u) = tkperroad_lcz (landurban%settyp(u)) !thermal conductivity of impervious [W/m-K]
+               tk_gimp(:,u) = tkimproad_lcz (landurban%settyp(u)) !thermal conductivity of impervious [W/m-K]
             ENDDO
 
             thick_roof = thickroof_lcz (landurban%settyp(u)) !thickness of roof [m]
@@ -247,7 +245,7 @@ MODULE MOD_UrbanReadin
                t_roommax(u) = 373.16                !maximum temperature of inner room [K]
                t_roommin(u) = 180.00                !minimum temperature of inner room [K]
             ENDIF
-#endif
+ENDIF
 
             IF (DEF_URBAN_WATER) THEN
                flake(u) = flake(u)/100. !urban water fractional cover

--- a/mksrfdata/Aggregation_Urban.F90
+++ b/mksrfdata/Aggregation_Urban.F90
@@ -25,11 +25,12 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
    USE MOD_Utils, only: num_max_frequency
    USE MOD_LandUrban
    USE MOD_Vars_Global, only: N_URB
-#ifdef URBAN_LCZ
    USE MOD_Urban_Const_LCZ, only: wtroof_lcz, htroof_lcz
-#endif
 #ifdef SinglePoint
    USE MOD_SingleSrfdata
+#endif
+#ifdef RangeCheck
+   USE MOD_RangeCheck
 #endif
 #ifdef SrfdataDiag
    USE MOD_SrfdataDiag
@@ -88,7 +89,6 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
    REAL(r8), allocatable, dimension(:) :: ulai_one
    REAL(r8), allocatable, dimension(:) :: slai_one
 
-#ifndef URBAN_LCZ
    ! urban morphological and thermal paras of NCAR data
    ! input variables, look-up-table data
    REAL(r8), allocatable, DIMENSION(:,:)  :: hwrcan, wtrd, emroof, emwall, ncar_wt
@@ -129,24 +129,25 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
    REAL(r8), ALLOCATABLE, DIMENSION(:,:,:) :: alb_wall
    REAL(r8), ALLOCATABLE, DIMENSION(:,:,:) :: alb_imrd
    REAL(r8), ALLOCATABLE, DIMENSION(:,:,:) :: alb_perd
-#endif
 
    ! landfile variables
    CHARACTER(len=256) landsrfdir, landdir, landname, suffix
-   CHARACTER(len=4)   cyear, c5year, cmonth, clay
+   CHARACTER(len=4)   cyear, c5year, cmonth, clay, c1, iyear
 
    ! local vars
    REAL(r8) :: sumarea
 
    ! index
-   INTEGER  :: iurban, urb_typidx, urb_regidx
-   INTEGER  :: pop_i, imonth, start_year, end_year
-   INTEGER  :: ipxstt, ipxend, ipxl, il, iy
+   INTEGER :: iurban, urb_typidx, urb_regidx
+   INTEGER :: pop_i, imonth, start_year, end_year
+   INTEGER :: ipxstt, ipxend, ipxl, il, iy
 
    ! for surface data diag
 #ifdef SrfdataDiag
    INTEGER  :: ityp
-   INTEGER  :: typindex(N_URB)
+   INTEGER, allocatable, dimension(:) :: typindex
+
+   allocate( typindex(N_URB) )
 #endif
 
    write(cyear,'(i4.4)') lc_year
@@ -171,7 +172,7 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
 
       landname = TRIM(dir_rawdata)//'urban/LUCY_countryid.nc'
       CALL allocate_block_data (grid_urban_5km, LUCY_reg)
-      CALL ncio_read_block (landname, 'Country_id', grid_urban_5km, LUCY_reg)
+      CALL ncio_read_block (landname, 'LUCY_COUNTRY_ID', grid_urban_5km, LUCY_reg)
 
 #ifdef USEMPI
       CALL aggregation_data_daemon (grid_urban_5km, data_i4_2d_in1 = LUCY_reg)
@@ -214,6 +215,10 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
    CALL mpi_barrier (p_comm_glb, p_err)
 #endif
 
+#ifdef RangeCheck
+   CALL check_vector_data ('LUCY_ID ', LUCY_coun)
+#endif
+
    ! ******* POP_DEN *******
    ! allocate and read the grided population raw data(500m)
    ! NOTE, the population is year-by-year
@@ -222,7 +227,7 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
       CALL allocate_block_data (grid_urban_500m, pop)
 
       landdir = TRIM(dir_rawdata)//'/urban/'
-      suffix  = 'URB'//trim(c5year)
+      suffix  = 'URBSRF'//trim(c5year)
 
       ! populaiton data is year by year,
       ! so pop_i is calculated to determine the dimension of POP data reads
@@ -233,7 +238,7 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
       ENDIF
 
       ! read the population data of total 5x5 region
-      CALL read_5x5_data_time (landdir, suffix, grid_urban_500m, "POP", pop_i, pop)
+      CALL read_5x5_data_time (landdir, suffix, grid_urban_500m, "POP_DEN", pop_i, pop)
 
 #ifdef USEMPI
       CALL aggregation_data_daemon (grid_urban_500m, data_r8_2d_in1 = pop)
@@ -284,6 +289,10 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
    CALL mpi_barrier (p_comm_glb, p_err)
 #endif
 
+#ifdef RangeCheck
+   CALL check_vector_data ('POP_DEN ', pop_den)
+#endif
+
    ! ******* Tree : PCT_Tree, HTOP *******
    ! allocate and read the grided tree cover and tree height raw data(500m)
    ! NOTE, tree cover raw data is available every five years,
@@ -291,7 +300,7 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
    IF (p_is_io) THEN
 
       landdir = TRIM(dir_rawdata)//'/urban/'
-      suffix  = 'URB'//trim(c5year)
+      suffix  = 'URBSRF'//trim(c5year)
 
       CALL allocate_block_data (grid_urban_500m, gfcc_tc)
       CALL read_5x5_data (landdir, suffix, grid_urban_500m, "PCT_Tree", gfcc_tc)
@@ -368,6 +377,11 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
    CALL mpi_barrier (p_comm_glb, p_err)
 #endif
 
+#ifdef RangeCheck
+   CALL check_vector_data ('Urban Tree Cover ', pct_tree)
+   CALL check_vector_data ('Urban Tree Top '  , htop_urb)
+#endif
+
    ! ******* PCT_Water *******
    ! allocate and read grided water cover raw data
    IF (p_is_io) THEN
@@ -375,7 +389,7 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
       CALL allocate_block_data (grid_urban_500m, gl30_wt)
 
       landdir = TRIM(dir_rawdata)//'/urban/'
-      suffix  = 'URB'//trim(c5year)
+      suffix  = 'URBSRF'//trim(c5year)
       CALL read_5x5_data (landdir, suffix, grid_urban_500m, "PCT_Water", gl30_wt)
 
 #ifdef USEMPI
@@ -424,16 +438,20 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
    CALL mpi_barrier (p_comm_glb, p_err)
 #endif
 
+#ifdef RangeCheck
+   CALL check_vector_data ('Urban Water Cover ', pct_urbwt)
+#endif
+
    ! ******* Building : Weight, HTOP_Roof *******
    ! if building data is missing, how to look-up-table?
    ! a new arry with region id was used for look-up-table (urban_reg)
-#ifndef URBAN_LCZ
+IF (DEF_URBAN_type_scheme == 1) THEN
    ! only used when urban patch have nan data of building height and fraction
-   landname = TRIM(dir_rawdata)//'urban/urban_properties.nc'
+   landname = TRIM(dir_rawdata)//'urban/NCAR_urban_properties.nc'
 
    CALL ncio_read_bcast_serial (landname,  "WTLUNIT_ROOF"       , ncar_wt )
    CALL ncio_read_bcast_serial (landname,  "HT_ROOF"            , ncar_ht )
-#endif
+ENDIF
 
    ! allocate and read grided building hegight and cover raw data
    IF (p_is_io) THEN
@@ -441,16 +459,16 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
       CALL allocate_block_data (grid_urban_500m, wtrf)
       CALL allocate_block_data (grid_urban_500m, htrf)
 
-      landdir = TRIM(dir_rawdata)//'urban/'
-      suffix  = 'URB'//trim(c5year)
+      landdir = TRIM(dir_rawdata)//'urban_type/'
+      suffix  = 'URBTYP'
       CALL read_5x5_data (landdir, suffix, grid_urban_500m, "REGION_ID", reg_typid)
 
       landdir = TRIM(dir_rawdata)//'/urban/'
-      suffix  = 'URB'//trim(c5year)
-      CALL read_5x5_data (landdir, suffix, grid_urban_500m, "WTLUNIT_ROOF", wtrf)
+      suffix  = 'URBSRF'//trim(c5year)
+      CALL read_5x5_data (landdir, suffix, grid_urban_500m, "PCT_ROOF", wtrf)
 
       landdir = TRIM(dir_rawdata)//'/urban/'
-      suffix  = 'URB'//trim(c5year)
+      suffix  = 'URBSRF'//trim(c5year)
       CALL read_5x5_data (landdir, suffix, grid_urban_500m, "HT_ROOF", htrf)
 
 #ifdef USEMPI
@@ -470,7 +488,7 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
             data_r8_2d_in1 = wtrf, data_r8_2d_out1 = wt_roof_one, &
             data_r8_2d_in2 = htrf, data_r8_2d_out2 = ht_roof_one)
 
-#ifndef URBAN_LCZ
+IF (DEF_URBAN_type_scheme == 1) THEN
          ! when urban patch has no data, use table data to fill gap
          ! urban type and region id for look-up-table
          urb_typidx = landurban%settyp(iurban)
@@ -492,7 +510,7 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
          where (ht_roof_one <= 0)
             ht_roof_one = ncar_ht(urb_typidx,reg_typid_one)
          END where
-#else
+ELSE IF (DEF_URBAN_type_scheme == 2) THEN
          ! same for above, but for LCZ case
          ! LCZ type for look-up-table
          urb_typidx     = landurban%settyp(iurban)
@@ -504,7 +522,7 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
          where (ht_roof_one <= 0)
             ht_roof_one = htroof_lcz(urb_typidx)
          END where
-#endif
+ENDIF
 
          ! area-weight average
          wt_roof(iurban) = sum(wt_roof_one * area_one) / sum(area_one)
@@ -544,7 +562,13 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
    CALL mpi_barrier (p_comm_glb, p_err)
 #endif
 
+#ifdef RangeCheck
+   CALL check_vector_data ('Urban Roof Fraction ', wt_roof)
+   CALL check_vector_data ('Urban Roof Height '  , ht_roof)
+#endif
+
    ! ******* LAI, SAI *******
+#ifndef LULCC
    IF (DEF_LAI_CHANGE_YEARLY) THEN
       start_year = DEF_simulation_time%start_year
       end_year   = DEF_simulation_time%end_year
@@ -552,9 +576,12 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
       start_year = lc_year
       end_year   = lc_year
    ENDIF
-   ! allocate and read grided LSAI raw data
-   landdir = TRIM(dir_rawdata)//'/urban_lai_5x5/'
-   suffix  = 'UrbLAI_v5_'//trim(c5year)
+#else
+   start_year = lc_year
+   end_year   = lc_year
+#endif
+
+
 
    IF (p_is_io) THEN
       CALL allocate_block_data (grid_urban_500m, ulai)
@@ -570,9 +597,13 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
    ENDIF
 
    DO iy = start_year, end_year
-      write(cyear,'(i4.4)') iy
-      landsrfdir = trim(dir_srfdata) // '/urban/' // trim(cyear) // '/LAI'
+      write(iyear,'(i4.4)') iy
+      landsrfdir = trim(dir_srfdata) // '/urban/' // trim(iyear) // '/LAI'
       CALL system('mkdir -p ' // trim(adjustl(landsrfdir)))
+
+      ! allocate and read grided LSAI raw data
+      landdir = TRIM(dir_rawdata)//'/urban_lai_5x5/'
+      suffix  = 'UrbLAI_'//trim(iyear)
       ! loop for month
       DO imonth = 1, 12
 
@@ -621,24 +652,24 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
          ENDIF
 
       ! output
-         landname = trim(dir_srfdata) // '/urban/'//trim(cyear)//'/LAI/urban_LAI_'//trim(cmonth)//'.nc'
+         landname = trim(dir_srfdata) // '/urban/'//trim(iyear)//'/LAI/urban_LAI_'//trim(cmonth)//'.nc'
          CALL ncio_create_file_vector (landname, landurban)
          CALL ncio_define_dimension_vector (landname, landurban, 'urban')
          CALL ncio_write_vector (landname, 'TREE_LAI', 'urban', landurban, lai_urb, 1)
 
-         landname = trim(dir_srfdata) // '/urban/'//trim(cyear)//'/LAI/urban_SAI_'//trim(cmonth)//'.nc'
+         landname = trim(dir_srfdata) // '/urban/'//trim(iyear)//'/LAI/urban_SAI_'//trim(cmonth)//'.nc'
          CALL ncio_create_file_vector (landname, landurban)
          CALL ncio_define_dimension_vector (landname, landurban, 'urban')
          CALL ncio_write_vector (landname, 'TREE_SAI', 'urban', landurban, sai_urb, 1)
 
 #ifdef SrfdataDiag
          typindex = (/(ityp, ityp = 1, N_URB)/)
-         landname  = trim(dir_srfdata) // '/diag/Urban_Tree_LAI_' // trim(cyear) // '.nc'
+         landname  = trim(dir_srfdata) // '/diag/Urban_Tree_LAI_' // trim(iyear) // '.nc'
          CALL srfdata_map_and_write (lai_urb, landurban%settyp, typindex, m_urb2diag, &
             -1.0e36_r8, landname, 'TREE_LAI_'//trim(cmonth), compress = 0, write_mode = 'one')
 
          typindex = (/(ityp, ityp = 1, N_URB)/)
-         landname  = trim(dir_srfdata) // '/diag/Urban_Tree_SAI_' // trim(cyear) // '.nc'
+         landname  = trim(dir_srfdata) // '/diag/Urban_Tree_SAI_' // trim(iyear) // '.nc'
          CALL srfdata_map_and_write (sai_urb, landurban%settyp, typindex, m_urb2diag, &
             -1.0e36_r8, landname, 'TREE_SAI_'//trim(cmonth), compress = 0, write_mode = 'one')
 #endif
@@ -646,12 +677,19 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
 #ifdef USEMPI
          CALL mpi_barrier (p_comm_glb, p_err)
 #endif
+
+         write(c1,'(i2.2)') imonth
+
+#ifdef RangeCheck
+         CALL check_vector_data ('Urban Tree LAI '//trim(c1), lai_urb)
+         CALL check_vector_data ('Urban Tree SAI '//trim(c1), sai_urb)
+#endif
       ENDDO
    ENDDO
 
-#ifndef URBAN_LCZ
+IF (DEF_URBAN_type_scheme == 1) THEN
    ! look up table of NCAR urban properties (using look-up tables)
-   landname = TRIM(dir_rawdata)//'urban/urban_properties.nc'
+   landname = TRIM(dir_rawdata)//'urban/NCAR_urban_properties.nc'
 
    CALL ncio_read_bcast_serial (landname,  "CANYON_HWR"    , hwrcan   )
    CALL ncio_read_bcast_serial (landname,  "WTROAD_PERV"   , wtrd     )
@@ -884,33 +922,47 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
    CALL srfdata_map_and_write (hwr_can, landurban%settyp, typindex, m_urb2diag, &
       -1.0e36_r8, landname, 'CANYON_HWR_'//trim(cyear), compress = 0, write_mode = 'one')
 
-   ! typindex = (/(ityp, ityp = 1, N_URB)/)
-   ! landname  = trim(dir_srfdata) // '/diag/PCT_Urban.nc'
-   ! CALL srfdata_map_and_write (area_tb, landurban%settyp, typindex, m_urb2diag, &
-   !    -1.0e36_r8, landname, 'PCT_Urban', compress = 0, write_mode = 'one')
-   ! typindex = (/(ityp, ityp = 1, N_URB)/)
-   ! landname  = trim(dir_srfdata) // '/diag/PCT_Urban.nc'
-   ! CALL srfdata_map_and_write (area_hd, landurban%settyp, typindex, m_urb2diag, &
-   !    -1.0e36_r8, landname, 'PCT_Urban', compress = 0, write_mode = 'one')
-   ! typindex = (/(ityp, ityp = 1, N_URB)/)
-   ! landname  = trim(dir_srfdata) // '/diag/PCT_Urban.nc'
-   ! CALL srfdata_map_and_write (area_md, landurban%settyp, typindex, m_urb2diag, &
-   !    -1.0e36_r8, landname, 'PCT_Urban', compress = 0, write_mode = 'one')
-
    typindex = (/(ityp, ityp = 1, N_URB)/)
    landname  = trim(dir_srfdata) // '/diag/cv_imrd' // trim(cyear) // '.nc'
+
    DO il = 1, 10
       write(clay, '(i2.2)') il
       CALL srfdata_map_and_write (cv_imrd(il,:), landurban%settyp, typindex, m_urb2diag, &
-         -1.0e36_r8, landname, 'CV_IMPROAD_'//trim(clay), compress = 0, write_mode = 'one')
+      -1.0e36_r8, landname, 'CV_IMPROAD', compress = 0, write_mode = 'one', lastdimname = 'layer', lastdimvalue = il)
+      ! CALL srfdata_map_and_write (cv_imrd(il,:), landurban%settyp, typindex, m_urb2diag, &
+      !    -1.0e36_r8, landname, 'CV_IMPROAD_'//trim(clay), compress = 0, write_mode = 'one')
    ENDDO
+   deallocate(typindex)
+#endif
+
+#ifdef RangeCheck
+   CALL check_vector_data ('CANYON_HWR '    , hwr_can )
+   CALL check_vector_data ('WTROAD_PERV '   , wt_rd   )
+   CALL check_vector_data ('EM_ROOF '       , em_roof )
+   CALL check_vector_data ('EM_WALL '       , em_wall )
+   CALL check_vector_data ('EM_IMPROAD '    , em_imrd )
+   CALL check_vector_data ('EM_PERROAD '    , em_perd )
+   CALL check_vector_data ('ALB_ROOF '      , alb_roof)
+   CALL check_vector_data ('ALB_WALL '      , alb_wall)
+   CALL check_vector_data ('ALB_IMPROAD '   , alb_imrd)
+   CALL check_vector_data ('ALB_PERROAD '   , alb_perd)
+   CALL check_vector_data ('TK_ROOF '       , tk_roof )
+   CALL check_vector_data ('TK_WALL '       , tk_wall )
+   CALL check_vector_data ('TK_IMPROAD '    , tk_imrd )
+   CALL check_vector_data ('CV_ROOF '       , cv_roof )
+   CALL check_vector_data ('CV_WALL '       , cv_wall )
+   CALL check_vector_data ('CV_IMPROAD '    , cv_imrd )
+   CALL check_vector_data ('THICK_ROOF '    , th_roof )
+   CALL check_vector_data ('THICK_WALL '    , th_wall )
+   CALL check_vector_data ('T_BUILDING_MIN ', tb_min  )
+   CALL check_vector_data ('T_BUILDING_MAX ', tb_max  )
 #endif
 
 #ifdef USEMPI
    CALL mpi_barrier (p_comm_glb, p_err)
 #endif
 
-#endif
+ENDIF
 
    IF (p_is_worker) THEN
       IF (allocated(LUCY_coun)) deallocate (LUCY_coun)
@@ -922,7 +974,7 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
       IF (allocated(ht_roof  )) deallocate (ht_roof  )
       IF (allocated(lai_urb  )) deallocate (lai_urb  )
       IF (allocated(sai_urb  )) deallocate (sai_urb  )
-#ifndef URBAN_LCZ
+IF (DEF_URBAN_type_scheme == 1) THEN
       IF (allocated(ncar_ht  )) deallocate (ncar_ht  )
       IF (allocated(ncar_wt  )) deallocate (ncar_wt  )
       IF (allocated(area_urb )) deallocate (area_urb )
@@ -948,7 +1000,7 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
       IF (allocated(alb_wall )) deallocate (alb_wall )
       IF (allocated(alb_imrd )) deallocate (alb_imrd )
       IF (allocated(alb_perd )) deallocate (alb_perd )
-#endif
+ENDIF
       IF (allocated(area_one    )) deallocate(area_one    )
       IF (allocated(LUCY_reg_one)) deallocate(LUCY_reg_one)
       IF (allocated(pop_one     )) deallocate(pop_one     )

--- a/mksrfdata/MOD_LandUrban.F90
+++ b/mksrfdata/MOD_LandUrban.F90
@@ -100,20 +100,20 @@ CONTAINS
       ! allocate and read the grided LCZ/NCAR urban type
       if (p_is_io) then
 
-         dir_urban = trim(DEF_dir_rawdata) // '/urban'
+         dir_urban = trim(DEF_dir_rawdata) // '/urban_type'
 
          CALL allocate_block_data (gurban, data_urb_class)
          CALL flush_block_data (data_urb_class, 0)
 
-         write(cyear,'(i4.4)') int(lc_year/5)*5
-         suffix = 'URB'//trim(cyear)
-#ifdef URBAN_LCZ
-         CALL read_5x5_data (dir_urban, suffix, gurban, 'LCZ', data_urb_class)
-#else
+         !write(cyear,'(i4.4)') int(lc_year/5)*5
+         suffix = 'URBTYP'
+IF (DEF_URBAN_type_scheme == 1) THEN
          ! NOTE!!!
          ! region id is assigned in aggreagation_urban.F90 now
          CALL read_5x5_data (dir_urban, suffix, gurban, 'URBAN_DENSITY_CLASS', data_urb_class)
-#endif
+ELSE IF (DEF_URBAN_type_scheme == 2) THEN
+         CALL read_5x5_data (dir_urban, suffix, gurban, 'LCZ_DOM', data_urb_class)
+ENDIF
 
 #ifdef USEMPI
          CALL aggregation_data_daemon (gurban, data_i4_2d_in1 = data_urb_class)
@@ -154,18 +154,18 @@ CONTAINS
                CALL aggregation_request_data (landpatch, ipatch, gurban, &
                   data_i4_2d_in1 = data_urb_class, data_i4_2d_out1 = ibuff)
 
-#ifndef URBAN_LCZ
+IF (DEF_URBAN_type_scheme == 1) THEN
                ! Some urban patches and NCAR data are inconsistent (NCAR has no urban ID),
                ! so the these points are assigned by the 3(medium density), or can define by ueser
                where (ibuff < 1 .or. ibuff > 3)
                   ibuff = 3
                END where
-#else
+ELSE IF(DEF_URBAN_type_scheme == 2) THEN
                ! Same for NCAR, fill the gap LCZ class of urban patch if LCZ data is non-urban
-               where (ibuff > 10)
+               where (ibuff > 10 .or. ibuff == 0)
                   ibuff = 9
                END where
-#endif
+ENDIF
 
                npxl = ipxend - ipxstt + 1
 

--- a/share/MOD_Namelist.F90
+++ b/share/MOD_Namelist.F90
@@ -33,7 +33,7 @@ MODULE MOD_Namelist
 
    ! ----- For Single Point -----
 #ifdef SinglePoint
-   
+
    CHARACTER(len=256) :: SITE_fsrfdata  = 'null'
 
    LOGICAL  :: USE_SITE_pctpfts         = .true.
@@ -120,7 +120,11 @@ MODULE MOD_Namelist
    INTEGER :: DEF_LULCC_SCHEME = 1
 
    ! ------ Urban model related -------
-   !INTEGER :: DEF_URBAN_type_scheme = 1
+   ! Options for urban type scheme
+   ! 1: NCAR Urban Classification, 3 urban type with Tall Building, High Density and Medium Density
+   ! 2: LCZ Classification, 10 urban type with LCZ 1-10
+   INTEGER :: DEF_URBAN_type_scheme = 1
+   LOGICAL :: DEF_URBAN_ONLY   = .false.
    logical :: DEF_URBAN_RUN    = .false.
    LOGICAL :: DEF_URBAN_BEM    = .true.
    LOGICAL :: DEF_URBAN_TREE   = .true.
@@ -658,7 +662,8 @@ CONTAINS
          DEF_LC_YEAR,                     &
          DEF_LULCC_SCHEME,                &
 
-        !DEF_URBAN_type_scheme,           &
+         DEF_URBAN_type_scheme,           &
+         DEF_URBAN_ONLY,                  &
          DEF_URBAN_RUN,                   &   !add by hua yuan, open urban model or not
          DEF_URBAN_BEM,                   &   !add by hua yuan, open urban BEM model or not
          DEF_URBAN_TREE,                  &   !add by hua yuan, modeling urban tree or not
@@ -1000,8 +1005,9 @@ CONTAINS
       CALL mpi_bcast (DEF_LC_YEAR,         1, mpi_integer, p_root, p_comm_glb, p_err)
       CALL mpi_bcast (DEF_LULCC_SCHEME,    1, mpi_integer, p_root, p_comm_glb, p_err)
 
-      !CALL mpi_bcast (DEF_URBAN_type_scheme, 1, mpi_integer, p_root, p_comm_glb, p_err)
+      CALL mpi_bcast (DEF_URBAN_type_scheme, 1, mpi_integer, p_root, p_comm_glb, p_err)
       ! 05/2023, added by yuan
+      CALL mpi_bcast (DEF_URBAN_ONLY,      1, mpi_logical, p_root, p_comm_glb, p_err)
       CALL mpi_bcast (DEF_URBAN_RUN,       1, mpi_logical, p_root, p_comm_glb, p_err)
       CALL mpi_bcast (DEF_URBAN_BEM,       1, mpi_logical, p_root, p_comm_glb, p_err)
       CALL mpi_bcast (DEF_URBAN_TREE,      1, mpi_logical, p_root, p_comm_glb, p_err)


### PR DESCRIPTION
    -add(MOD_Initialize.F90):
        add urban patch mask and initialize patchmask var.

    -add(MOD_Vars_TimeInvariants.F90):
        add var patchmask.

    -mod(CoLMDRIVER.F90,MOD_Hist.F90,MOD_Vars_1DAccFluxes.F90):
        adjust for applying patchmask.
    
    -mod(main/MOD_Vars_Global.F90): 
        N_URB is defined by urban type scheme.

    -mod(share/MOD_Namelist.F90):
        add description of urban type option.

    -mod(Aggregation_Urban.F90,MOD_LandUrban.F90,MOD_UrbanReadin.F90):
        changes relate to LCZ namelist and filename/vars renames.

