### PR TITLE
Change aggregation of crop percentages.

### DIFF
--- a/main/HYDRO/MOD_Hydro_BasinNeighbour.F90
+++ b/main/HYDRO/MOD_Hydro_BasinNeighbour.F90
@@ -558,7 +558,7 @@ CONTAINS
          DO ibasin = 1, numbasin
             IF (lake_id(ibasin) == 0) THEN
                IF ((to_lake(ibasin)) .or. (riverdown(ibasin) <= 0)) THEN
-                  ! river to lake, ocean or inland depression
+                  ! river to lake, ocean, inland depression or out of region
                   outletwth(ibasin) = riverwth(ibasin)
                ELSE
                   ! river to river

--- a/main/HYDRO/MOD_Hydro_LateralFlow.F90
+++ b/main/HYDRO/MOD_Hydro_LateralFlow.F90
@@ -231,7 +231,7 @@ CONTAINS
             dtolw = sum(patcharea * xwsur) / 1.e3 * deltime
          ENDIF
          IF (numelm > 0) THEN
-            toldis = sum(discharge*deltime, mask = riverdown == 0)
+            toldis = sum(discharge*deltime, mask = (riverdown == 0) .or. (riverdown == -3))
             dtolw  = dtolw - toldis
          ENDIF
 

--- a/main/MOD_Forcing.F90
+++ b/main/MOD_Forcing.F90
@@ -79,6 +79,9 @@ contains
       USE MOD_Mesh
       USE MOD_LandElm
       USE MOD_LandPatch
+#ifdef CROP
+      USE MOD_LandCrop
+#endif
       use MOD_Mapping_Grid2Pset
       use MOD_UserSpecifiedForcing
       USE MOD_NetCDFSerial
@@ -192,7 +195,7 @@ contains
 
          IF (p_is_worker) THEN
 #if (defined CROP)
-            CALL elm_patch%build (landelm, landpatch, use_frac = .true., shadowfrac = pctcrop)
+            CALL elm_patch%build (landelm, landpatch, use_frac = .true., sharedfrac = pctshrpch)
 #else
             CALL elm_patch%build (landelm, landpatch, use_frac = .true.)
 #endif

--- a/main/MOD_HistGridded.F90
+++ b/main/MOD_HistGridded.F90
@@ -42,6 +42,9 @@ contains
 #ifdef URBAN_MODEL
       USE MOD_LandUrban
 #endif
+#ifdef CROP
+      USE MOD_LandCrop
+#endif
       use MOD_Mapping_Pset2Grid
       use MOD_Vars_1DAccFluxes
       USE MOD_Forcing, only : gforc
@@ -61,7 +64,7 @@ contains
 #ifndef CROP
       call mp2g_hist%build (landpatch, ghist)
 #else
-      call mp2g_hist%build (landpatch, ghist, pctcrop)
+      call mp2g_hist%build (landpatch, ghist, pctshrpch)
 #endif
 
 #ifdef URBAN_MODEL

--- a/main/MOD_Vars_1DAccFluxes.F90
+++ b/main/MOD_Vars_1DAccFluxes.F90
@@ -332,6 +332,9 @@ contains
       USE MOD_LandElm
       use MOD_LandPatch
       USE MOD_LandUrban, only: numurban
+#ifdef CROP
+      USE MOD_LandCrop
+#endif
       USE MOD_Vars_Global
       implicit none
 
@@ -661,7 +664,7 @@ contains
 
       IF (p_is_worker) THEN
 #if (defined CROP)
-         CALL elm_patch%build (landelm, landpatch, use_frac = .true., shadowfrac = pctcrop)
+         CALL elm_patch%build (landelm, landpatch, use_frac = .true., sharedfrac = pctshrpch)
 #else
          CALL elm_patch%build (landelm, landpatch, use_frac = .true.)
 #endif

--- a/mkinidata/MOD_PercentagesPFTReadin.F90
+++ b/mkinidata/MOD_PercentagesPFTReadin.F90
@@ -61,11 +61,11 @@ MODULE MOD_PercentagesPFTReadin
       lndname = trim(dir_landdata)//'/pctpft/'//trim(cyear)//'/pct_crops.nc'
       call ncio_read_vector (lndname, 'pct_crops', landpatch, pctshrpch)
 #else
-      allocate (pctcrop (numpatch))
+      allocate (pctshrpch (numpatch))
       IF (SITE_landtype == CROPLAND) THEN
-         pctcrop = pack(SITE_pctcrop, SITE_pctcrop > 0.)
+         pctshrpch = pack(SITE_pctcrop, SITE_pctcrop > 0.)
       ELSE
-         pctcrop = 0.
+         pctshrpch = 0.
       ENDIF
 #endif
 #endif

--- a/mkinidata/MOD_PercentagesPFTReadin.F90
+++ b/mkinidata/MOD_PercentagesPFTReadin.F90
@@ -25,6 +25,9 @@ MODULE MOD_PercentagesPFTReadin
       use MOD_SPMD_Task
       USE MOD_NetCDFVector
       USE MOD_LandPatch
+#ifdef CROP
+      USE MOD_LandCrop
+#endif
 #ifdef RangeCheck
       USE MOD_RangeCheck
 #endif
@@ -56,7 +59,7 @@ MODULE MOD_PercentagesPFTReadin
 #if (defined CROP)
 #ifndef SinglePoint
       lndname = trim(dir_landdata)//'/pctpft/'//trim(cyear)//'/pct_crops.nc'
-      call ncio_read_vector (lndname, 'pct_crops', landpatch, pctcrop)
+      call ncio_read_vector (lndname, 'pct_crops', landpatch, pctshrpch)
 #else
       allocate (pctcrop (numpatch))
       IF (SITE_landtype == CROPLAND) THEN
@@ -84,7 +87,7 @@ MODULE MOD_PercentagesPFTReadin
 
       CALL check_vector_data ('Sum PFT pct', sumpct)
 #if (defined CROP)
-      CALL check_vector_data ('CROP pct', pctcrop)
+      CALL check_vector_data ('CROP pct', pctshrpch)
 #endif
 
 #endif

--- a/mksrfdata/Aggregation_PercentagesPFT.F90
+++ b/mksrfdata/Aggregation_PercentagesPFT.F90
@@ -18,6 +18,9 @@ SUBROUTINE Aggregation_PercentagesPFT (gland, dir_rawdata, dir_model_landdata, l
    USE MOD_SPMD_Task
    USE MOD_Grid
    USE MOD_LandPatch
+#ifdef CROP
+   USE MOD_LandCrop
+#endif
    USE MOD_NetCDFBlock
    USE MOD_NetCDFVector
 #ifdef RangeCheck
@@ -187,19 +190,19 @@ SUBROUTINE Aggregation_PercentagesPFT (gland, dir_rawdata, dir_model_landdata, l
    lndname = trim(landdir)//'/pct_crops.nc'
    CALL ncio_create_file_vector (lndname, landpatch)
    CALL ncio_define_dimension_vector (lndname, landpatch, 'patch')
-   CALL ncio_write_vector (lndname, 'pct_crops', 'patch', landpatch, pctcrop, 1)
+   CALL ncio_write_vector (lndname, 'pct_crops', 'patch', landpatch, pctshrpch, 1)
 
 #ifdef SrfdataDiag
    typcrop = (/(ityp, ityp = 1, N_CFT)/)
-   lndname = trim(dir_model_landdata) // '/diag/pct_crops_patch_' // trim(cyear) // '.nc'
-   CALL srfdata_map_and_write (pctcrop, cropclass, typcrop, m_patch2diag, &
-      -1.0e36_r8, lndname, 'pctcrop', compress = 1, write_mode = 'one')
+   lndname = trim(dir_model_landdata) // '/diag/pct_crop_patch_' // trim(cyear) // '.nc'
+   CALL srfdata_map_and_write (pctshrpch, cropclass, typcrop, m_patch2diag, &
+      -1.0e36_r8, lndname, 'pct_crop_patch', compress = 1, write_mode = 'one')
 #endif
 #else
    allocate (SITE_croptyp(numpatch))
    allocate (SITE_pctcrop(numpatch))
    SITE_croptyp = cropclass
-   SITE_pctcrop = pctcrop
+   SITE_pctcrop = pctshrpch
 #endif
 #endif
 

--- a/mksrfdata/MKSRFDATA.F90
+++ b/mksrfdata/MKSRFDATA.F90
@@ -65,6 +65,9 @@ PROGRAM MKSRFDATA
 #ifdef URBAN_MODEL
    USE MOD_LandUrban
 #endif
+#ifdef CROP
+   USE MOD_LandCrop
+#endif
    USE MOD_RegionClip
 #ifdef SrfdataDiag
    USE MOD_SrfdataDiag, only : gdiag, srfdata_diag_init
@@ -293,6 +296,10 @@ PROGRAM MKSRFDATA
    CALL landurban_build(lc_year)
 #endif
 
+#ifdef CROP
+   CALL landcrop_build (lc_year)
+#endif
+
 #if (defined LULC_IGBP_PFT || defined LULC_IGBP_PC)
    CALL landpft_build(lc_year)
 #endif
@@ -328,7 +335,7 @@ PROGRAM MKSRFDATA
    ! ................................................................
 #ifdef SrfdataDiag
 #if (defined CROP)
-   CALL elm_patch%build (landelm, landpatch, use_frac = .true., shadowfrac = pctcrop)
+   CALL elm_patch%build (landelm, landpatch, use_frac = .true., sharedfrac = pctshrpch)
 #else
    CALL elm_patch%build (landelm, landpatch, use_frac = .true.)
 #endif

--- a/mksrfdata/MOD_ElmVector.F90
+++ b/mksrfdata/MOD_ElmVector.F90
@@ -36,6 +36,9 @@ CONTAINS
       USE MOD_Mesh
       USE MOD_LandElm
       USE MOD_LandPatch
+#ifdef CROP
+      USE MOD_LandCrop
+#endif
       IMPLICIT NONE
 
       ! Local Variables
@@ -49,7 +52,7 @@ CONTAINS
       
       IF (p_is_worker) THEN
 #if (defined CROP) 
-         CALL elm_patch%build (landelm, landpatch, use_frac = .true., shadowfrac = pctcrop)
+         CALL elm_patch%build (landelm, landpatch, use_frac = .true., sharedfrac = pctshrpch)
 #else
          CALL elm_patch%build (landelm, landpatch, use_frac = .true.)
 #endif

--- a/mksrfdata/MOD_HRUVector.F90
+++ b/mksrfdata/MOD_HRUVector.F90
@@ -37,6 +37,9 @@ CONTAINS
       USE MOD_LandHRU
       USE MOD_LandPatch
       USE MOD_ElmVector
+#ifdef CROP
+      USE MOD_LandCrop
+#endif
       IMPLICIT NONE
 
       ! Local Variables
@@ -56,7 +59,7 @@ CONTAINS
          CALL basin_hru%build (landelm, landhru,   use_frac = .true.)
 
 #if (defined CROP) 
-         CALL hru_patch%build (landhru, landpatch, use_frac = .true., shadowfrac = pctcrop)
+         CALL hru_patch%build (landhru, landpatch, use_frac = .true., sharedfrac = pctshrpch)
 #else
          CALL hru_patch%build (landhru, landpatch, use_frac = .true.)
 #endif

--- a/mksrfdata/MOD_LandCrop.F90
+++ b/mksrfdata/MOD_LandCrop.F90
@@ -19,7 +19,6 @@ MODULE MOD_LandCrop
    ! ---- Instance ----
    TYPE(grid_type) :: gcrop
    INTEGER,  allocatable :: cropclass (:)
-   REAL(r8), allocatable :: pctcrop   (:)
    REAL(r8), allocatable :: pctshrpch (:)
 
 CONTAINS
@@ -68,12 +67,12 @@ CONTAINS
 
          numpatch = count(SITE_pctcrop > 0.)
 
-         allocate (pctcrop  (numpatch))
+         allocate (pctshrpch (numpatch))
          allocate (cropclass(numpatch))
          cropclass = pack(SITE_croptyp, SITE_pctcrop > 0.)
-         pctcrop   = pack(SITE_pctcrop, SITE_pctcrop > 0.)
+         pctshrpch = pack(SITE_pctcrop, SITE_pctcrop > 0.)
 
-         pctcrop = pctcrop / sum(pctcrop)
+         pctshrpch = pctshrpch / sum(pctshrpch)
 
          allocate (landpatch%eindex (numpatch))
          allocate (landpatch%ipxstt (numpatch))

--- a/mksrfdata/MOD_LandCrop.F90
+++ b/mksrfdata/MOD_LandCrop.F90
@@ -1,0 +1,168 @@
+#include <define.h>
+
+#ifdef CROP
+MODULE MOD_LandCrop
+
+   !------------------------------------------------------------------------------------
+   ! DESCRIPTION:
+   !
+   !    Build crop patches.
+   !
+   ! Created by Shupeng Zhang, Sep 2023
+   !    porting codes from Hua Yuan's OpenMP version to MPI parallel version.
+   !------------------------------------------------------------------------------------
+
+   USE MOD_Precision
+   USE MOD_Grid
+   IMPLICIT NONE
+
+   ! ---- Instance ----
+   TYPE(grid_type) :: gcrop
+   INTEGER,  allocatable :: cropclass (:)
+   REAL(r8), allocatable :: pctcrop   (:)
+   REAL(r8), allocatable :: pctshrpch (:)
+
+CONTAINS
+
+   ! -------------------------------
+   SUBROUTINE landcrop_build (lc_year)
+
+      USE MOD_SPMD_Task
+      USE MOD_Namelist
+      USE MOD_Block
+      USE MOD_DataType
+      USE MOD_LandElm
+#ifdef CATCHMENT
+      USE MOD_LandHRU
+#endif
+      USE MOD_LandPatch
+      USE MOD_NetCDFBlock
+      USE MOD_PixelsetShared
+      USE MOD_5x5DataReadin
+#ifdef SinglePoint
+      USE MOD_SingleSrfdata
+#endif
+
+      IMPLICIT NONE
+
+      INTEGER, intent(in) :: lc_year
+
+      ! Local Variables
+      CHARACTER(len=255) :: cyear, file_patch, dir_5x5, suffix
+      INTEGER :: npatch_glb
+      TYPE(block_data_real8_2d) :: pctcrop_xy
+      TYPE(block_data_real8_3d) :: pctshared_xy
+      TYPE(block_data_real8_3d) :: cropdata
+      INTEGER :: sharedfilter(1), cropfilter(1)
+      integer :: iblkme, ib, jb
+      real(r8), allocatable :: pctshared  (:)
+      integer , allocatable :: classshared(:)
+
+      write(cyear,'(i4.4)') lc_year
+      IF (p_is_master) THEN
+         write(*,'(A)') 'Making patches (crop shared) :'
+      ENDIF
+
+#if (defined SinglePoint && defined CROP)
+      IF ((SITE_landtype == CROPLAND) .and. (USE_SITE_pctcrop)) THEN
+
+         numpatch = count(SITE_pctcrop > 0.)
+
+         allocate (pctcrop  (numpatch))
+         allocate (cropclass(numpatch))
+         cropclass = pack(SITE_croptyp, SITE_pctcrop > 0.)
+         pctcrop   = pack(SITE_pctcrop, SITE_pctcrop > 0.)
+
+         pctcrop = pctcrop / sum(pctcrop)
+
+         allocate (landpatch%eindex (numpatch))
+         allocate (landpatch%ipxstt (numpatch))
+         allocate (landpatch%ipxend (numpatch))
+         allocate (landpatch%settyp (numpatch))
+         allocate (landpatch%ielm   (numpatch))
+
+         landpatch%eindex(:) = 1
+         landpatch%ielm  (:) = 1
+         landpatch%ipxstt(:) = 1
+         landpatch%ipxend(:) = 1
+         landpatch%settyp(:) = CROPLAND
+
+         landpatch%nset = numpatch
+         CALL landpatch%set_vecgs
+
+         RETURN
+      ENDIF
+#endif
+
+#ifdef USEMPI
+      CALL mpi_barrier (p_comm_glb, p_err)
+#endif
+
+      IF (p_is_io) THEN
+
+         dir_5x5 = trim(DEF_dir_rawdata) // '/plant_15s'
+         suffix  = 'MOD'//trim(cyear)
+
+         CALL allocate_block_data (gpatch, pctcrop_xy)
+         CALL read_5x5_data (dir_5x5, suffix, gpatch, 'PCT_CROP', pctcrop_xy)
+         
+         CALL allocate_block_data (gpatch, pctshared_xy, 2)
+         DO iblkme = 1, gblock%nblkme
+            ib = gblock%xblkme(iblkme)
+            jb = gblock%yblkme(iblkme)
+            pctshared_xy%blk(ib,jb)%val(1,:,:) = 1. - pctcrop_xy%blk(ib,jb)%val/100.
+            pctshared_xy%blk(ib,jb)%val(2,:,:) = pctcrop_xy%blk(ib,jb)%val/100.
+         ENDDO
+      ENDIF
+      
+      sharedfilter = (/ 1 /)
+
+      CALL pixelsetshared_build (landpatch, gpatch, pctshared_xy, 2, sharedfilter, &
+         pctshared, classshared)
+
+      IF (p_is_worker) THEN
+         IF (landpatch%nset > 0) THEN
+            WHERE (classshared == 2) landpatch%settyp = CROPLAND
+         ENDIF
+      ENDIF
+
+      IF (p_is_io) THEN
+         file_patch = trim(DEF_dir_rawdata) // '/global_CFT_surface_data.nc'
+         CALL allocate_block_data (gcrop, cropdata, N_CFT)
+         CALL ncio_read_block (file_patch, 'PCT_CFT', gcrop, N_CFT, cropdata)
+      ENDIF
+
+      cropfilter = (/ CROPLAND /)
+
+      CALL pixelsetshared_build (landpatch, gcrop, cropdata, N_CFT, cropfilter, &
+         pctshrpch, cropclass, fracin = pctshared)
+
+      numpatch = landpatch%nset
+
+      IF (allocated(pctshared  )) deallocate(pctshared  )
+      IF (allocated(classshared)) deallocate(classshared)
+
+#ifdef USEMPI
+      IF (p_is_worker) THEN
+         CALL mpi_reduce (numpatch, npatch_glb, 1, MPI_INTEGER, MPI_SUM, p_root, p_comm_worker, p_err)
+         IF (p_iam_worker == 0) THEN
+            write(*,'(A,I12,A)') 'Total: ', npatch_glb, ' patches.'
+         ENDIF
+      ENDIF
+
+      CALL mpi_barrier (p_comm_glb, p_err)
+#else
+      write(*,'(A,I12,A)') 'Total: ', numpatch, ' patches.'
+#endif
+
+      CALL elm_patch%build (landelm, landpatch, use_frac = .true., sharedfrac = pctshrpch)
+#ifdef CATCHMENT
+      CALL hru_patch%build (landhru, landpatch, use_frac = .true., sharedfrac = pctshrpch)
+#endif
+
+      CALL write_patchfrac (DEF_dir_landdata, lc_year)
+   
+   END SUBROUTINE landcrop_build
+
+END MODULE MOD_LandCrop
+#endif

--- a/mksrfdata/MOD_LandPFT.F90
+++ b/mksrfdata/MOD_LandPFT.F90
@@ -54,6 +54,9 @@ CONTAINS
       USE MOD_LandPatch
       USE MOD_AggregationRequestData
       USE MOD_Const_LC
+#ifdef CROP
+      USE MOD_LandCrop
+#endif
 
       IMPLICIT NONE
 

--- a/mksrfdata/MOD_SrfdataDiag.F90
+++ b/mksrfdata/MOD_SrfdataDiag.F90
@@ -53,6 +53,9 @@ CONTAINS
       USE MOD_SPMD_Task
       USE MOD_LandElm
       USE MOD_LandPatch
+#ifdef CROP
+      USE MOD_LandCrop
+#endif
 #if (defined LULC_IGBP_PFT || defined LULC_IGBP_PC)
       USE MOD_LandPFT
 #endif
@@ -82,7 +85,7 @@ CONTAINS
 #ifndef CROP
       CALL m_patch2diag%build (landpatch, gdiag)
 #else
-      CALL m_patch2diag%build (landpatch, gdiag, pctcrop)
+      CALL m_patch2diag%build (landpatch, gdiag, pctshrpch)
 #endif
 
 #if (defined LULC_IGBP_PFT || defined LULC_IGBP_PC)

--- a/share/MOD_Pixelset.F90
+++ b/share/MOD_Pixelset.F90
@@ -510,7 +510,7 @@ CONTAINS
    END SUBROUTINE vec_gather_scatter_free_mem
 
    ! --------------------------------
-   SUBROUTINE subset_build (this, superset, subset, use_frac, shadowfrac)
+   SUBROUTINE subset_build (this, superset, subset, use_frac, sharedfrac)
 
       USE MOD_Mesh
       USE MOD_Pixel
@@ -522,7 +522,7 @@ CONTAINS
       TYPE (pixelset_type), intent(in) :: superset
       TYPE (pixelset_type), intent(in) :: subset
       LOGICAL, intent(in) :: use_frac
-      REAL(r8), intent(in), optional :: shadowfrac (:)
+      REAL(r8), intent(in), optional :: sharedfrac (:)
 
       ! Local Variables
       INTEGER :: isuperset, isubset, ielm, ipxl, istt, iend
@@ -576,8 +576,8 @@ CONTAINS
                   pixel%lon_w(mesh(ielm)%ilon(ipxl)), &
                   pixel%lon_e(mesh(ielm)%ilon(ipxl)) )
             ENDDO
-            IF (present(shadowfrac)) THEN
-               this%subfrc(isubset) = this%subfrc(isubset) * shadowfrac(isubset)
+            IF (present(sharedfrac)) THEN
+               this%subfrc(isubset) = this%subfrc(isubset) * sharedfrac(isubset)
             ENDIF
          ENDDO
 


### PR DESCRIPTION
1. 打开PFT&CROP时，聚合的方式改为：先将所有植被合并，形成settyp=1的patch，再根据PFT数据将settyp=1的patch分为自然植被和作物两个共享位置的patch，作物patch根据CFT数据进一步分为多个共享位置的作物patch（多个文件修改）.
2. 侧向流模块：区域模拟时，增加到非模拟区域的出口（main/HYDRO/MOD_Hydro_RiverLakeFlow.F90）.