### PR TITLE
1) Fix for solar radiation cosine zenith angle interpolation and change LB/UB forcing when reaching the Upper boundary time; 2) Change the default value of thermk for PFT and PC; 3) Change back to the original setting for the dry case of qg, and unify the same setting for DEF_SPLIT_SOILSNOW.

### DIFF
--- a/main/MOD_Albedo.F90
+++ b/main/MOD_Albedo.F90
@@ -230,7 +230,7 @@ MODULE MOD_Albedo
       ! for nighttime longwave calculations.
       !thermk    = 1.e-3
       IF (lai+sai <= 1.e-6) THEN
-         thermk = 1.e-3
+         thermk = 1.
       ENDIF
       extkb     = 1.
       extkd     = 0.718
@@ -254,7 +254,7 @@ IF (patchtype == 0) THEN
       ssha_p(:,:,ps:pe) = 0.
       ! 07/06/2023, yuan: use the values of previous timestep.
       !thermk_p(ps:pe)   = 1.e-3
-      WHERE (lai_p(ps:pe)+sai_p(ps:pe) <= 1.e-6) thermk_p(ps:pe) = 1.e-3
+      WHERE (lai_p(ps:pe)+sai_p(ps:pe) <= 1.e-6) thermk_p(ps:pe) = 1.
       extkb_p(ps:pe)    = 1.
       extkd_p(ps:pe)    = 0.718
 #endif

--- a/main/MOD_Forcing.F90
+++ b/main/MOD_Forcing.F90
@@ -224,9 +224,9 @@ contains
          ENDIF
          allocate (iforctime(NVAR))
       ENDIF
-      
+
       IF (trim(DEF_forcing%dataset) == 'POINT') then
-      
+
          filename = trim(dir_forcing)//trim(fprefix(1))
 
          IF (ncio_var_exist(filename,'reference_height_v')) THEN
@@ -1370,17 +1370,17 @@ contains
          real(r8) :: calday, cosz
          type(timestamp) :: tstamp
 
-         tstamp = idate ! tstamp_LB(7)
+         tstamp = tstamp_LB(7)
          ntime = 0
-         do while (tstamp <= tstamp_UB(7))
+         do while (tstamp < tstamp_UB(7))
             ntime  = ntime + 1
             tstamp = tstamp + deltim_int
          ENDDO
 
-         tstamp = idate ! tstamp_LB(7)
+         tstamp = tstamp_LB(7)
          call flush_block_data (avgcos, 0._r8)
 
-         do while (tstamp <= tstamp_UB(7))
+         do while (tstamp < tstamp_UB(7))
 
             DO iblkme = 1, gblock%nblkme
                ib = gblock%xblkme(iblkme)

--- a/main/MOD_Forcing.F90
+++ b/main/MOD_Forcing.F90
@@ -681,7 +681,7 @@ contains
 
          ! lower and upper boundary data already exist, cycle
          if ( .NOT.(tstamp_LB(ivar)=='NULL') .AND. .NOT.(tstamp_UB(ivar)=='NULL') .AND. &
-            tstamp_LB(ivar)<=mtstamp .AND. mtstamp<=tstamp_UB(ivar) ) then
+            tstamp_LB(ivar)<=mtstamp .AND. mtstamp<tstamp_UB(ivar) ) then
             cycle
          end if
 
@@ -1370,14 +1370,14 @@ contains
          real(r8) :: calday, cosz
          type(timestamp) :: tstamp
 
-         tstamp = tstamp_LB(7)
+         tstamp = idate !tstamp_LB(7)
          ntime = 0
          do while (tstamp < tstamp_UB(7))
             ntime  = ntime + 1
             tstamp = tstamp + deltim_int
          ENDDO
 
-         tstamp = tstamp_LB(7)
+         tstamp = idate !tstamp_LB(7)
          call flush_block_data (avgcos, 0._r8)
 
          do while (tstamp < tstamp_UB(7))

--- a/main/MOD_Forcing.F90
+++ b/main/MOD_Forcing.F90
@@ -419,10 +419,10 @@ contains
             call block_data_copy (forcn(6), forc_xy_us , sca = 1/sqrt(2.0_r8))
             call block_data_copy (forcn(6), forc_xy_vs , sca = 1/sqrt(2.0_r8))
          ELSE
-	    if (.not.trim(DEF_forcing%dataset) == 'CPL7') then
-                write(6, *) "At least one of the wind components must be provided! stop!";
-                CALL CoLM_stop()
-	    ENDIF
+            if (.not.trim(DEF_forcing%dataset) == 'CPL7') then
+               write(6, *) "At least one of the wind components must be provided! stop!";
+               CALL CoLM_stop()
+            ENDIF
          ENDIF
 
          call flush_block_data (forc_xy_hgt_u, real(HEIGHT_V,r8))
@@ -728,7 +728,7 @@ contains
          end if
 
          ! set upper boundary time stamp and get data
-         if (tstamp_UB(ivar) == 'NULL' .OR. tstamp_UB(ivar) < mtstamp) then
+         if (tstamp_UB(ivar) == 'NULL' .OR. tstamp_UB(ivar) <= mtstamp) then
             if ( .NOT. (tstamp_UB(ivar) == 'NULL') ) then
                call block_data_copy (forcn_UB(ivar), forcn_LB(ivar))
             end if

--- a/main/MOD_Thermal.F90
+++ b/main/MOD_Thermal.F90
@@ -537,13 +537,12 @@ ENDIF
 IF (.not. DEF_SPLIT_SOILSNOW) THEN
       CALL qsadv(t_grnd,forc_psrf,eg,degdT,qsatg,qsatgdT)
 
-      IF (qsatg > forc_q .and. forc_q > qred*qsatg) THEN
-        !qg = forc_q; dqgdT = 0.
-        qsatg = forc_q; qsatgdT = 0.
-      ENDIF
-
       qg     = qred*qsatg
       dqgdT  = qred*qsatgdT
+
+      IF (qsatg > forc_q .and. forc_q > qred*qsatg) THEN
+        qg = forc_q; dqgdT = 0.
+      ENDIF
 
       q_soil = qg
       q_snow = qg
@@ -551,18 +550,14 @@ IF (.not. DEF_SPLIT_SOILSNOW) THEN
 ELSE
       call qsadv(t_soil,forc_psrf,eg,degdT,qsatg,qsatgdT)
 
-      if(qsatg > forc_q .and. forc_q > hr*qsatg)then
-        qsatg = forc_q; qsatgdT = 0.
-      ENDIF
-
       q_soil = hr*qsatg
       dqgdT  = (1.-fsno)*hr*qsatgdT
 
-      call qsadv(t_snow,forc_psrf,eg,degdT,qsatg,qsatgdT)
-
       if(qsatg > forc_q .and. forc_q > hr*qsatg)then
-        qsatg = forc_q; qsatgdT = 0.
+        q_soil = forc_q; dqgdT = 0.
       ENDIF
+
+      call qsadv(t_snow,forc_psrf,eg,degdT,qsatg,qsatgdT)
 
       q_snow = qsatg
       dqgdT  = dqgdT + fsno*qsatgdT


### PR DESCRIPTION
    -fix(MOD_Forcing.F90):
        Change LB/UB forcing when reaching the Upper boundary time. And fix for
        solar radiation cosine zenith angle interpolation. 
        change tstamp_UB < mtstamp ==> tstamp_UB <= mtstamp
        (tstamp <= tstamp_UB) ==> (tstamp < tstamp_UB)
        NOTE: this bug mainly affect the step-wise modeling results for point case,
        which cases one time step lag of solar input radiation.
        [co-by @Wenzong Dong and @Shupeng Zhang]

    -fix&mod(MOD_Albedo.F90):
        Change the default value of thermk for PFT and PC. 
        set thermk from 1.e-3 ==> 1. when lai+sai<1.e-6.
        Bugs raised from running BGC in PC case. [by @Xingjie Lu]

    -fix(MOD_Thermal.F90):
        when (qsatg > forc_q .and. forc_q > qred*qsatg), change
          qsatg = forc_q; qsatgdT = 0.
        back to
          qg = forc_q; dqgdT = 0.
        cause there may be some fluctuations for some dry soil cases
        which will mainly affact the stepwise modeling results. [by @Zhuo Liu]