### PR TITLE
Update MOD_Lulcc_TMatrix.F90

### DIFF
--- a/main/LULCC/MOD_Lulcc_TMatrix.F90
+++ b/main/LULCC/MOD_Lulcc_TMatrix.F90
@@ -59,7 +59,7 @@ MODULE MOD_Lulcc_TMatrix
       USE MOD_NetCDFBlock
       USE MOD_5x5DataReadin
       USE MOD_Namelist, only : DEF_dir_rawdata
-#ifdef CoLMDEBUG
+#ifdef RangeCheck
       USE MOD_RangeCheck
 #endif
       USE MOD_AggregationRequestData


### PR DESCRIPTION
Only when CoLMDEBUG is defined will check_vector_data 