### PR TITLE
set the default vector io mode to multiple files mode

### DIFF
--- a/include/define.h
+++ b/include/define.h
@@ -68,7 +68,7 @@
 !     2) "VectorInOneFileS" : write vector data in one file in serial mode;  
 !     3) Neither "VectorInOneFileS" nor "VectorInOneFileP" is defined : 
 !        write vector data in separate files.  
-#define VectorInOneFileP
+#undef VectorInOneFileP
 !     Conflict
 #ifdef VectorInOneFileP
 #undef VectorInOneFileS

--- a/run/create_clone
+++ b/run/create_clone
@@ -1,15 +1,23 @@
 #!/bin/bash
 
-#----------------------------------------------------------
+Help()
+{
+#DISPLAY help
+   echo "-------------------- Usage --------------------------------"
+   echo "Descripion:clone CoLM simulation case from an existing case"
 
-# usage: ./create_clone $SourcePath/$SourceName $DestPath/DestName
-# no "/" at end of both paths.
+   echo !---------------------------------------------------------
+   echo 'Syntax: ./create_clone -s $SourcePath -d $DestinationPath'
+   echo !---------------------------------------------------------
+   echo options:
+   echo -s The path of the source case, which your clone will be copied from '(including case name but without ''/'' at end of case path)'
+   echo -d The path of the destimation case, which you want to create '(including case name but without ''/'' at end of case path)'
+   echo -h display command information
+}
 
-#----------------------------------------------------------
-if [ $# -ne 2 ];then
-   echo "error: argument number. 2 arguments are expected. $# arguments were used"
-   exit
-else 
+CreateClone()
+{
+
    if [ "${1:0:1}" == '/' ];then
       SourceName=`echo "${1##*/}"`
       SourcePath=`echo "${1%/*}"`
@@ -34,26 +42,92 @@ else
       echo $DestPath
       echo $DestName
    fi
+
+   mkdir -p $DestPath/$DestName
+   cd $DestPath/$DestName
+   mkdir -p history
+   mkdir -p restart
+   ln -sf $SourcePath/$SourceName/landdata ./
+   echo copy scripts and namelist
+   cp -p $SourcePath/$SourceName/mksrf.submit ./
+   sed -i "s/$SourceName/$DestName/g" ./mksrf.submit
+   cp -p $SourcePath/$SourceName/init.submit ./
+   sed -i "s/$SourceName/$DestName/g" ./init.submit
+   cp -p $SourcePath/$SourceName/case.submit ./
+   sed -i "s/$SourceName/$DestName/g" ./case.submit
+   cp -p $SourcePath/$SourceName/input_$SourceName.nml ./input_$DestName.nml
+   sed -i "s/$SourceName/$DestName/g" ./input_$DestName.nml
+   
+   echo copy source files 
+   cd $SourcePath/$SourceName/bld/
+   if [ ! -d $DestPath/$DestName/bld/ ];then
+      mkdir $DestPath/$DestName/bld/
+   fi
+   for files1 in *
+   do
+      if [ -f $files1 ];then
+         cp -p $files1 $DestPath/$DestName/bld/
+      else
+         if [ -d $files1 ];then
+            if [ ! -d $DestPath/$DestName/bld/$files1 ];then
+               mkdir $DestPath/$DestName/bld/$files1
+            fi
+            cd $SourcePath/$SourceName/bld/$files1
+            if [ $files1 = CaMa -o $files1 = include -o $files1 = run -o $files1 = preprocess ];then
+               cp -pr * $DestPath/$DestName/bld/$files1/
+            else
+               if [ $files1 = postprocess ];then
+                  cp -p *F90 $DestPath/$DestName/bld/$files1/
+               else
+                  for files2 in *
+                  do 
+                     if [ -d $files2 ];then
+                        if [ ! -d $DestPath/$DestName/bld/$files1/$files2/ ];then
+                           mkdir $DestPath/$DestName/bld/$files1/$files2/
+                        fi
+                        cd $SourcePath/$SourceName/bld/$files1/$files2
+                        for files3 in *
+                        do
+                           if echo $files3 | grep -q -E '.F90$'
+                           then
+                              cp -p $files3 $DestPath/$DestName/bld/$files1/$files2/
+                           fi
+                        done
+                        cd ../
+                     else 
+                        if echo $files2 | grep -q -E '.F90$'
+                        then
+                           cp -p $files2 $DestPath/$DestName/bld/$files1/
+                        fi
+                     fi
+                  done
+               fi
+            fi
+            cd ..
+         fi
+      fi
+   done
+}
+
+
+while getopts ":hs:d:" options ;
+do
+    case $options in
+      s) Source="$OPTARG" ;;
+      d) Destination="$OPTARG"  ;;
+      h) Help; exit;;
+      *) echo "invalid option: $@";exit ;;
+    esac
+done
+
+if [ -z "${Source}" ] || [ -z "${Destination}" ]; then
+   echo
+   echo 'Error: either "-s" or "-d" is missing' 
+   echo
+   Help
+   exit
+else 
+   echo $Source,$Destination
+   CreateClone $Source $Destination
 fi
 
-mkdir -p $DestPath/$DestName
-cd $DestPath/$DestName
-mkdir -p history
-mkdir -p restart
-ln -sf $SourcePath/$SourceName/landdata ./
-echo copy scripts and namelist
-cp -p $SourcePath/$SourceName/mksrf.submit ./
-sed -i "s/$SourceName/$DestName/g" ./mksrf.submit
-cp -p $SourcePath/$SourceName/init.submit ./
-sed -i "s/$SourceName/$DestName/g" ./init.submit
-cp -p $SourcePath/$SourceName/case.submit ./
-sed -i "s/$SourceName/$DestName/g" ./case.submit
-cp -p $SourcePath/$SourceName/input_$SourceName.nml ./input_$DestName.nml
-sed -i "s/$SourceName/$DestName/g" ./input_$DestName.nml
-
-echo copy source files 
-cp -pr $SourcePath/$SourceName/bld $DestPath/$DestName/
-echo copy restart files
-cp -pr $SourcePath/$SourceName/restart/$SourceName*nc $DestPath/$DestName/restart/
-cd $DestPath/$DestName/restart/
-rename $SourceName $DestName *nc

--- a/share/MOD_NetCDFVectorOneP.F90
+++ b/share/MOD_NetCDFVectorOneP.F90
@@ -975,7 +975,7 @@ CONTAINS
          CALL nccheck( nf90_open (trim(filename), ior(NF90_WRITE,NF90_NETCDF4), ncid, &
             comm = p_comm_io, info = MPI_INFO_NULL) )
 #else
-         CALL nccheck( nf90_open (trim(filename), ior(NF90_WRITE,NF90_NETCDF4), ncid)
+         CALL nccheck( nf90_open (trim(filename), ior(NF90_WRITE,NF90_NETCDF4), ncid))
 #endif
 
          CALL nccheck (nf90_redef(ncid))
@@ -1113,7 +1113,7 @@ CONTAINS
          CALL nccheck( nf90_open(trim(filename), ior(NF90_WRITE,NF90_NETCDF4), ncid, &
             comm = p_comm_io, info = MPI_INFO_NULL) )
 #else
-         CALL nccheck( nf90_open(trim(filename), ior(NF90_WRITE,NF90_NETCDF4), ncid)
+         CALL nccheck( nf90_open(trim(filename), ior(NF90_WRITE,NF90_NETCDF4), ncid))
 #endif
 
          IF (present(compress_level)) THEN
@@ -1210,7 +1210,7 @@ CONTAINS
          CALL nccheck( nf90_open(trim(filename), ior(NF90_WRITE,NF90_NETCDF4), ncid, &
             comm = p_comm_io, info = MPI_INFO_NULL) )
 #else
-         CALL nccheck( nf90_open(trim(filename), ior(NF90_WRITE,NF90_NETCDF4), ncid)
+         CALL nccheck( nf90_open(trim(filename), ior(NF90_WRITE,NF90_NETCDF4), ncid))
 #endif
 
          IF (present(compress_level)) THEN
@@ -1319,7 +1319,7 @@ CONTAINS
          CALL nccheck( nf90_open(trim(filename), ior(NF90_WRITE,NF90_NETCDF4), ncid, &
             comm = p_comm_io, info = MPI_INFO_NULL) )
 #else
-         CALL nccheck( nf90_open(trim(filename), ior(NF90_WRITE,NF90_NETCDF4), ncid)
+         CALL nccheck( nf90_open(trim(filename), ior(NF90_WRITE,NF90_NETCDF4), ncid))
 #endif
 
          IF (present(compress_level)) THEN
@@ -1416,7 +1416,7 @@ CONTAINS
          CALL nccheck( nf90_open(trim(filename), ior(NF90_WRITE,NF90_NETCDF4), ncid, &
             comm = p_comm_io, info = MPI_INFO_NULL) )
 #else
-         CALL nccheck( nf90_open(trim(filename), ior(NF90_WRITE,NF90_NETCDF4), ncid)
+         CALL nccheck( nf90_open(trim(filename), ior(NF90_WRITE,NF90_NETCDF4), ncid))
 #endif
 
          IF (present(compress_level)) THEN
@@ -1514,7 +1514,7 @@ CONTAINS
          CALL nccheck( nf90_open(trim(filename), ior(NF90_WRITE,NF90_NETCDF4), ncid, &
             comm = p_comm_io, info = MPI_INFO_NULL) )
 #else
-         CALL nccheck( nf90_open(trim(filename), ior(NF90_WRITE,NF90_NETCDF4), ncid)
+         CALL nccheck( nf90_open(trim(filename), ior(NF90_WRITE,NF90_NETCDF4), ncid))
 #endif
 
          IF (present(compress_level)) THEN
@@ -1612,7 +1612,7 @@ CONTAINS
          CALL nccheck( nf90_open(trim(filename), ior(NF90_WRITE,NF90_NETCDF4), ncid, &
             comm = p_comm_io, info = MPI_INFO_NULL) )
 #else
-         CALL nccheck( nf90_open(trim(filename), ior(NF90_WRITE,NF90_NETCDF4), ncid)
+         CALL nccheck( nf90_open(trim(filename), ior(NF90_WRITE,NF90_NETCDF4), ncid))
 #endif
 
          IF (present(compress_level)) THEN
@@ -1710,7 +1710,7 @@ CONTAINS
          CALL nccheck( nf90_open(trim(filename), ior(NF90_WRITE,NF90_NETCDF4), ncid, &
             comm = p_comm_io, info = MPI_INFO_NULL) )
 #else
-         CALL nccheck( nf90_open(trim(filename), ior(NF90_WRITE,NF90_NETCDF4), ncid)
+         CALL nccheck( nf90_open(trim(filename), ior(NF90_WRITE,NF90_NETCDF4), ncid))
 #endif
 
          IF (present(compress_level)) THEN


### PR DESCRIPTION
1. IO for Vector variables in netcdf files still use Multiple files mode before better solution for Single file mode. i.e.
The default of include/define.h
#undef VectorInOneFileP
#undef VectorInOneFileS

2. update create_clone, new syntax is : ./create_clone -s SourceCase -d DestnationCase. The help option (-h) is also enabled.