### PR TITLE
1. 基于数据进行土壤和积雪状态的初始化； 2. 改进文件中单元内像素点的存储；3. 几个变量或子程序名的调整

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,8 +214,6 @@ OBJS_CAMA_T = $(addprefix .bld/,${OBJECTS_CAMA})
 endif
 
 OBJS_MAIN = \
-				MOD_DA_GRACE.o                            \
-				MOD_DataAssimilation.o                    \
 				MOD_Hydro_BasinNeighbour.o                \
 				MOD_Hydro_HillslopeFlow.o                 \
 				MOD_Hydro_SubsurfaceFlow.o                \
@@ -258,6 +256,8 @@ OBJS_MAIN = \
 				MOD_UserSpecifiedForcing.o                \
 				MOD_ForcingDownscaling.o                  \
 				MOD_Forcing.o                             \
+				MOD_DA_GRACE.o                            \
+				MOD_DataAssimilation.o                    \
 				MOD_AssimStomataConductance.o             \
 				MOD_PlantHydraulic.o                      \
 				MOD_FrictionVelocity.o                    \

--- a/main/CoLMMAIN.F90
+++ b/main/CoLMMAIN.F90
@@ -157,7 +157,7 @@ SUBROUTINE CoLMMAIN ( &
   USE MOD_Albedo
   USE MOD_LAIEmpirical
   USE MOD_TimeManager
-  USE MOD_Namelist, only: DEF_Interception_scheme, DEF_USE_VARIABLY_SATURATED_FLOW, &
+  USE MOD_Namelist, only: DEF_Interception_scheme, DEF_USE_VariablySaturatedFlow, &
                           DEF_USE_PLANTHYDRAULICS, DEF_USE_IRRIGATION
   USE MOD_LeafInterception
 #if(defined CaMa_Flood)
@@ -618,7 +618,7 @@ IF (patchtype <= 2) THEN ! <=== is - URBAN and BUILT-UP   (patchtype = 1)
 
       totwb = ldew + scv + sum(wice_soisno(1:)+wliq_soisno(1:)) + wa
 
-      IF (DEF_USE_VARIABLY_SATURATED_FLOW) THEN
+      IF (DEF_USE_VariablySaturatedFlow) THEN
          totwb = totwb + wdsrf
          IF (patchtype == 2) THEN
             totwb = totwb + wetwat
@@ -736,9 +736,9 @@ ENDIF
            pg_snow           ,t_precip          ,qintr_rain        ,qintr_snow        ,&
            snofrz(lbsn:0)    ,sabg_snow_lyr(lb:1)                                      )
 
-      IF (.not. DEF_USE_VARIABLY_SATURATED_FLOW) THEN
+      IF (.not. DEF_USE_VariablySaturatedFlow) THEN
 
-         CALL WATER (ipatch     ,patchtype         ,lb                ,nl_soil           ,&
+         CALL WATER_2014 (ipatch,patchtype         ,lb                ,nl_soil           ,&
               deltim            ,z_soisno(lb:)     ,dz_soisno(lb:)    ,zi_soisno(lb-1:)  ,&
               bsw               ,porsl             ,psi0              ,hksati            ,&
               rootr,rootflux    ,t_soisno(lb:)     ,wliq_soisno(lb:)  ,wice_soisno(lb:)  ,smp,hk,&
@@ -863,7 +863,7 @@ ENDIF
       ! ----------------------------------------
       endwb=sum(wice_soisno(1:)+wliq_soisno(1:))+ldew+scv + wa
 
-      IF (DEF_USE_VARIABLY_SATURATED_FLOW) THEN
+      IF (DEF_USE_VariablySaturatedFlow) THEN
          endwb = endwb + wdsrf
          IF (patchtype == 2) THEN
             endwb = endwb + wetwat
@@ -888,7 +888,7 @@ ENDIF
       if (DEF_USE_IRRIGATION) errorw = errorw - irrig_rate(ipatch)*deltim
 #endif
 
-      IF (.not. DEF_USE_VARIABLY_SATURATED_FLOW) THEN
+      IF (.not. DEF_USE_VariablySaturatedFlow) THEN
          IF (patchtype==2) errorw=0.    !wetland
       ENDIF
 
@@ -932,7 +932,7 @@ ELSE IF(patchtype == 3)THEN   ! <=== is LAND ICE (glacier/ice sheet) (patchtype 
       ENDDO
 
       totwb = scv + sum(wice_soisno(1:)+wliq_soisno(1:))
-      IF (DEF_USE_VARIABLY_SATURATED_FLOW) THEN
+      IF (DEF_USE_VariablySaturatedFlow) THEN
          totwb = wdsrf + totwb
       ENDIF
 
@@ -1031,7 +1031,7 @@ ELSE IF(patchtype == 3)THEN   ! <=== is LAND ICE (glacier/ice sheet) (patchtype 
                    ssi         ,wimp        ,forc_us    ,forc_vs     )
       ENDIF
 
-      IF (.not. DEF_USE_VARIABLY_SATURATED_FLOW) THEN
+      IF (.not. DEF_USE_VariablySaturatedFlow) THEN
          rsur = max(0.0,gwat)
          rnof = rsur
       ELSE
@@ -1063,7 +1063,7 @@ ELSE IF(patchtype == 3)THEN   ! <=== is LAND ICE (glacier/ice sheet) (patchtype 
       zerr=errore
 
       endwb = scv + sum(wice_soisno(1:)+wliq_soisno(1:))
-      IF (DEF_USE_VARIABLY_SATURATED_FLOW) THEN
+      IF (DEF_USE_VariablySaturatedFlow) THEN
          endwb = wdsrf + endwb
       ENDIF
 
@@ -1074,7 +1074,7 @@ ELSE IF(patchtype == 3)THEN   ! <=== is LAND ICE (glacier/ice sheet) (patchtype 
 #endif
 
 #if(defined CoLMDEBUG)
-      IF (DEF_USE_VARIABLY_SATURATED_FLOW) THEN
+      IF (DEF_USE_VariablySaturatedFlow) THEN
          IF (abs(errorw) > 1.e-3) THEN
             write(6,*) 'Warning: water balance violation in CoLMMAIN (land ice) ', errorw
             CALL CoLM_stop ()
@@ -1082,7 +1082,7 @@ ELSE IF(patchtype == 3)THEN   ! <=== is LAND ICE (glacier/ice sheet) (patchtype 
       ENDIF
 #endif
 
-      IF (DEF_USE_VARIABLY_SATURATED_FLOW) THEN
+      IF (DEF_USE_VariablySaturatedFlow) THEN
          xerr=errorw/deltim
       ELSE
          xerr = 0.
@@ -1095,7 +1095,7 @@ ELSE IF(patchtype == 4) THEN   ! <=== is LAND WATER BODIES (lake, reservior and 
 !======================================================================
 
       totwb = scv + sum(wice_soisno(1:)+wliq_soisno(1:)) + wa
-      IF (DEF_USE_VARIABLY_SATURATED_FLOW) THEN
+      IF (DEF_USE_VariablySaturatedFlow) THEN
          totwb = totwb + wdsrf
       ENDIF
 
@@ -1205,7 +1205,7 @@ ELSE IF(patchtype == 4) THEN   ! <=== is LAND WATER BODIES (lake, reservior and 
       a = (sum(wliq_soisno(1:))+sum(wice_soisno(1:))+scv-w_old-scvold)/deltim
       aa = qseva+qsubl-qsdew-qfros
 
-      IF (.not. DEF_USE_VARIABLY_SATURATED_FLOW) THEN
+      IF (.not. DEF_USE_VariablySaturatedFlow) THEN
          rsur = max(0., pg_rain + pg_snow - aa - a)
          rnof = rsur
       ELSE
@@ -1232,7 +1232,7 @@ ELSE IF(patchtype == 4) THEN   ! <=== is LAND WATER BODIES (lake, reservior and 
       ENDIF
 
       endwb  = scv + sum(wice_soisno(1:)+wliq_soisno(1:)) + wa
-      IF (DEF_USE_VARIABLY_SATURATED_FLOW) THEN
+      IF (DEF_USE_VariablySaturatedFlow) THEN
          endwb  = endwb  + wdsrf
       ENDIF
 
@@ -1242,7 +1242,7 @@ ELSE IF(patchtype == 4) THEN   ! <=== is LAND WATER BODIES (lake, reservior and 
 #endif
 
 #if(defined CoLMDEBUG)
-      IF (DEF_USE_VARIABLY_SATURATED_FLOW) THEN
+      IF (DEF_USE_VariablySaturatedFlow) THEN
          IF (abs(errorw) > 1.e-3) THEN
             write(*,*) 'Warning: water balance violation in CoLMMAIN (lake) ', errorw
             CALL CoLM_stop ()
@@ -1250,7 +1250,7 @@ ELSE IF(patchtype == 4) THEN   ! <=== is LAND WATER BODIES (lake, reservior and 
       ENDIF
 #endif
 
-      IF (DEF_USE_VARIABLY_SATURATED_FLOW) THEN
+      IF (DEF_USE_VariablySaturatedFlow) THEN
          xerr = errorw / deltim
       ELSE
          xerr = 0.
@@ -1502,7 +1502,7 @@ ENDIF
        rootflux      = 0.
        zwt           = 0.
 
-       IF (.not. DEF_USE_VARIABLY_SATURATED_FLOW) THEN
+       IF (.not. DEF_USE_VariablySaturatedFlow) THEN
           wa = 4800.
        ENDIF
 
@@ -1514,7 +1514,7 @@ ENDIF
 
     h2osoi = wliq_soisno(1:)/(dz_soisno(1:)*denh2o) + wice_soisno(1:)/(dz_soisno(1:)*denice)
 
-    IF (DEF_USE_VARIABLY_SATURATED_FLOW) THEN
+    IF (DEF_USE_VariablySaturatedFlow) THEN
        wat = sum(wice_soisno(1:)+wliq_soisno(1:))+ldew+scv+wetwat
     ELSE
        wat = sum(wice_soisno(1:)+wliq_soisno(1:))+ldew+scv + wa

--- a/main/MOD_HistWriteBack.F90
+++ b/main/MOD_HistWriteBack.F90
@@ -58,9 +58,9 @@ module MOD_HistWriteBack
    real(r8), allocatable :: lon_c(:), lon_w(:), lon_e(:)
 
    ! 2: catchment based; 3: unstructured 
-   integer :: SDimLength 
-   integer*8, allocatable :: vindex1(:)
-   integer,   allocatable :: vindex2(:)
+   ! integer :: SDimLength 
+   ! integer*8, allocatable :: vindex1(:)
+   ! integer,   allocatable :: vindex2(:)
 
    ! Memory limits
    integer*8, parameter :: MaxHistMemSize  = 8589934592_8 ! 8*1024^3 
@@ -807,8 +807,9 @@ contains
       IF (allocated(lon_c   )) deallocate(lon_c   )
       IF (allocated(lon_w   )) deallocate(lon_w   )
       IF (allocated(lon_e   )) deallocate(lon_e   )
-      IF (allocated(vindex1 )) deallocate(vindex1 )
-      IF (allocated(vindex2 )) deallocate(vindex2 )
+      
+      ! IF (allocated(vindex1 )) deallocate(vindex1 )
+      ! IF (allocated(vindex2 )) deallocate(vindex2 )
       
       IF (.not. p_is_writeback) THEN
          CALL mpi_barrier (p_comm_glb, p_err)

--- a/main/MOD_NewSnow.F90
+++ b/main/MOD_NewSnow.F90
@@ -26,7 +26,7 @@ MODULE MOD_NewSnow
 !=======================================================================
 !
    use MOD_Precision
-   USE MOD_Namelist, only : DEF_USE_VARIABLY_SATURATED_FLOW
+   USE MOD_Namelist, only : DEF_USE_VariablySaturatedFlow
    use MOD_Const_Physical, only : tfrz, cpliq, cpice
 
    implicit none
@@ -72,7 +72,7 @@ MODULE MOD_NewSnow
        scv = scv + pg_snow*deltim            ! snow water equivalent (mm)
 
        if(patchtype==2 .AND. t_grnd>tfrz)then  ! snowfall on warmer wetland
-          IF (present(wetwat) .and. DEF_USE_VARIABLY_SATURATED_FLOW) THEN
+          IF (present(wetwat) .and. DEF_USE_VariablySaturatedFlow) THEN
              wetwat = wetwat + scv
           ENDIF
           scv=0.; snowdp=0.; sag=0.; fsno = 0.

--- a/main/MOD_SoilSnowHydrology.F90
+++ b/main/MOD_SoilSnowHydrology.F90
@@ -19,7 +19,7 @@ MODULE MOD_SoilSnowHydrology
   SAVE
 
 ! PUBLIC MEMBER FUNCTIONS:
-  public :: WATER
+  public :: WATER_2014
   PUBLIC :: WATER_VSF
   public :: snowwater
   public :: soilwater
@@ -39,7 +39,7 @@ MODULE MOD_SoilSnowHydrology
 
 
 
-  subroutine WATER (ipatch,patchtype  ,lb          ,nl_soil ,deltim,&
+  subroutine WATER_2014 (ipatch,patchtype,lb       ,nl_soil ,deltim,&
              z_soisno    ,dz_soisno   ,zi_soisno                   ,&
              bsw         ,porsl       ,psi0        ,hksati  ,rootr ,rootflux, &
              t_soisno    ,wliq_soisno ,wice_soisno ,smp     ,hk    ,pg_rain ,sm    ,&
@@ -65,12 +65,12 @@ MODULE MOD_SoilSnowHydrology
 !
 ! Original author : Yongjiu Dai, /09/1999/, /08/2002/, /04/2014/
 !
-! FLOW DIAGRAM FOR WATER.F90
+! FLOW DIAGRAM FOR WATER_2014.F90
 !
-! WATER ===> snowwater
-!            surfacerunoff
-!            soilwater
-!            subsurfacerunoff
+! WATER_2014 ===> snowwater
+!                 surfacerunoff
+!                 soilwater
+!                 subsurfacerunoff
 !
 !=======================================================================
 
@@ -420,7 +420,7 @@ ENDIF
 
   endif
 
-  end subroutine WATER
+  end subroutine WATER_2014
 
 !-----------------------------------------------------------------------
   subroutine WATER_VSF (ipatch,  patchtype,lb      ,nl_soil ,deltim ,&
@@ -464,13 +464,6 @@ ENDIF
 !    Modeling Variably Saturated Flow in Stratified Soils
 !      With Explicit Tracking of Wetting Front and Water Table Locations.
 !    Water Resources Research. doi:10.1029/2019wr025368
-!
-! FLOW DIAGRAM FOR WATER_VSF.F90
-!
-! WATER ===> snowwater
-!            surfacerunoff     [caculated by lateral flow when defined Lateral_Flow]
-!            subsurfacerunoff  [caculated by lateral flow when defined Lateral_Flow]
-!            soilwater         [Variably Saturated Flow algorithm]
 !
 !===================================================================================
 

--- a/main/URBAN/MOD_Urban_Hydrology.F90
+++ b/main/URBAN/MOD_Urban_Hydrology.F90
@@ -221,7 +221,7 @@ CONTAINS
 ! [1] for pervious road, the same as soil
 !=======================================================================
       rootflux(:) = rootr(:)*etr
-      CALL WATER ( ipatch,patchtype   ,lbp         ,nl_soil   ,deltim    ,&
+      CALL WATER_2014 (ipatch,patchtype, lbp       ,nl_soil   ,deltim    ,&
              z_gpersno   ,dz_gpersno  ,zi_gpersno  ,&
              bsw         ,porsl       ,psi0        ,hksati,rootr,rootflux,&
              t_gpersno   ,wliq_gpersno,wice_gpersno,smp,hk,pgper_rain,sm_gper,&

--- a/mkinidata/CoLMINI.F90
+++ b/mkinidata/CoLMINI.F90
@@ -47,6 +47,8 @@ PROGRAM CoLMINI
    USE MOD_HRUVector
 #endif
    USE MOD_Initialize
+   ! SNICAR
+   USE MOD_SnowSnicar, only: SnowAge_init, SnowOptics_init
    implicit none
 
    ! ----------------local variables ---------------------------------
@@ -137,6 +139,10 @@ PROGRAM CoLMINI
    CALL hru_vector_init ()
 #endif
 #endif
+
+   ! Read in SNICAR optical and aging parameters
+   CALL SnowOptics_init( DEF_file_snowoptics ) ! SNICAR optical parameters
+   CALL SnowAge_init( DEF_file_snowaging )     ! SNICAR aging   parameters
 
    CALL initialize (casename, dir_landdata, dir_restart, idate, lc_year, greenwich)
 

--- a/mkinidata/MOD_IniTimeVariable.F90
+++ b/mkinidata/MOD_IniTimeVariable.F90
@@ -121,7 +121,7 @@ CONTAINS
          soil_t(nl_soil_ini),    &! soil temperature from initial file (K)
          soil_w(nl_soil_ini)      ! soil wetness from initial file (-)
    
-   LOGICAL, intent(in)  :: use_snowini
+   LOGICAL,  intent(in) :: use_snowini
    REAL(r8), intent(in) :: snow_d ! snow depth (m)
 
    LOGICAL,  intent(in) :: use_wtd

--- a/mkinidata/MOD_IniTimeVariable.F90
+++ b/mkinidata/MOD_IniTimeVariable.F90
@@ -60,7 +60,7 @@ CONTAINS
                      ,diagVX_n_vr_acc            , upperVX_n_vr_acc           , lowerVX_n_vr_acc           &
 !------------------------------------------------------------
 #endif
-                     ,use_soilini, nl_soil_ini, soil_z,   soil_t,   soil_w, snow_d     &
+                     ,use_soilini, nl_soil_ini, soil_z,   soil_t,   soil_w, use_snowini, snow_d &
                      ,use_wtd,     zwtmm,       zc_soimm, zi_soimm, vliq_r, nprms, prms)
 
 !=======================================================================
@@ -71,7 +71,7 @@ CONTAINS
 
    USE MOD_Precision
    USE MOD_Utils
-   USE MOD_Const_Physical, only: tfrz
+   USE MOD_Const_Physical, only: tfrz, denh2o, denice
    USE MOD_Vars_TimeVariables, only: tlai, tsai, wdsrf
    USE MOD_Const_PFT, only: isevg, woody, leafcn, deadwdcn, slatop
    USE MOD_Vars_TimeInvariants, only : ibedrock, dbedrock
@@ -119,8 +119,10 @@ CONTAINS
    REAL(r8), intent(in) ::       &!
          soil_z(nl_soil_ini),    &! soil layer depth for initial (m)
          soil_t(nl_soil_ini),    &! soil temperature from initial file (K)
-         soil_w(nl_soil_ini),    &! soil wetness from initial file (-)
-         snow_d                   ! snow depth (m)
+         soil_w(nl_soil_ini)      ! soil wetness from initial file (-)
+   
+   LOGICAL, intent(in)  :: use_snowini
+   REAL(r8), intent(in) :: snow_d ! snow depth (m)
 
    LOGICAL,  intent(in) :: use_wtd
    REAL(r8), intent(in) :: zwtmm
@@ -168,9 +170,11 @@ CONTAINS
          thermk,                 &! canopy gap fraction for tir radiation
          extkb,                  &! (k, g(mu)/mu) direct solar extinction coefficient
          extkd,                  &! diffuse and scattered diffuse PAR extinction coefficient
-         wa,                     &! water storage in aquifer [mm]
-         zwt,                    &! the depth to water table [m]
+         wa                       ! water storage in aquifer [mm]
+   REAL(r8), intent(inout) ::    &!
+         zwt                      ! the depth to water table [m]
 
+   REAL(r8), intent(out) ::      &!
          snw_rds  ( maxsnl+1:0 ), &! effective grain radius (col,lyr) [microns, m-6]
          mss_bcphi( maxsnl+1:0 ), &! mass concentration of hydrophilic BC (col,lyr) [kg/kg]
          mss_bcpho( maxsnl+1:0 ), &! mass concentration of hydrophobic BC (col,lyr) [kg/kg]
@@ -315,7 +319,7 @@ CONTAINS
 #endif
 
         INTEGER j, snl, m, ivt
-        REAL(r8) wet(nl_soil), vliq, wt, ssw, oro, rhosno_ini, a
+        REAL(r8) wet(nl_soil), zi_soi_a(0:nl_soil), psi, vliq, wt, ssw, oro, rhosno_ini, a
 
         ! SNICAR
         REAL(r8) pg_snow                 ! snowfall onto ground including canopy runoff [kg/(m2 s)]
@@ -325,51 +329,116 @@ CONTAINS
 
    !-----------------------------------------------------------------------
    IF(patchtype <= 5)THEN ! land grid
-
+      
       ! (1) SOIL temperature, water and SNOW
       ! Variables: t_soisno, wliq_soisno, wice_soisno
       !            snowdp, sag, scv, fsno, snl, z_soisno, dz_soisno
       IF (use_soilini) THEN
 
+         zi_soi_a(:) = (/0., zi_soi/)
+               
          DO j = 1, nl_soil
             CALL polint(soil_z,soil_t,nl_soil_ini,z_soisno(j),t_soisno(j))
-            CALL polint(soil_z,soil_w,nl_soil_ini,z_soisno(j),wet(j))
-            a = min(soil_t(1),soil_t(2),soil_t(3))-5.
-            t_soisno(j) = max(t_soisno(j), a)
-            a = max(soil_t(1),soil_t(2),soil_t(3))+5.
-            t_soisno(j) = min(t_soisno(j), a)
+         ENDDO
 
-            a = min(soil_w(1),soil_w(2),soil_w(3))
-            wet(j) = max(wet(j), a, 0.1)
-            a = max(soil_w(1),soil_w(2),soil_w(3))
-            wet(j) = min(wet(j), a, 0.5)
+         IF (patchtype <= 1) THEN ! soil or urban
 
-            wet(j) = min(wet(j), porsl(j))
+            DO j = 1, nl_soil
 
-            IF(t_soisno(j).ge.tfrz)THEN
-               wliq_soisno(j) = wet(j)*dz_soisno(j)*1000.
-               wice_soisno(j) = 0.
+               CALL polint(soil_z,soil_w,nl_soil_ini,z_soisno(j),wet(j))
+
+               wet(j) = min(max(wet(j),0.), porsl(j))
+
+               IF (zwt <= zi_soi_a(j-1))  THEN
+                  wet(j) = porsl(j)
+               ELSEIF (zwt < zi_soi_a(j)) THEN
+                  wet(j) = ((zi_soi_a(j)-zwt)*porsl(j) + (zwt-zi_soi_a(j-1))*wet(j)) &
+                     / (zi_soi_a(j)-zi_soi_a(j-1))
+               ENDIF
+
+               IF(t_soisno(j).ge.tfrz)THEN
+                  wliq_soisno(j) = wet(j)*dz_soisno(j)*denh2o
+                  wice_soisno(j) = 0.
+               ELSE
+                  wliq_soisno(j) = 0.
+                  wice_soisno(j) = wet(j)*dz_soisno(j)*denice
+               ENDIF
+            ENDDO
+
+            ! get wa from zwt
+            IF (zwt > zi_soi_a(nl_soil)) THEN
+               psi  = psi0(nl_soil) - (zwt*1000. - zi_soi_a(nl_soil)*1000.) * 0.5
+               vliq = soil_vliq_from_psi (psi, porsl(nl_soil), vliq_r(nl_soil), psi0(nl_soil), &
+                  nprms, prms(:,nl_soil))
+               wa   = -(zwt*1000. - zi_soi_a(nl_soil)*1000.)*(porsl(nl_soil)-vliq)
             ELSE
+               wa = 0.
+            ENDIF
+
+         ELSEIF ((patchtype == 2) .or. (patchtype == 4)) THEN ! (2) wetland or (4) lake
+
+            DO j = 1, nl_soil
+               IF(t_soisno(j).ge.tfrz)THEN
+                  wliq_soisno(j) = porsl(j)*dz_soisno(j)*denh2o
+                  wice_soisno(j) = 0.
+               ELSE
+                  wliq_soisno(j) = 0.
+                  wice_soisno(j) = porsl(j)*dz_soisno(j)*denice
+               ENDIF
+            ENDDO
+
+            wa = 0.
+
+         ELSEIF (patchtype == 3) THEN ! land ice
+            
+            DO j = 1, nl_soil
                wliq_soisno(j) = 0.
-               wice_soisno(j) = wet(j)*dz_soisno(j)*1000.
+               wice_soisno(j) = dz_soisno(j)*denice
+            ENDDO
+            
+            wa = 0.
+
+         ENDIF
+
+         IF (.not. DEF_USE_VariablySaturatedFlow) THEN
+            wa = wa + 5000.
+         ENDIF
+
+      ELSE
+
+         ! soil temperature, water content
+         DO j = 1, nl_soil
+            IF(patchtype==3)THEN !land ice
+               t_soisno(j) = 253.
+               wliq_soisno(j) = 0.
+               wice_soisno(j) = dz_soisno(j)*denice
+            ELSE
+               t_soisno(j) = 283.
+               wliq_soisno(j) = dz_soisno(j)*porsl(j)*denh2o
+               wice_soisno(j) = 0.
             ENDIF
          ENDDO
 
+      ENDIF
+
+      z0m = htop * z0mr
+#if (defined LULC_IGBP_PFT || defined LULC_IGBP_PC)
+      IF(patchtype==0)THEN
+         ps = patch_pft_s(ipatch)
+         pe = patch_pft_e(ipatch)
+         IF (ps>0 .and. pe>0) THEN
+            z0m_p(ps:pe) = htop_p(ps:pe) * z0mr
+         ENDIF
+      ENDIF
+#endif
+
+      IF (use_snowini) THEN
+         
          rhosno_ini = 250.
          snowdp = snow_d
          sag    = 0.
          scv    = snowdp*rhosno_ini
-         z0m    = htop * z0mr
-#if (defined LULC_IGBP_PFT || defined LULC_IGBP_PC)
-         IF(patchtype==0)THEN
-            ps = patch_pft_s(ipatch)
-            pe = patch_pft_e(ipatch)
-            IF (ps>0 .and. pe>0) THEN
-               z0m_p(ps:pe) = htop_p(ps:pe) * z0mr
-            ENDIF
-         ENDIF
-#endif
-
+         
          ! 08/02/2019, yuan: NOTE! need to be changed in future
          ! for LULC_IGBP_PFT or LULC_IGBP_PC
          ! have done but not for SOILINI right now
@@ -394,34 +463,11 @@ CONTAINS
 
       ELSE
 
-         ! soil temperature, water content
-         DO j = 1, nl_soil
-            IF(patchtype==3)THEN !land ice
-               t_soisno(j) = 253.
-               wliq_soisno(j) = 0.
-               wice_soisno(j) = dz_soisno(j)*1000.
-            ELSE
-               t_soisno(j) = 283.
-               wliq_soisno(j) = dz_soisno(j)*porsl(j)*1000.
-               wice_soisno(j) = 0.
-            ENDIF
-         ENDDO
-
          snowdp = 0.
          sag    = 0.
          scv    = 0.
          fsno   = 0.
          snl    = 0
-         z0m    = htop * z0mr
-#if (defined LULC_IGBP_PFT || defined LULC_IGBP_PC)
-         IF(patchtype==0)THEN
-            ps = patch_pft_s(ipatch)
-            pe = patch_pft_e(ipatch)
-            IF (ps>0 .and. pe>0) THEN
-               z0m_p(ps:pe) = htop_p(ps:pe) * z0mr
-            ENDIF
-         ENDIF
-#endif
 
          ! snow temperature and water content
          t_soisno   (maxsnl+1:0) = -999.
@@ -436,14 +482,16 @@ CONTAINS
       ! Variables: wa, zwt
       IF (.not. use_wtd) THEN
 
-         IF (DEF_USE_VARIABLY_SATURATED_FLOW) THEN
-            wa  = 0.
-            zwt = zi_soimm(nl_soil)/1000.
-         ELSE
-            ! water table depth (initially at 1.0 m below the model bottom; wa when zwt
-            !                    is below the model bottom zi(nl_soil)
-            wa  = 4800.                             !assuming aquifer capacity is 5000 mm
-            zwt = (25. + z_soisno(nl_soil))+dz_soisno(nl_soil)/2. - wa/1000./0.2 !to result in zwt = zi(nl_soil) + 1.0 m
+         IF (.not. use_soilini) THEN
+            IF (DEF_USE_VariablySaturatedFlow) THEN
+               wa  = 0.
+               zwt = zi_soimm(nl_soil)/1000.
+            ELSE
+               ! water table depth (initially at 1.0 m below the model bottom; wa when zwt
+               !                    is below the model bottom zi(nl_soil)
+               wa  = 4800.                             !assuming aquifer capacity is 5000 mm
+               zwt = (25. + z_soisno(nl_soil))+dz_soisno(nl_soil)/2. - wa/1000./0.2 !to result in zwt = zi(nl_soil) + 1.0 m
+            ENDIF
          ENDIF
       ELSE
          IF (patchtype <= 1) THEN
@@ -452,6 +500,10 @@ CONTAINS
          ELSE
             wa  = 0.
             zwt = 0.
+         ENDIF
+
+         IF (.not. DEF_USE_VariablySaturatedFlow) THEN
+            wa = wa + 5000.
          ENDIF
       ENDIF
 

--- a/mkinidata/MOD_Initialize.F90
+++ b/mkinidata/MOD_Initialize.F90
@@ -102,23 +102,26 @@ MODULE MOD_Initialize
       real(r8) :: rlon, rlat
 
       ! for SOIL INIT of water, temperature, snow depth
-      LOGICAL :: use_soilini
+      LOGICAL :: use_soilini, use_snowini
 
-      character(len=256) :: fsoildat
-      type(grid_type) :: gsoil
-      type(mapping_grid2pset_type) :: ms2p
+      character(len=256) :: fsoildat, fsnowdat
+      type(grid_type) :: gsoil, gsnow
+      type(mapping_grid2pset_type) :: msoil2p, msnow2p
 
-      integer :: nl_soil_ini
+      integer  :: nl_soil_ini
+      real(r8) :: missing_value
 
       real(r8), allocatable :: soil_z(:)
 
       type(block_data_real8_2d) :: snow_d_grid
       type(block_data_real8_3d) :: soil_t_grid
       type(block_data_real8_3d) :: soil_w_grid
+      type(block_data_real8_2d) :: zwt_grid
 
       real(r8), allocatable :: snow_d(:)
       real(r8), allocatable :: soil_t(:,:)
       real(r8), allocatable :: soil_w(:,:)
+      logical , allocatable :: mvalmask(:)
 
       ! for SOIL Water INIT by using water table depth
       LOGICAL  :: use_wtd
@@ -451,10 +454,10 @@ MODULE MOD_Initialize
       !2.3 READ in or GUSSES land state information
       ! ...........................................
 
-      ! for SOIL INIT of water, temperature, snow depth
-      IF (DEF_USE_SOIL_INIT) THEN
+      ! for SOIL INIT of water, temperature
+      IF (DEF_USE_SoilInit) THEN
 
-         fsoildat = DEF_file_soil_init
+         fsoildat = DEF_file_SoilInit
          IF (p_is_master) THEN
             inquire (file=trim(fsoildat), exist=use_soilini)
          ENDIF
@@ -464,35 +467,66 @@ MODULE MOD_Initialize
 
          IF (use_soilini) THEN
 
-            call ncio_read_bcast_serial (fsoildat, 'soil_z', soil_z)
+            ! soil layer depth (m)
+            call ncio_read_bcast_serial (fsoildat, 'soildepth', soil_z)
+           
             nl_soil_ini = size(soil_z)
+            
+            call gsoil%define_from_file (fsoildat, latname = 'lat', lonname = 'lon')
+         
+            CALL julian2monthday (idate(1), idate(2), month, mday)
+         
+            IF (p_is_master) THEN
+               CALL ncio_get_attr (fsoildat, 'zwt', 'missing_value', missing_value)
+            ENDIF
+#ifdef USEMPI
+            CALL mpi_bcast (missing_value, 1, MPI_REAL8, p_root, p_comm_glb, p_err)
+#endif
 
             if (p_is_io) then
                ! soil layer temperature (K)
-               call allocate_block_data (gsoil, soil_t_grid, nl_soil_ini)
-               call ncio_read_block (fsoildat, 'soil_t', gsoil, nl_soil_ini, soil_t_grid)
+               call allocate_block_data  (gsoil, soil_t_grid, nl_soil_ini)
+               call ncio_read_block_time (fsoildat, 'soiltemp', &
+                  gsoil, nl_soil_ini, month, soil_t_grid)
                ! soil layer wetness (-)
-               call allocate_block_data (gsoil, soil_w_grid, nl_soil_ini)
-               call ncio_read_block (fsoildat, 'soil_w', gsoil, nl_soil_ini, soil_w_grid)
-               ! snow depth (m)
-               call allocate_block_data (gsoil, snow_d_grid)
-               call ncio_read_block (fsoildat, 'snow_d', gsoil, snow_d_grid)
+               call allocate_block_data  (gsoil, soil_w_grid, nl_soil_ini)
+               call ncio_read_block_time (fsoildat, 'soilwat', &
+                  gsoil, nl_soil_ini, month, soil_w_grid)
+               ! water table depth (m)
+               call allocate_block_data (gsoil, zwt_grid)
+               call ncio_read_block_time (fsoildat, 'zwt', gsoil, month, zwt_grid)
             end if
-
-            call gsoil%define_from_file (fsoildat)
-            call ms2p%build (gsoil, landpatch)
 
             if (p_is_worker) then
-               nl_soil_ini = nl_soil
-               allocate (soil_z (nl_soil_ini))
-               allocate (snow_d (numpatch))
-               allocate (soil_t (nl_soil_ini,numpatch))
-               allocate (soil_w (nl_soil_ini,numpatch))
+               IF (numpatch > 0) THEN
+                  allocate (soil_t (nl_soil_ini,numpatch))
+                  allocate (soil_w (nl_soil_ini,numpatch))
+                  allocate (mvalmask (numpatch))
+               ENDIF
             end if
 
-            call ms2p%map_aweighted (soil_t_grid, nl_soil_ini, soil_t)
-            call ms2p%map_aweighted (soil_w_grid, nl_soil_ini, soil_w)
-            call ms2p%map_aweighted (snow_d_grid, snow_d)
+            call msoil2p%build (gsoil, landpatch, zwt_grid, missing_value, mvalmask)
+            call msoil2p%map_aweighted (soil_t_grid, nl_soil_ini, soil_t)
+            call msoil2p%map_aweighted (soil_w_grid, nl_soil_ini, soil_w)
+            call msoil2p%map_aweighted (zwt_grid, zwt)
+
+            IF (p_is_worker) THEN
+               DO i = 1, numpatch
+                  IF (.not. mvalmask(i)) THEN
+                     IF (patchtype(i) == 3) THEN
+                        soil_t(:,i) = 250.
+                     ELSE
+                        soil_t(:,i) = 280.
+                     ENDIF
+
+                     soil_w(:,i) = 1.
+                     zwt(i) = 0.
+
+                  ENDIF
+               ENDDO
+            ENDIF
+
+            IF (allocated(mvalmask)) deallocate(mvalmask)
 
          ENDIF
 
@@ -504,16 +538,75 @@ MODULE MOD_Initialize
          !! not used, just for filling arguments
          if (p_is_worker) then
             allocate (soil_z (nl_soil))
-            allocate (snow_d (numpatch))
             allocate (soil_t (nl_soil,numpatch))
             allocate (soil_w (nl_soil,numpatch))
          end if
       ENDIF
 
+      if (p_is_worker) then
+         IF (numpatch > 0) THEN
+            allocate (snow_d (numpatch))
+         ENDIF
+      end if
+
+      IF (DEF_USE_SnowInit) THEN
+
+         fsnowdat = DEF_file_SnowInit
+         IF (p_is_master) THEN
+            inquire (file=trim(fsnowdat), exist=use_snowini)
+         ENDIF
+#ifdef USEMPI
+         call mpi_bcast (use_snowini, 1, MPI_LOGICAL, p_root, p_comm_glb, p_err)
+#endif
+
+         IF (use_snowini) THEN
+
+            call gsnow%define_from_file (fsnowdat, latname = 'lat', lonname = 'lon')
+         
+            CALL julian2monthday (idate(1), idate(2), month, mday)
+
+            IF (p_is_master) THEN
+               CALL ncio_get_attr (fsnowdat, 'snowdepth', 'missing_value', missing_value)
+            ENDIF
+#ifdef USEMPI
+            CALL mpi_bcast (missing_value, 1, MPI_REAL8, p_root, p_comm_glb, p_err)
+#endif
+
+            if (p_is_io) then
+               ! snow depth (m)
+               call allocate_block_data (gsnow, snow_d_grid)
+               call ncio_read_block_time (fsnowdat, 'snowdepth', gsnow, month, snow_d_grid)
+            end if
+            
+            if (p_is_worker) then
+               IF (numpatch > 0) THEN
+                  allocate (mvalmask (numpatch))
+               ENDIF
+            end if
+
+            call msnow2p%build (gsnow, landpatch, snow_d_grid, missing_value, mvalmask)
+            call msnow2p%map_aweighted (snow_d_grid, snow_d)
+            
+            IF (p_is_worker) THEN
+               WHERE (mvalmask)
+                  snow_d = 0.
+               END WHERE 
+            ENDIF
+
+            IF (allocated(mvalmask)) deallocate(mvalmask)
+
+         ENDIF
+
+      ELSE
+         use_snowini = .false.
+      ENDIF
+
+
       ! for SOIL Water INIT by using water table depth
       fwtd = trim(DEF_dir_runtime) // '/wtd.nc'
       IF (p_is_master) THEN
          inquire (file=trim(fwtd), exist=use_wtd)
+         IF (use_soilini) use_wtd = .false.
          IF (use_wtd) THEN
             write(*,'(/, 2A)') 'Use water table depth and derived equilibrium state ' &
                // ' to initialize soil water content: ', trim(fwtd)
@@ -547,10 +640,10 @@ MODULE MOD_Initialize
       if (p_is_worker) then
 
          do i = 1, numpatch
-            IF (DEF_USE_SOILINI) THEN
-               do nsl = 1, nl_soil
-                  t_soisno(nsl,i) = soil_t(min(nl_soil_ini,nsl),i)
-               enddo
+            IF (DEF_USE_SoilInit) THEN
+               DO nsl = 1, nl_soil
+                  CALL polint(soil_z,soil_t(:,i),nl_soil_ini,z_soi(nsl),t_soisno(nsl,i))
+               ENDDO
             ELSE
                t_soisno(1:,i) = 283.
             ENDIF
@@ -726,7 +819,7 @@ MODULE MOD_Initialize
    !------------------------------------------------------------
 #endif
                ! for SOIL INIT of water, temperature, snow depth
-               ,use_soilini, nl_soil_ini, soil_z, soil_t(1:,i), soil_w(1:,i), snow_d(i) &
+               ,use_soilini, nl_soil_ini, soil_z, soil_t(1:,i), soil_w(1:,i), use_snowini, snow_d(i) &
                ! for SOIL Water INIT by using water table depth
                ,use_wtd, zwtmm, zc_soimm, zi_soimm, vliq_r, nprms, prms)
 

--- a/mksrfdata/MOD_SrfdataRestart.F90
+++ b/mksrfdata/MOD_SrfdataRestart.F90
@@ -37,11 +37,11 @@ CONTAINS
 
       ! Local variables
       CHARACTER(len=256) :: filename, fileblock, cyear
-      INTEGER :: ie, je, nelm, elen, iblk, jblk, iworker, i
+      INTEGER :: ie, je, nelm, totlen, tothis, iblk, jblk, iworker, i
       INTEGER,   allocatable :: nelm_worker(:), ndsp_worker(:)
       INTEGER*8, allocatable :: elmindx(:)
       INTEGER,   allocatable :: npxlall(:)
-      INTEGER,   allocatable :: elmpixels(:,:,:)
+      INTEGER,   allocatable :: elmpixels(:,:)
       REAL(r8),  allocatable :: lon(:), lat(:)
       
       INTEGER :: nsend, nrecv, ndone, ndsp
@@ -69,33 +69,32 @@ CONTAINS
                IF (gblock%pio(iblk,jblk) == p_address_io(p_my_group)) THEN
 #endif
                   nelm = 0
-                  elen = 0
+                  totlen = 0
                   DO ie = 1, numelm
                      IF ((mesh(ie)%xblk == iblk) .and. (mesh(ie)%yblk == jblk)) THEN
                         nelm = nelm + 1
-                        elen = max(elen, mesh(ie)%npxl)
+                        totlen = totlen + mesh(ie)%npxl
                      ENDIF
                   ENDDO
-
-#ifdef USEMPI
-                  CALL mpi_allreduce (MPI_IN_PLACE, elen, 1, MPI_INTEGER, MPI_MAX, p_comm_group, p_err)
-#endif
 
                   IF (nelm > 0) THEN
 
                      allocate (elmindx (nelm))
                      allocate (npxlall (nelm))
-                     allocate (elmpixels (2,elen,nelm))
+                     allocate (elmpixels (2,totlen))
 
                      je = 0
+                     ndsp = 0
                      DO ie = 1, numelm
                         IF ((mesh(ie)%xblk == iblk) .and. (mesh(ie)%yblk == jblk)) THEN
                            je = je + 1
                            elmindx(je) = mesh(ie)%indx
                            npxlall(je) = mesh(ie)%npxl
 
-                           elmpixels(1,1:npxlall(je),je) = mesh(ie)%ilon
-                           elmpixels(2,1:npxlall(je),je) = mesh(ie)%ilat
+                           elmpixels(1,ndsp+1:ndsp+npxlall(je)) = mesh(ie)%ilon
+                           elmpixels(2,ndsp+1:ndsp+npxlall(je)) = mesh(ie)%ilat
+
+                           ndsp = ndsp + npxlall(je)
                         ENDIF
                      ENDDO
                   ENDIF
@@ -113,11 +112,11 @@ CONTAINS
                      p_root, p_comm_group, p_err)
 
                   ndone = 0
-                  DO WHILE (ndone < nelm)
-                     nsend = max(min(nelm-ndone, MesgMaxSize/(2*elen*4)), 1)
+                  DO WHILE (ndone < totlen)
+                     nsend = max(min(totlen-ndone, MesgMaxSize/8), 1)
                      CALL mpi_send (nsend, 1, &
                         MPI_INTEGER, p_root, mpi_tag_size, p_comm_group, p_err)
-                     CALL mpi_send (elmpixels(:,:,ndone+1:ndone+nsend), 2*elen*nsend, &
+                     CALL mpi_send (elmpixels(:,ndone+1:ndone+nsend), 2*nsend, &
                         MPI_INTEGER, p_root, mpi_tag_data, p_comm_group, p_err)
                      ndone = ndone + nsend
                   ENDDO 
@@ -128,9 +127,6 @@ CONTAINS
 #ifdef USEMPI
             IF (p_is_io) THEN
                IF (gblock%pio(iblk,jblk) == p_iam_glb) THEN
-
-                  elen = 0
-                  CALL mpi_allreduce (MPI_IN_PLACE, elen, 1, MPI_INTEGER, MPI_MAX, p_comm_group, p_err)
 
                   allocate (nelm_worker (0:p_np_group-1))
                   nelm_worker(0) = 0
@@ -155,16 +151,20 @@ CONTAINS
                      npxlall, nelm_worker(0:), ndsp_worker(0:), MPI_INTEGER, &
                      p_root, p_comm_group, p_err)
 
-                  allocate (elmpixels (2, elen, nelm))
+                  totlen = sum(npxlall)
+                  allocate (elmpixels (2, totlen))
 
+                  ndone = 0
                   DO iworker = 1, p_np_group-1
-                     ndone = 0
-                     DO WHILE (ndone < nelm_worker(iworker))
+
+                     ndsp   = ndsp_worker(iworker)
+                     tothis = ndone + sum(npxlall(ndsp+1:ndsp+nelm_worker(iworker)))
+
+                     DO WHILE (ndone < tothis)
+                     
                         CALL mpi_recv (nrecv, 1, &
                            MPI_INTEGER, iworker, mpi_tag_size, p_comm_group, p_stat, p_err)
-
-                        ndsp = ndsp_worker(iworker)+ndone
-                        CALL mpi_recv (elmpixels(:,:,ndsp+1:ndsp+nrecv), 2*elen*nrecv, &
+                        CALL mpi_recv (elmpixels(:,ndone+1:ndone+nrecv), 2*nrecv, &
                            MPI_INTEGER, iworker, mpi_tag_data, p_comm_group, p_stat, p_err)
 
                         ndone = ndone + nrecv
@@ -181,13 +181,13 @@ CONTAINS
                      CALL ncio_create_file (fileblock)
 
                      CALL ncio_define_dimension (fileblock, 'element',nelm)
-                     CALL ncio_define_dimension (fileblock, 'np_max', elen)
                      CALL ncio_define_dimension (fileblock, 'ncoor',  2   )
+                     CALL ncio_define_dimension (fileblock, 'pixel',  totlen)
 
                      CALL ncio_write_serial (fileblock, 'elmindex',  elmindx, 'element')
                      CALL ncio_write_serial (fileblock, 'elmnpxl',   npxlall, 'element')
                      CALL ncio_write_serial (fileblock, 'elmpixels', elmpixels, &
-                        'ncoor', 'np_max', 'element', compress = 1)
+                        'ncoor', 'pixel', compress = 1)
                   ENDIF
                ENDIF
             ENDIF
@@ -261,9 +261,10 @@ CONTAINS
 
       ! Local variables
       CHARACTER(len=256) :: filename, fileblock, cyear
-      INTEGER :: iblkme, iblk, jblk, ie, nelm, ndsp
+      INTEGER :: iblkme, iblk, jblk, ie, nelm, ndsp, pdsp
       INTEGER*8, allocatable :: elmindx(:)
-      INTEGER,   allocatable :: npxl(:), pixels(:,:,:)
+      INTEGER,   allocatable :: datasize(:)
+      INTEGER,   allocatable :: npxl(:), pixels(:,:), pixels2d(:,:,:)
 
 #ifdef USEMPI
       CALL mpi_barrier (p_comm_glb, p_err)
@@ -298,8 +299,15 @@ CONTAINS
                   CALL get_filename_block (filename, iblk, jblk, fileblock)
                   CALL ncio_read_serial (fileblock, 'elmindex',  elmindx)
                   CALL ncio_read_serial (fileblock, 'elmnpxl',   npxl   )
-                  CALL ncio_read_serial (fileblock, 'elmpixels', pixels )
 
+                  CALL ncio_inquire_varsize (fileblock, 'elmpixels', datasize)
+                  IF (size(datasize) == 3) THEN
+                     CALL ncio_read_serial (fileblock, 'elmpixels', pixels2d)
+                  ELSE
+                     CALL ncio_read_serial (fileblock, 'elmpixels', pixels)
+                  ENDIF
+
+                  pdsp = 0
                   DO ie = 1, nelm
                      mesh(ie+ndsp)%indx = elmindx(ie)
                      mesh(ie+ndsp)%npxl = npxl(ie)
@@ -309,8 +317,14 @@ CONTAINS
                      allocate (mesh(ie+ndsp)%ilon (npxl(ie)))
                      allocate (mesh(ie+ndsp)%ilat (npxl(ie)))
 
-                     mesh(ie+ndsp)%ilon = pixels(1,1:npxl(ie),ie)
-                     mesh(ie+ndsp)%ilat = pixels(2,1:npxl(ie),ie)
+                     IF (size(datasize) == 3) THEN
+                        mesh(ie+ndsp)%ilon = pixels2d(1,1:npxl(ie),ie)
+                        mesh(ie+ndsp)%ilat = pixels2d(2,1:npxl(ie),ie)
+                     ELSE
+                        mesh(ie+ndsp)%ilon = pixels(1,pdsp+1:pdsp+npxl(ie))
+                        mesh(ie+ndsp)%ilat = pixels(2,pdsp+1:pdsp+npxl(ie))
+                        pdsp = pdsp + npxl(ie)
+                     ENDIF
                   ENDDO
 
                   ndsp = ndsp + nelm
@@ -318,9 +332,11 @@ CONTAINS
             ENDDO
          ENDIF
 
-         IF (allocated(elmindx)) deallocate(elmindx)
-         IF (allocated(npxl  ))  deallocate(npxl   )
-         IF (allocated(pixels))  deallocate(pixels )
+         IF (allocated(elmindx ))  deallocate(elmindx )
+         IF (allocated(npxl    ))  deallocate(npxl    )
+         IF (allocated(datasize))  deallocate(datasize)
+         IF (allocated(pixels  ))  deallocate(pixels  )
+         IF (allocated(pixels2d))  deallocate(pixels2d)
 
       ENDIF
 

--- a/run/China_Grid_50km_IGBP_VG.nml
+++ b/run/China_Grid_50km_IGBP_VG.nml
@@ -1,0 +1,68 @@
+&nl_colm
+
+! Author: Shupeng Zhang 
+! Description : include soil state init from data.
+
+   DEF_CASE_NAME = 'China_Grid_10km_IGBP_VG'
+
+   DEF_domain%edges = 0.0
+   DEF_domain%edgen = 55.0
+   DEF_domain%edgew = 70.0
+   DEF_domain%edgee = 140.0
+
+   DEF_simulation_time%greenwich    = .TRUE.
+   DEF_simulation_time%start_year   = 2010
+   DEF_simulation_time%start_month  = 1
+   DEF_simulation_time%start_day    = 1
+   DEF_simulation_time%start_sec    = 0
+   DEF_simulation_time%end_year     = 2015
+   DEF_simulation_time%end_month    = 12
+   DEF_simulation_time%end_day      = 31
+   DEF_simulation_time%end_sec      = 86400
+   DEF_simulation_time%spinup_year  = 0
+   DEF_simulation_time%spinup_month = 1
+   DEF_simulation_time%spinup_day   = 365
+   DEF_simulation_time%spinup_sec   = 86400
+   DEF_simulation_time%spinup_repeat = 0
+
+   DEF_simulation_time%timestep     = 1800.
+
+   DEF_dir_rawdata = '/tera07/CoLMrawdata/'
+   DEF_dir_runtime = '/tera07/CoLMruntime/'
+   DEF_dir_output  = '/tera05/zhangsp/cases'
+
+   ! ----- land units and land sets -----
+   ! for GRIDBASED
+   DEF_GRIDBASED_lon_res = 0.5
+   DEF_GRIDBASED_lat_res = 0.5
+
+   ! soil state init
+   DEF_USE_SoilInit  = .true.
+   DEF_file_SoilInit = '/tera05/zhangsp/data/soilstate/soilstate.nc' 
+
+   ! LAI setting
+   DEF_LAI_MONTHLY = .true.
+   DEF_LAI_CHANGE_YEARLY = .false.
+
+   DEF_USE_PLANTHYDRAULICS = .false.
+
+   ! ----- forcing -----
+   ! Options :
+   ! PRINCETON | GSWP3   | QIAN  | CRUNCEPV4 | CRUNCEPV7 | ERA5LAND | ERA5 |  MSWX
+   ! WFDE5     | CRUJRA  | WFDEI | JRA55     | GDAS      | CMFD     | POINT
+   DEF_forcing_namelist = '/tera04/zhangsp/git/CoLM202X/run/forcing/ERA5LAND.nml'
+
+   ! ----- history -----
+   DEF_hist_grid_as_forcing = .true.
+   DEF_WRST_FREQ = 'YEARLY' ! write restart file frequency: HOURLY/DAILY/MONTHLY/YEARLY
+   DEF_HIST_FREQ = 'MONTHLY' ! write history file frequency: HOURLY/DAILY/MONTHLY/YEARLY
+   DEF_HIST_groupby = 'MONTH' ! history in one file: DAY/MONTH/YEAR
+   DEF_HIST_mode = 'one' ! history in one or block
+   DEF_REST_COMPRESS_LEVEL = 1
+   DEF_HIST_COMPRESS_LEVEL = 1
+
+   DEF_HIST_WriteBack = .true.
+
+   DEF_hist_vars_out_default = .true.
+
+/

--- a/run/GreaterBay_Grid_10km_IGBP_VG.nml
+++ b/run/GreaterBay_Grid_10km_IGBP_VG.nml
@@ -1,0 +1,66 @@
+&nl_colm
+
+! Author: Shupeng Zhang 
+! Description : include soil state init from data.
+
+   DEF_CASE_NAME = 'GreaterBay_Grid_10km_IGBP_VG'
+
+   DEF_domain%edges = 20.0
+   DEF_domain%edgen = 25.0
+   DEF_domain%edgew = 109.0
+   DEF_domain%edgee = 118.0
+
+   DEF_simulation_time%greenwich    = .TRUE.
+   DEF_simulation_time%start_year   = 2010
+   DEF_simulation_time%start_month  = 1
+   DEF_simulation_time%start_day    = 1
+   DEF_simulation_time%start_sec    = 0
+   DEF_simulation_time%end_year     = 2015
+   DEF_simulation_time%end_month    = 12
+   DEF_simulation_time%end_day      = 31
+   DEF_simulation_time%end_sec      = 86400
+   DEF_simulation_time%spinup_year  = 0
+   DEF_simulation_time%spinup_month = 1
+   DEF_simulation_time%spinup_day   = 365
+   DEF_simulation_time%spinup_sec   = 86400
+   DEF_simulation_time%spinup_repeat = 0
+
+   DEF_simulation_time%timestep     = 1800.
+
+   DEF_dir_rawdata = '/tera07/CoLMrawdata/'
+   DEF_dir_runtime = '/tera07/CoLMruntime/'
+   DEF_dir_output  = '/tera05/zhangsp/cases'
+
+   ! ----- land units and land sets -----
+   ! for GRIDBASED
+   DEF_GRIDBASED_lon_res = 0.1
+   DEF_GRIDBASED_lat_res = 0.1
+
+   ! soil state init
+   DEF_USE_SoilInit  = .true.
+   DEF_file_SoilInit = '/tera05/zhangsp/data/soilstate/soilstate.nc' 
+
+   ! LAI setting
+   DEF_LAI_MONTHLY = .true.
+   DEF_LAI_CHANGE_YEARLY = .false.
+
+   ! ----- forcing -----
+   ! Options :
+   ! PRINCETON | GSWP3   | QIAN  | CRUNCEPV4 | CRUNCEPV7 | ERA5LAND | ERA5 |  MSWX
+   ! WFDE5     | CRUJRA  | WFDEI | JRA55     | GDAS      | CMFD     | POINT
+   DEF_forcing_namelist = '/tera04/zhangsp/git/CoLM202X/run/forcing/ERA5LAND.nml'
+
+   ! ----- history -----
+   DEF_hist_grid_as_forcing = .true.
+   DEF_WRST_FREQ = 'YEARLY' ! write restart file frequency: HOURLY/DAILY/MONTHLY/YEARLY
+   DEF_HIST_FREQ = 'MONTHLY' ! write history file frequency: HOURLY/DAILY/MONTHLY/YEARLY
+   DEF_HIST_groupby = 'MONTH' ! history in one file: DAY/MONTH/YEAR
+   DEF_HIST_mode = 'one' ! history in one or block
+   DEF_REST_COMPRESS_LEVEL = 1
+   DEF_HIST_COMPRESS_LEVEL = 1
+
+   DEF_HIST_WriteBack = .true.
+
+   DEF_hist_vars_out_default = .true.
+
+/

--- a/share/MOD_Namelist.F90
+++ b/share/MOD_Namelist.F90
@@ -192,12 +192,12 @@ MODULE MOD_Namelist
    logical :: DEF_SPLIT_SOILSNOW = .false.
 
    ! ----- Model settings -----
-   LOGICAL :: DEF_LANDONLY                    = .true.
-   LOGICAL :: DEF_USE_DOMINANT_PATCHTYPE      = .false.
-   LOGICAL :: DEF_USE_VARIABLY_SATURATED_FLOW = .true.
-   LOGICAL :: DEF_USE_BEDROCK                 = .false.
-   LOGICAL :: DEF_USE_OZONESTRESS             = .false.
-   LOGICAL :: DEF_USE_OZONEDATA               = .false.
+   LOGICAL :: DEF_LANDONLY                  = .true.
+   LOGICAL :: DEF_USE_DOMINANT_PATCHTYPE    = .false.
+   LOGICAL :: DEF_USE_VariablySaturatedFlow = .true.
+   LOGICAL :: DEF_USE_BEDROCK               = .false.
+   LOGICAL :: DEF_USE_OZONESTRESS           = .false.
+   LOGICAL :: DEF_USE_OZONEDATA             = .false.
 
    ! .true. for running SNICAR model
    logical :: DEF_USE_SNICAR                  = .false.
@@ -215,8 +215,11 @@ MODULE MOD_Namelist
    INTEGER :: DEF_IRRIGATION_METHOD = 1
 
    ! ----- Initialization -----
-   LOGICAL            :: DEF_USE_SOIL_INIT  = .false.
-   CHARACTER(len=256) :: DEF_file_soil_init = 'null'
+   LOGICAL            :: DEF_USE_SoilInit  = .false.
+   CHARACTER(len=256) :: DEF_file_SoilInit = 'null'
+
+   LOGICAL            :: DEF_USE_SnowInit  = .false.
+   CHARACTER(len=256) :: DEF_file_SnowInit = 'null'
 
    CHARACTER(len=256) :: DEF_file_snowoptics = 'null'
    CHARACTER(len=256) :: DEF_file_snowaging  = 'null'
@@ -224,7 +227,7 @@ MODULE MOD_Namelist
    ! ----- history -----
    LOGICAL  :: DEF_HISTORY_IN_VECTOR = .false.
 
-   LOGICAL  :: DEF_hist_grid_as_forcing   = .false.
+   LOGICAL  :: DEF_hist_grid_as_forcing = .false.
    REAL(r8) :: DEF_hist_lon_res = 0.5
    REAL(r8) :: DEF_hist_lat_res = 0.5
 
@@ -781,7 +784,7 @@ CONTAINS
 
          DEF_LANDONLY,                    &
          DEF_USE_DOMINANT_PATCHTYPE,      &
-         DEF_USE_VARIABLY_SATURATED_FLOW, &
+         DEF_USE_VariablySaturatedFlow,   &
          DEF_USE_BEDROCK,                 &
          DEF_USE_OZONESTRESS,             &
          DEF_USE_OZONEDATA,               &
@@ -791,8 +794,11 @@ CONTAINS
 
          DEF_precip_phase_discrimination_scheme, &
 
-         DEF_USE_SOIL_INIT,               &
-         DEF_file_soil_init,              &
+         DEF_USE_SoilInit,                &
+         DEF_file_SoilInit,               &
+
+         DEF_USE_SnowInit,                &
+         DEF_file_SnowInit,               &
 
          DEF_file_snowoptics,             &
          DEF_file_snowaging ,             &
@@ -871,15 +877,15 @@ CONTAINS
 ! ----- SOIL model related ------ Macros&Namelist conflicts and dependency management
 #if (defined vanGenuchten_Mualem_SOIL_MODEL)
          write(*,*) '                  *****                  '
-         write(*,*) 'Note: DEF_USE_VARIABLY_SATURATED_FLOW is automaticlly set to .true.  '
+         write(*,*) 'Note: DEF_USE_VariablySaturatedFlow is automaticlly set to .true.  '
          write(*,*) 'when using vanGenuchten_Mualem_SOIL_MODEL. '
-         DEF_USE_VARIABLY_SATURATED_FLOW = .true.
+         DEF_USE_VariablySaturatedFlow = .true.
 #endif
 #if (defined LATERAL_FLOW)
          write(*,*) '                  *****                  '
-         write(*,*) 'Note: DEF_USE_VARIABLY_SATURATED_FLOW is automaticlly set to .true.  '
+         write(*,*) 'Note: DEF_USE_VariablySaturatedFlow is automaticlly set to .true.  '
          write(*,*) 'when defined LATERAL_FLOW. '
-         DEF_USE_VARIABLY_SATURATED_FLOW = .true.
+         DEF_USE_VariablySaturatedFlow = .true.
 #endif
 
 
@@ -1201,17 +1207,20 @@ CONTAINS
       call mpi_bcast (DEF_USE_CNSOYFIXN      , 1, mpi_logical, p_root, p_comm_glb, p_err)
       call mpi_bcast (DEF_USE_FIRE           , 1, mpi_logical, p_root, p_comm_glb, p_err)
 
-      call mpi_bcast (DEF_LANDONLY,                   1, mpi_logical, p_root, p_comm_glb, p_err)
-      call mpi_bcast (DEF_USE_DOMINANT_PATCHTYPE,     1, mpi_logical, p_root, p_comm_glb, p_err)
-      call mpi_bcast (DEF_USE_VARIABLY_SATURATED_FLOW,1, mpi_logical, p_root, p_comm_glb, p_err)
-      call mpi_bcast (DEF_USE_BEDROCK                ,1, mpi_logical, p_root, p_comm_glb, p_err)
-      call mpi_bcast (DEF_USE_OZONESTRESS            ,1, mpi_logical, p_root, p_comm_glb, p_err)
-      call mpi_bcast (DEF_USE_OZONEDATA              ,1, mpi_logical, p_root, p_comm_glb, p_err)
+      call mpi_bcast (DEF_LANDONLY                 , 1, mpi_logical, p_root, p_comm_glb, p_err)
+      call mpi_bcast (DEF_USE_DOMINANT_PATCHTYPE   , 1, mpi_logical, p_root, p_comm_glb, p_err)
+      call mpi_bcast (DEF_USE_VariablySaturatedFlow, 1, mpi_logical, p_root, p_comm_glb, p_err)
+      call mpi_bcast (DEF_USE_BEDROCK              , 1, mpi_logical, p_root, p_comm_glb, p_err)
+      call mpi_bcast (DEF_USE_OZONESTRESS          , 1, mpi_logical, p_root, p_comm_glb, p_err)
+      call mpi_bcast (DEF_USE_OZONEDATA            , 1, mpi_logical, p_root, p_comm_glb, p_err)
 
       CALL mpi_bcast (DEF_precip_phase_discrimination_scheme, 5, mpi_character, p_root, p_comm_glb, p_err)
 
-      call mpi_bcast (DEF_USE_SOIL_INIT,    1, mpi_logical,   p_root, p_comm_glb, p_err)
-      CALL mpi_bcast (DEF_file_soil_init, 256, mpi_character, p_root, p_comm_glb, p_err)
+      call mpi_bcast (DEF_USE_SoilInit,    1, mpi_logical,   p_root, p_comm_glb, p_err)
+      CALL mpi_bcast (DEF_file_SoilInit, 256, mpi_character, p_root, p_comm_glb, p_err)
+
+      call mpi_bcast (DEF_USE_SnowInit,    1, mpi_logical,   p_root, p_comm_glb, p_err)
+      CALL mpi_bcast (DEF_file_SnowInit, 256, mpi_character, p_root, p_comm_glb, p_err)
 
       call mpi_bcast (DEF_USE_SNICAR,        1, mpi_logical,   p_root, p_comm_glb, p_err)
       CALL mpi_bcast (DEF_file_snowoptics, 256, mpi_character, p_root, p_comm_glb, p_err)

--- a/share/MOD_NetCDFBlock.F90
+++ b/share/MOD_NetCDFBlock.F90
@@ -34,6 +34,7 @@ MODULE MOD_NetCDFBlock
    interface ncio_read_block_time
       MODULE procedure ncio_read_block_int32_2d_time
       MODULE procedure ncio_read_block_real8_2d_time
+      MODULE procedure ncio_read_block_real8_3d_time
    END interface ncio_read_block_time
 
    PUBLIC :: ncio_read_site_time
@@ -323,11 +324,6 @@ CONTAINS
             count3(1) = min(grid%xcnt(iblk), grid%nlon-grid%xdsp(iblk))
             count3(2) = grid%ycnt(jblk)
             count3(3) = 1
-!            if(trim(dataname) == "irrigation_method")then
-!               print*,'irrig_method',p_iam_glb,gblock%nblkme,iblk,jblk
-!               print*,'start',p_iam_glb,start3
-!               print*,'count',p_iam_glb,count3
-!            end if
             IF (count3(1) == grid%xcnt(iblk)) THEN
                CALL nccheck (nf90_get_var(ncid, varid, rdata%blk(iblk,jblk)%val, &
                   start3, count3) ,trace=trim(filename))
@@ -349,6 +345,68 @@ CONTAINS
       ENDIF
 
    END SUBROUTINE ncio_read_block_real8_2d_time
+
+   ! ----
+   SUBROUTINE ncio_read_block_real8_3d_time (filename, dataname, grid, ndim1, itime, rdata)
+
+      USE netcdf
+      USE MOD_Block
+      USE MOD_Grid
+      USE MOD_DataType
+      USE MOD_SPMD_Task
+      IMPLICIT NONE
+
+      CHARACTER (len=*), intent(in) :: filename
+      CHARACTER (len=*), intent(in) :: dataname
+      TYPE (grid_type),  intent(in) :: grid
+      INTEGER, intent(in) :: ndim1, itime
+
+      TYPE (block_data_real8_3d), intent(inout) :: rdata
+
+      ! Local variables
+      INTEGER :: iblk, jblk, ndims(3), start4(4), count4(4), start_mem
+      INTEGER :: ncid, varid
+      INTEGER :: iblkme
+
+      IF (p_is_io) THEN
+
+         CALL check_ncfile_exist (filename)
+         CALL nccheck (nf90_open(trim(filename), NF90_NOWRITE, ncid) ,trace=trim(filename)//' cannot open')
+         CALL nccheck (nf90_inq_varid(ncid, trim(dataname), varid) ,trace=trim(dataname)//' in file '//trim(filename))
+
+         DO iblkme = 1, gblock%nblkme
+            iblk = gblock%xblkme(iblkme)
+            jblk = gblock%yblkme(iblkme)
+
+            ndims = (/ndim1, grid%xcnt(iblk), grid%ycnt(jblk)/)
+            IF (any(ndims == 0)) cycle
+
+            start4 = (/1, grid%xdsp(iblk)+1, grid%ydsp(jblk)+1, itime/)
+            count4(1) = ndim1
+            count4(2) = min(grid%xcnt(iblk), grid%nlon-grid%xdsp(iblk))
+            count4(3) = grid%ycnt(jblk)
+            count4(4) = 1
+            IF (count4(2) == grid%xcnt(iblk)) THEN
+               CALL nccheck (nf90_get_var(ncid, varid, rdata%blk(iblk,jblk)%val, &
+                  start4, count4) ,trace=trim(filename))
+            ELSE
+               CALL nccheck (nf90_get_var(ncid, varid, &
+                  rdata%blk(iblk,jblk)%val(:,1:count4(2),:), start4, count4) )
+
+               start4(2) = 1
+               start_mem = count4(2) + 1
+               count4(2) = grid%xdsp(iblk) + grid%xcnt(iblk) - grid%nlon
+               CALL nccheck (nf90_get_var(ncid, varid, &
+                  rdata%blk(iblk,jblk)%val(:,start_mem:ndims(2),:), start4, count4) )
+            ENDIF
+
+         ENDDO
+
+         CALL nccheck( nf90_close(ncid) )
+
+      ENDIF
+
+   END SUBROUTINE ncio_read_block_real8_3d_time
 
    ! ----
    SUBROUTINE ncio_read_site_time (filename, dataname, itime, rdata)


### PR DESCRIPTION
1. 基于数据进行土壤和积雪状态的初始化：可由文件读入土壤水、土壤温度和积雪厚度数据，对土壤和积雪的状态进行初始化；文件内数据的网格（包括经纬度和土壤层数）可任意，模式自动进行插值；文件中需包含12个月的数据，初始化时，读取当前月份的数据；
2. 改进文件中单元内像素点的存储：原mesh_xxxxxx.nc文件中，像素点以三维数组存储（coordinate, max pixels, element），有对齐数据的额外开销，现优化为二维数据（coordinate, pixel）；
3. 几个变量名或子程序名的调整：DEF_USE_VARIABLY_SATURATED_FLOW改为DEF_USE_VariablySaturatedFlow，DEF_USE_SOIL_INIT改为DEF_USE_SoilInit，子程序WATER改为WATER_2014.