### PR TITLE
Runoff parameterization schemes added.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,6 +268,9 @@ OBJS_MAIN = \
 				MOD_LeafTemperature.o                     \
 				MOD_LeafTemperaturePC.o                   \
 				MOD_SoilThermalParameters.o               \
+				MOD_Hydro_VIC_Variables.o                 \
+				MOD_Hydro_VIC.o                           \
+				MOD_Runoff.o                              \
 				MOD_SoilSnowHydrology.o                   \
 				MOD_SnowLayersCombineDivide.o             \
 				MOD_PhaseChange.o                         \

--- a/main/CoLMDRIVER.F90
+++ b/main/CoLMDRIVER.F90
@@ -87,16 +87,15 @@ SUBROUTINE CoLMDRIVER (idate,deltim,dolai,doalb,dosst,oro)
                soil_s_v_alb(i), soil_d_v_alb(i), soil_s_n_alb(i), soil_d_n_alb(i), &
                vf_quartz(1:,i), vf_gravels(1:,i),vf_om(1:,i),     vf_sand(1:,i),   &
                wf_gravels(1:,i),wf_sand(1:,i),   porsl(1:,i),     psi0(1:,i),      &
-               bsw(1:,i),                                                          &
-
+               bsw(1:,i),       theta_r(1:,i),                                     &
 #ifdef vanGenuchten_Mualem_SOIL_MODEL
-               theta_r(1:,i),   alpha_vgm(1:,i), n_vgm(1:,i),     L_vgm(1:,i),     &
-               sc_vgm (1:,i),   fc_vgm   (1:,i),                                   &
+               alpha_vgm(1:,i), n_vgm(1:,i),     L_vgm(1:,i),                      &
+               sc_vgm(1:,i),    fc_vgm(1:,i),                                      &
 #endif
                hksati(1:,i),    csol(1:,i),      k_solids(1:,i),  dksatu(1:,i),    &
                dksatf(1:,i),    dkdry(1:,i),                                       &
                BA_alpha(1:,i),  BA_beta(1:,i),                                     &
-               rootfr(1:,m),    lakedepth(i),    dz_lake(1:,i),                    &
+               rootfr(1:,m),    lakedepth(i),    dz_lake(1:,i),   topostd(i),      &
 #if(defined CaMa_Flood)
              ! flood variables [mm, m2/m2, mm/s, mm/s]
                flddepth_cama(i),fldfrc_cama(i),fevpg_fld(i),  finfg_fld(i),        &
@@ -211,7 +210,7 @@ SUBROUTINE CoLMDRIVER (idate,deltim,dolai,doalb,dosst,oro)
             em_gper(u)      ,cv_roof(:,u)    ,cv_wall(:,u)    ,cv_gimp(:,u)    ,&
             tk_roof(:,u)    ,tk_wall(:,u)    ,tk_gimp(:,u)    ,z_roof(:,u)     ,&
             z_wall(:,u)     ,dz_roof(:,u)    ,dz_wall(:,u)                     ,&
-            lakedepth(i)    ,dz_lake(1:,i)                                     ,&
+            lakedepth(i)    ,dz_lake(1:,i)   ,topostd(i)      ,&
 
           ! LUCY INPUT PARAMETERS
             fix_holiday(:,u),week_holiday(:,u),hum_prof(:,u)  ,pop_den(u)      ,&
@@ -220,9 +219,9 @@ SUBROUTINE CoLMDRIVER (idate,deltim,dolai,doalb,dosst,oro)
           ! SOIL INFORMATION AND LAKE DEPTH
             vf_quartz(1:,i) ,vf_gravels(1:,i),vf_om(1:,i)     ,vf_sand(1:,i)   ,&
             wf_gravels(1:,i),wf_sand(1:,i)   ,porsl(1:,i)     ,psi0(1:,i)      ,&
-            bsw(1:,i)       ,&
+            bsw(1:,i)       ,theta_r(1:,i)   ,&
 #ifdef vanGenuchten_Mualem_SOIL_MODEL
-            theta_r(1:,i)   ,alpha_vgm(1:,i) ,n_vgm(1:,i)     ,L_vgm(1:,i)     ,&
+            alpha_vgm(1:,i) ,n_vgm(1:,i)     ,L_vgm(1:,i)     ,&
             sc_vgm (1:,i)   ,fc_vgm   (1:,i) ,&
 #endif
             hksati(1:,i)    ,csol(1:,i)      ,k_solids(1:,i),  dksatu(1:,i)    ,&

--- a/main/CoLMDRIVER.F90
+++ b/main/CoLMDRIVER.F90
@@ -155,8 +155,9 @@ SUBROUTINE CoLMDRIVER (idate,deltim,dolai,doalb,dosst,oro)
                taux(i),         tauy(i),         fsena(i),        fevpa(i),        &
                lfevpa(i),       fsenl(i),        fevpl(i),        etr(i),          &
                fseng(i),        fevpg(i),        olrg(i),         fgrnd(i),        &
-               trad(i),         tref(i),         qref(i),         rsur(i),         &
-               rnof(i),         qintr(i),        qinfl(i),        qdrip(i),        &
+               trad(i),         tref(i),         qref(i),                          & 
+               rsur(i),         rsur_se(i),      rsur_ie(i),      rnof(i),         &
+               qintr(i),        qinfl(i),        qdrip(i),                         &
                rst(i),          assim(i),        respc(i),        sabvsun(i),      &
                sabvsha(i),      sabg(i),         sr(i),           solvd(i),        &
                solvi(i),        solnd(i),        solni(i),        srvd(i),         &

--- a/main/CoLMMAIN.F90
+++ b/main/CoLMMAIN.F90
@@ -77,8 +77,9 @@ SUBROUTINE CoLMMAIN ( &
            taux,         tauy,         fsena,        fevpa,         &
            lfevpa,       fsenl,        fevpl,        etr,           &
            fseng,        fevpg,        olrg,         fgrnd,         &
-           trad,         tref,         qref,         rsur,          &
-           rnof,         qintr,        qinfl,        qdrip,         &
+           trad,         tref,         qref,                        &
+           rsur,         rsur_se,      rsur_ie,      rnof,          &
+           qintr,        qinfl,        qdrip,                       &
            rst,          assim,        respc,        sabvsun,       &
            sabvsha,      sabg,         sr,           solvd,         &
            solvi,        solnd,        solni,        srvd,          &
@@ -415,6 +416,8 @@ SUBROUTINE CoLMMAIN ( &
         qref        ,&! 2 m height air specific humidity
         trad        ,&! radiative temperature [K]
         rsur        ,&! surface runoff (mm h2o/s)
+        rsur_se     ,&! saturation excess surface runoff (mm h2o/s)
+        rsur_ie     ,&! infiltration excess surface runoff (mm h2o/s)
         rnof        ,&! total runoff (mm h2o/s)
         qintr       ,&! interception (mm h2o/s)
         qinfl       ,&! inflitration (mm h2o/s)
@@ -759,8 +762,8 @@ SUBROUTINE CoLMMAIN ( &
                  deltim            ,z_soisno(lb:)     ,dz_soisno(lb:)    ,zi_soisno(lb-1:)  ,&
                  bsw               ,theta_r           ,topostd           ,&
 #ifdef vanGenuchten_Mualem_SOIL_MODEL
-                 alpha_vgm         ,n_vgm             ,L_vgm             ,&
-                 sc_vgm            ,fc_vgm            ,&
+                 alpha_vgm         ,n_vgm             ,L_vgm             ,sc_vgm            ,&
+                 fc_vgm            ,&
 #endif
                  porsl             ,psi0              ,hksati            ,rootr             ,&
                  rootflux          ,t_soisno(lb:)     ,wliq_soisno(lb:)  ,wice_soisno(lb:)  ,&
@@ -768,10 +771,10 @@ SUBROUTINE CoLMMAIN ( &
                  etr               ,qseva             ,qsdew             ,qsubl             ,&
                  qfros             ,qseva_soil        ,qsdew_soil        ,qsubl_soil        ,&
                  qfros_soil        ,qseva_snow        ,qsdew_snow        ,qsubl_snow        ,&
-                 qfros_snow        ,fsno              ,rsur              ,rnof              ,&
-                 qinfl             ,wtfact            ,ssi               ,pondmx            ,&
-                 wimp              ,zwt               ,wdsrf             ,wa                ,&
-                 wetwat            ,qcharge           ,errw_rsub         ,&
+                 qfros_snow        ,fsno              ,rsur              ,rsur_se           ,&
+                 rsur_ie           ,rnof              ,qinfl             ,wtfact            ,&
+                 ssi               ,pondmx            ,wimp              ,zwt               ,&
+                 wdsrf             ,wa                ,wetwat            ,&
 #if(defined CaMa_Flood)
              !add variables for flood depth [mm], flood fraction [0-1] and re-infiltration [mm/s] calculation.
                  flddepth          ,fldfrc            ,qinfl_fld         ,&
@@ -1031,6 +1034,8 @@ SUBROUTINE CoLMMAIN ( &
                rsur = 0.
             ENDIF
             rnof = rsur
+            rsur_se = rsur
+            rsur_ie = 0.
 #endif
          ENDIF
 
@@ -1206,6 +1211,8 @@ SUBROUTINE CoLMMAIN ( &
                rsur = 0.
             ENDIF
             rnof = rsur
+            rsur_se = rsur
+            rsur_ie = 0.
 #endif
          ENDIF
 
@@ -1271,6 +1278,8 @@ SUBROUTINE CoLMMAIN ( &
                     trad    = tssea
                     fgrnd   = 0.0
                     rsur    = 0.0
+                    rsur_se = 0.0
+                    rsur_ie = 0.0
                     rnof    = 0.0
                     xerr    = 0.0
 

--- a/main/CoLMMAIN.F90
+++ b/main/CoLMMAIN.F90
@@ -734,7 +734,7 @@ SUBROUTINE CoLMMAIN ( &
             CALL WATER_2014 (ipatch,patchtype         ,lb                ,nl_soil           ,&
                  deltim            ,z_soisno(lb:)     ,dz_soisno(lb:)    ,zi_soisno(lb-1:)  ,&
                  bsw               ,porsl             ,psi0              ,hksati            ,&
-                 topostd           ,&
+                 topostd           ,theta_r           ,&
                  rootr             ,rootflux          ,t_soisno(lb:)     ,wliq_soisno(lb:)  ,&
                  wice_soisno(lb:)  ,smp               ,hk                ,pg_rain           ,&
                  sm                ,etr               ,qseva             ,qsdew             ,&

--- a/main/CoLMMAIN.F90
+++ b/main/CoLMMAIN.F90
@@ -734,7 +734,7 @@ SUBROUTINE CoLMMAIN ( &
             CALL WATER_2014 (ipatch,patchtype         ,lb                ,nl_soil           ,&
                  deltim            ,z_soisno(lb:)     ,dz_soisno(lb:)    ,zi_soisno(lb-1:)  ,&
                  bsw               ,porsl             ,psi0              ,hksati            ,&
-                 topostd           ,theta_r           ,&
+                 theta_r           ,topostd           ,&
                  rootr             ,rootflux          ,t_soisno(lb:)     ,wliq_soisno(lb:)  ,&
                  wice_soisno(lb:)  ,smp               ,hk                ,pg_rain           ,&
                  sm                ,etr               ,qseva             ,qsdew             ,&

--- a/main/CoLMMAIN.F90
+++ b/main/CoLMMAIN.F90
@@ -11,14 +11,14 @@ SUBROUTINE CoLMMAIN ( &
            soil_s_v_alb, soil_d_v_alb, soil_s_n_alb, soil_d_n_alb,  &
            vf_quartz,    vf_gravels,   vf_om,        vf_sand,       &
            wf_gravels,   wf_sand,      porsl,        psi0,          &
-           bsw,          &
+           bsw,          theta_r,      &
 #ifdef vanGenuchten_Mualem_SOIL_MODEL
-           theta_r,      alpha_vgm,    n_vgm,        L_vgm,         &
+           alpha_vgm,    n_vgm,        L_vgm,         &
            sc_vgm,       fc_vgm,       &
 #endif
            hksati,       csol,         k_solids,     dksatu,        &
            dksatf,       dkdry,        BA_alpha,     BA_beta,       &
-           rootfr,       lakedepth,    dz_lake,      &
+           rootfr,       lakedepth,    dz_lake,      topostd,       &
 #if(defined CaMa_Flood)
            ! add flood depth, flood fraction, flood evaporation and
            ! flood re-infiltration
@@ -191,6 +191,8 @@ SUBROUTINE CoLMMAIN ( &
    real(r8), intent(in) :: &
         lakedepth        ,&! lake depth (m)
         dz_lake(nl_lake) ,&! lake layer thickness (m)
+        
+        topostd          ,&! standard deviation of elevation (m)
 
         ! soil physical parameters and lake info
         soil_s_v_alb     ,&! albedo of visible of the saturated soil
@@ -207,8 +209,8 @@ SUBROUTINE CoLMMAIN ( &
         porsl     (nl_soil)  ,& ! fraction of soil that is voids [-]
         psi0      (nl_soil)  ,& ! minimum soil suction [mm]
         bsw       (nl_soil)  ,& ! clapp and hornbereger "b" parameter [-]
+        theta_r  (1:nl_soil) ,& ! residual water content (cm3/cm3) 
 #ifdef vanGenuchten_Mualem_SOIL_MODEL
-        theta_r  (1:nl_soil) ,& ! residual water content (cm3/cm3) in vanGenuchten_Mualem_SOIL_MODEL
         alpha_vgm(1:nl_soil) ,& ! the parameter corresponding approximately to the inverse of the air-entry value
         n_vgm    (1:nl_soil) ,& ! a shape parameter
         L_vgm    (1:nl_soil) ,& ! pore-connectivity parameter
@@ -732,6 +734,7 @@ SUBROUTINE CoLMMAIN ( &
             CALL WATER_2014 (ipatch,patchtype         ,lb                ,nl_soil           ,&
                  deltim            ,z_soisno(lb:)     ,dz_soisno(lb:)    ,zi_soisno(lb-1:)  ,&
                  bsw               ,porsl             ,psi0              ,hksati            ,&
+                 topostd           ,&
                  rootr             ,rootflux          ,t_soisno(lb:)     ,wliq_soisno(lb:)  ,&
                  wice_soisno(lb:)  ,smp               ,hk                ,pg_rain           ,&
                  sm                ,etr               ,qseva             ,qsdew             ,&
@@ -754,11 +757,9 @@ SUBROUTINE CoLMMAIN ( &
 
             CALL WATER_VSF (ipatch ,patchtype         ,lb                ,nl_soil           ,&
                  deltim            ,z_soisno(lb:)     ,dz_soisno(lb:)    ,zi_soisno(lb-1:)  ,&
-#ifdef Campbell_SOIL_MODEL
-                 bsw               ,&
-#endif
+                 bsw               ,theta_r           ,topostd           ,&
 #ifdef vanGenuchten_Mualem_SOIL_MODEL
-                 theta_r           ,alpha_vgm         ,n_vgm             ,L_vgm             ,&
+                 alpha_vgm         ,n_vgm             ,L_vgm             ,&
                  sc_vgm            ,fc_vgm            ,&
 #endif
                  porsl             ,psi0              ,hksati            ,rootr             ,&

--- a/main/HYDRO/MOD_Hydro_VIC.F90
+++ b/main/HYDRO/MOD_Hydro_VIC.F90
@@ -1,0 +1,531 @@
+module MOD_Hydro_VIC
+    use MOD_Hydro_VIC_Variables
+    implicit none
+
+    public :: compute_vic_runoff
+
+    private :: compute_runoff_and_asat
+    private :: calc_Q12
+    private :: compute_zwt
+    private :: wrap_compute_zwt
+
+    contains
+
+    ! /******************************************************************************
+    ! * @brief    Calculate infiltration and runoff from the surface, gravity driven
+    ! *           drainage between all soil layers, and generates baseflow from the
+    ! *           bottom layer.
+    ! ******************************************************************************/
+    subroutine compute_vic_runoff(soil_con, ppt, frost_fract, cell)
+        use MOD_Hydro_VIC_Variables
+        USE MOD_Namelist
+        implicit none
+
+        !-----------------------Arguments---------------------------------------
+        type(soil_con_struct), intent(in) :: soil_con
+        real(r8), intent(in) :: ppt              ! /**< amount of liquid water coming to the surface   */
+        real(r8), intent(in) :: frost_fract(:)   ! /**< spatially distributed frost coverage fractions */
+        type(cell_data_struct),intent(inout) :: cell
+
+        !-----------------------Local Variables---------------------------------
+        integer :: lindex, time_step
+        integer :: last_index, tmplayer, fidx
+        real(r8) :: A
+        real(r8) :: frac
+        real(r8) :: tmp_runoff
+        real(r8) :: inflow
+        real(r8) :: resid_moist(MAX_LAYERS) ! residual moisture (mm)
+        real(r8) :: org_moist(MAX_LAYERS) ! total soil moisture (liquid and frozen) at beginning of this function (mm)
+        real(r8) :: avail_liq(MAX_LAYERS, MAX_FROST_AREAS) ! liquid soil moisture available for evap/drainage (mm)
+        real(r8) :: liq(MAX_LAYERS)
+        real(r8) :: ice(MAX_LAYERS)
+        real(r8) :: moist(MAX_LAYERS)
+        real(r8) :: max_moist(MAX_LAYERS)
+        real(r8) :: Ksat(MAX_LAYERS)
+        real(r8) :: Q12(MAX_LAYERS - 1)
+        real(r8) :: Dsmax
+        real(r8) :: tmp_inflow
+        real(r8) :: tmp_moist
+        real(r8) :: tmp_moist_for_runoff(MAX_LAYERS)
+        real(r8) :: tmp_liq
+        real(r8) :: dt_inflow
+        real(r8) :: dt_runoff
+        real(r8) :: runoff(MAX_FROST_AREAS)
+        real(r8) :: tmp_dt_runoff(MAX_FROST_AREAS)
+        real(r8) :: baseflow(MAX_FROST_AREAS)
+        real(r8) :: dt_baseflow
+        real(r8) :: rel_moist
+        real(r8) :: evap(MAX_LAYERS, MAX_FROST_AREAS)
+        real(r8) :: sum_liq
+        real(r8) :: evap_fraction
+        real(r8) :: evap_sum
+        type(layer_data_struct), dimension(MAX_LAYERS) :: layer  
+
+        real(r8) :: dltime                !/**< timestep in seconds */
+        integer  :: runoff_steps_per_day  !/**< Number of runoff timesteps per day */
+        integer  :: model_steps_per_day   !/**< Number of model timesteps per day */
+        integer  :: runoff_steps_per_dt  
+
+        !-----------------------End Variable List-------------------------------
+
+        dltime = DEF_simulation_time%timestep
+        runoff_steps_per_day = 86400/dltime
+        model_steps_per_day  = 86400/dltime
+
+        ! /** Set Temporary Variables **/
+        do lindex = 1, Nlayer
+            resid_moist(lindex) = soil_con%resid_moist(lindex)
+            max_moist(lindex) = soil_con%max_moist(lindex)
+            Ksat(lindex) = soil_con%Ksat(lindex) / runoff_steps_per_day
+        end do
+
+        ! /** Allocate and Set Values for Soil Sublayers **/
+        layer = cell%layer
+        cell%runoff = 0
+        cell%baseflow = 0
+        cell%asat = 0
+
+        runoff_steps_per_dt = runoff_steps_per_day / model_steps_per_day
+
+        ! initialize baseflow
+        do fidx = 1, Nfrost
+            baseflow(fidx) = 0.0
+        end do
+
+        do lindex = 1, Nlayer
+            evap(lindex, 1) = layer(lindex)%evap / real(runoff_steps_per_dt)
+            org_moist(lindex) = layer(lindex)%moist
+            layer(lindex)%moist = 0.0
+
+            ! if there is positive evaporation
+            if (evap(lindex, 1) > 0.0) then
+                sum_liq = 0.0
+                ! compute available soil moisture for each frost sub area
+                do fidx = 1, Nfrost
+                    avail_liq(lindex, fidx) = org_moist(lindex) - layer(lindex)%ice(fidx) - resid_moist(lindex)
+                    if (avail_liq(lindex, fidx) < 0.0) then
+                        avail_liq(lindex, fidx) = 0.0
+                    end if
+                    sum_liq = sum_liq + avail_liq(lindex, fidx) * frost_fract(fidx)
+                end do
+
+                ! compute fraction of available soil moisture that is evaporated
+                if (sum_liq > 0.0) then
+                    evap_fraction = evap(lindex, 1) / sum_liq
+                else
+                    evap_fraction = 1.0
+                end if
+
+                ! distribute evaporation between frost sub areas by percentage
+                evap_sum = evap(lindex, 1)
+                do fidx = Nfrost, 1, -1
+                    evap(lindex, fidx) = avail_liq(lindex, fidx) * evap_fraction
+                    avail_liq(lindex, fidx) = avail_liq(lindex, fidx) - evap(lindex, fidx)
+                    evap_sum = evap_sum - evap(lindex, fidx) * frost_fract(fidx)
+                end do
+            else
+                ! if no evaporation
+                do fidx = Nfrost, 2, -1
+                    evap(lindex, fidx) = evap(lindex, 1)
+                end do
+            end if
+        end do
+
+
+        do fidx = 1, Nfrost
+            ! ppt = amount of liquid water coming to the surface 
+            inflow = ppt
+
+            ! /**************************************************
+            ! Initialize Variables
+            ! **************************************************/
+            do lindex = 1, Nlayer
+                ! Set Layer Liquid Moisture Content
+                liq(lindex) = org_moist(lindex) - layer(lindex)%ice(fidx)
+
+                ! Set Layer Frozen Moisture Content
+                ice(lindex) = layer(lindex)%ice(fidx)
+            end do
+
+            ! /******************************************************
+            !    Runoff Based on Soil Moisture Level of Upper Layers
+            ! ******************************************************/        
+            do lindex = 1, Nlayer
+                tmp_moist_for_runoff(lindex) = liq(lindex) + ice(lindex)
+            end do
+
+            call compute_runoff_and_asat(soil_con, tmp_moist_for_runoff, inflow, A, runoff(fidx))
+
+            ! Save dt_runoff based on initial runoff estimate
+            tmp_dt_runoff(fidx) = runoff(fidx) / real(runoff_steps_per_dt, kind=r8)
+
+            ! /**************************************************
+            !     Compute Flow Between Soil Layers ()
+            ! **************************************************/
+            dt_inflow = inflow / real(runoff_steps_per_dt, kind=r8)
+
+            Dsmax = soil_con%Dsmax / runoff_steps_per_day
+
+            do time_step = 1, runoff_steps_per_dt
+                inflow = dt_inflow
+
+                ! /*************************************
+                !     Compute Drainage between Sublayers
+                ! *************************************/
+                do lindex = 1, Nlayer - 1
+                    ! Brooks & Corey relation for hydraulic conductivity
+                    tmp_liq = liq(lindex) - evap(lindex, fidx)  ! Assume evap is a 2D array now, adjusted indexing
+
+                    if (tmp_liq < resid_moist(lindex)) then
+                        tmp_liq = resid_moist(lindex)
+                    end if
+
+                    if (tmp_liq > resid_moist(lindex)) then
+                        call calc_Q12(Ksat(lindex), tmp_liq, resid_moist(lindex), max_moist(lindex), soil_con%expt(lindex),Q12(lindex))
+                    else
+                        Q12(lindex) = 0.0
+                    end if
+                end do
+
+                ! /**************************************************
+                !     Solve for Current Soil Layer Moisture, and
+                !     Check Versus Maximum and Minimum Moisture Contents.
+                ! **************************************************/
+                last_index = 0
+                do lindex = 1, Nlayer - 1
+                    if (lindex == 1) then
+                        dt_runoff = tmp_dt_runoff(fidx)
+                    else
+                        dt_runoff = 0.0
+                    endif
+
+                    ! transport moisture for all sublayers
+                    tmp_inflow = 0.0
+
+                    ! Update soil layer moisture content
+                    liq(lindex) = liq(lindex) + (inflow - dt_runoff) - (Q12(lindex) + evap(lindex, fidx))
+
+                    ! Verify that soil layer moisture is less than maximum
+                    if ((liq(lindex) + ice(lindex)) > max_moist(lindex)) then
+                        tmp_inflow = (liq(lindex) + ice(lindex)) - max_moist(lindex)
+                        liq(lindex) = max_moist(lindex) - ice(lindex)
+
+                        if (lindex == 1) then
+                            Q12(lindex) = Q12(lindex) + tmp_inflow
+                            tmp_inflow = 0.0
+                        else
+                            tmplayer = lindex
+                            do while (tmp_inflow > 0)
+                                tmplayer = tmplayer - 1
+                                if (tmplayer < 1) then
+                                    ! If top layer saturated, add to runoff
+                                    runoff(fidx) = runoff(fidx) + tmp_inflow
+                                    tmp_inflow = 0.0
+                                else
+                                    ! else add excess soil moisture to next higher layer
+                                    liq(tmplayer) = liq(tmplayer) + tmp_inflow
+                                    if ((liq(tmplayer) + ice(tmplayer)) > max_moist(tmplayer)) then
+                                        tmp_inflow = (liq(tmplayer) + ice(tmplayer)) - max_moist(tmplayer)
+                                        liq(tmplayer) = max_moist(tmplayer) - ice(tmplayer)
+                                    else
+                                        tmp_inflow = 0.0
+                                    endif
+                                endif
+                            end do
+                        endif ! /** end trapped excess moisture **/
+                    endif ! /** end check if excess moisture in top layer **/
+
+                    ! verify that current layer moisture is greater than minimum
+                    if (liq(lindex) < 0.0) then
+                        ! liquid cannot fall below 0
+                        Q12(lindex) = Q12(lindex) + liq(lindex)
+                        liq(lindex) = 0.0
+                    endif
+                    if ((liq(lindex) + ice(lindex)) < resid_moist(lindex)) then
+                        ! moisture cannot fall below minimum
+                        Q12(lindex) = Q12(lindex) + (liq(lindex) + ice(lindex)) - resid_moist(lindex)
+                        liq(lindex) = resid_moist(lindex) - ice(lindex)
+                    endif
+
+                    inflow = Q12(lindex) + tmp_inflow
+                    Q12(lindex) = Q12(lindex) + tmp_inflow
+
+                    last_index = last_index + 1
+                end do ! /* end loop through soil layers */
+
+                ! /**************************************************
+                !     Compute Baseflow
+                ! **************************************************/
+                ! ARNO model for the bottom soil layer (based on bottom
+                ! soil layer moisture from previous time step)
+
+                lindex = Nlayer
+
+                ! Compute relative moisture
+                rel_moist = (liq(lindex) - resid_moist(lindex)) / &
+                            (max_moist(lindex) - resid_moist(lindex))
+
+                ! Compute baseflow as function of relative moisture
+                frac = Dsmax * soil_con%Ds / soil_con%Ws
+                dt_baseflow = frac * rel_moist
+                if (rel_moist > soil_con%Ws) then
+                    frac = (rel_moist - soil_con%Ws) / (1 - soil_con%Ws)
+                    dt_baseflow = dt_baseflow + Dsmax * (1 - soil_con%Ds / soil_con%Ws) * &
+                                frac ** soil_con%c
+                endif
+
+                ! Make sure baseflow isn't negative
+                if (dt_baseflow < 0) then
+                    dt_baseflow = 0.0
+                endif
+
+                ! Extract baseflow from the bottom soil layer
+                liq(lindex) = liq(lindex) + Q12(lindex - 1) - (evap(lindex, fidx) + dt_baseflow)
+
+                ! Check Lower Sub-Layer Moistures
+                tmp_moist = 0.0
+
+                ! /* If soil moisture has gone below minimum, take water out
+                !  * of baseflow and add back to soil to make up the difference
+                !  * Note: this may lead to negative baseflow, in which case we will
+                !  * reduce evap to make up for it */
+                if ((liq(lindex) + ice(lindex)) < resid_moist(lindex)) then
+                    dt_baseflow = dt_baseflow + &
+                                (liq(lindex) + ice(lindex)) - resid_moist(lindex)
+                    liq(lindex) = resid_moist(lindex) - ice(lindex)
+                endif
+
+                if ((liq(lindex) + ice(lindex)) > max_moist(lindex)) then
+                    ! soil moisture above maximum
+                    tmp_moist = (liq(lindex) + ice(lindex)) - max_moist(lindex)
+                    liq(lindex) = max_moist(lindex) - ice(lindex)
+                    tmplayer = lindex
+                    do while (tmp_moist > 0)
+                        tmplayer = tmplayer - 1
+                        if (tmplayer < 1) then
+                            ! If top layer saturated, add to runoff
+                            runoff(fidx) = runoff(fidx) + tmp_moist
+                            tmp_moist = 0.0
+                        else
+                            ! else if sublayer exists, add excess soil moisture
+                            liq(tmplayer) = liq(tmplayer) + tmp_moist
+                            if ((liq(tmplayer) + ice(tmplayer)) > max_moist(tmplayer)) then
+                                tmp_moist = (liq(tmplayer) + ice(tmplayer)) - max_moist(tmplayer)
+                                liq(tmplayer) = max_moist(tmplayer) - ice(tmplayer)
+                            else
+                                tmp_moist = 0.0
+                            endif
+                        endif
+                    end do
+                endif
+
+                baseflow(fidx) = baseflow(fidx) + dt_baseflow
+            end do ! /* end of sub-dt time step loop */
+
+            ! If negative baseflow, reduce evap accordingly
+            if (baseflow(fidx) < 0.0) then
+                ! layer(lindex)%evap = layer(lindex)%evap + baseflow(fidx)   !!!! need check
+                baseflow(fidx) = 0.0
+            endif
+
+            ! Recompute Asat based on final moisture level of upper layers
+            do lindex = 1, Nlayer
+                tmp_moist_for_runoff(lindex) = (liq(lindex) + ice(lindex))
+            end do
+
+            call compute_runoff_and_asat(soil_con, tmp_moist_for_runoff, real(0.0, kind=r8), A, tmp_runoff)
+
+            ! Store tile-wide values
+            do lindex = 1, Nlayer
+                layer(lindex)%moist = layer(lindex)%moist + &
+                                    ((liq(lindex) + ice(lindex)) * frost_fract(fidx))
+            end do
+            cell%asat = cell%asat + A * frost_fract(fidx)
+            cell%runoff = cell%runoff + runoff(fidx) * frost_fract(fidx)
+            cell%baseflow = cell%baseflow + baseflow(fidx) * frost_fract(fidx)
+
+            ! ! /** Compute water table depth **/
+            ! call wrap_compute_zwt(soil_con, cell)
+
+        end do
+
+    end subroutine compute_vic_runoff
+
+
+    ! ******************************************************************************
+    ! * @brief    Calculate the saturated area and runoff
+    ! ******************************************************************************
+    subroutine compute_runoff_and_asat(soil_con, moist, inflow, A, runoff)
+        USE MOD_Hydro_VIC_Variables, only: soil_con_struct, Nlayer
+        implicit none
+        !-----------------------Arguments---------------------------------------
+        type(soil_con_struct), intent(in) :: soil_con
+        real(r8), intent(in) :: moist(Nlayer)     
+        real(r8), intent(in) :: inflow
+        real(r8), intent(inout) :: A
+        real(r8), intent(inout) :: runoff
+        !-----------------------Local Variables---------------------------------
+        real(r8) :: top_moist !! total moisture (liquid and frozen) in topmost soil layers (mm)
+        real(r8) :: top_max_moist  !! maximum storable moisture (liquid and frozen) in topmost soil layers (mm)
+        integer :: lindex
+        real(r8) :: ex, max_infil, i_0, basis
+        !-----------------------End Variable List-------------------------------
+
+        top_moist = 0.0
+        top_max_moist = 0.0
+        do lindex = 1, Nlayer - 1
+            top_moist = top_moist + moist(lindex)
+            top_max_moist = top_max_moist + soil_con%max_moist(lindex)
+        end do
+        if (top_moist > top_max_moist) then
+            top_moist = top_max_moist
+        endif
+
+        ! A as in Wood et al. in JGR 97, D3, 1992 equation (1)
+        ex = soil_con%b_infilt / (1.0 + soil_con%b_infilt)
+        A = 1.0 - (1.0 - top_moist / top_max_moist)**ex
+
+        max_infil = (1.0 + soil_con%b_infilt) * top_max_moist
+        i_0 = max_infil * (1.0 - (1.0 - A)**(1.0 / soil_con%b_infilt))
+
+        ! equation (3a) Wood et al.
+        if (inflow == 0.0) then
+            runoff = 0.0
+        else if (max_infil == 0.0) then
+            runoff = inflow
+        else if ((i_0 + inflow) > max_infil) then
+            runoff = inflow - top_max_moist + top_moist
+        ! equation (3b) Wood et al. (wrong in paper)
+        else
+            basis = 1.0 - (i_0 + inflow) / max_infil
+            runoff = (inflow - top_max_moist + top_moist + &
+                    top_max_moist * basis**(1.0 * (1.0 + soil_con%b_infilt)))
+        endif
+        if (runoff < 0.0) then
+            runoff = 0.0
+        endif
+    end subroutine compute_runoff_and_asat
+
+
+    ! ******************************************************************************
+    ! * @brief    Calculate drainage between two layers
+    ! ******************************************************************************
+    subroutine calc_Q12(Ksat, init_moist, resid_moist, max_moist, expt, Q12)
+        implicit none
+        real(r8), intent(in) :: Ksat, init_moist, resid_moist, max_moist, expt
+        real(r8), intent(out) :: Q12
+
+        Q12 = init_moist - ((init_moist - resid_moist)**(1.0d0 - expt) - Ksat / &
+            (max_moist - resid_moist)**expt * (1.0d0 - expt))**(1.0d0 / (1.0d0 - expt)) - resid_moist
+
+    end subroutine calc_Q12
+
+
+    ! /******************************************************************************
+    !  * @brief    Compute spatial average water table position (zwt).  Water table
+    !  *           position is measured in cm and is negative below the soil surface.
+    !  *****************************************************************************/
+    subroutine compute_zwt(soil_con,lindex, moist, zwt)
+        use MOD_Hydro_VIC_Variables
+        implicit none
+        !-----------------------Arguments---------------------------------------
+        type(soil_con_struct), intent(in) :: soil_con
+        integer, intent(in) :: lindex
+        real(r8), intent(in) :: moist
+        real(r8), intent(out) :: zwt
+        !-----------------------Local Variables---------------------------------
+        integer :: i
+        real(r8) :: MISSING =  -99999. !/**< missing value */ 
+        !-----------------------End Variable List-------------------------------
+
+        zwt = MISSING
+
+        ! /** Compute zwt using soil moisture v zwt curve **/
+        i = MAX_ZWTVMOIST - 1
+        do while (i >= 1 .and. moist > soil_con%zwtvmoist_moist(lindex, i))
+            i = i - 1
+        end do
+
+        if (i == MAX_ZWTVMOIST - 1) then
+            if (moist < soil_con%zwtvmoist_moist(lindex, i)) then
+                zwt = 999.0 ! 999 indicates water table not present in this layer
+            else if (moist == soil_con%zwtvmoist_moist(lindex, i)) then
+                zwt = soil_con%zwtvmoist_zwt(lindex, i) ! Just barely enough water for a water table
+            end if
+        else
+            zwt = soil_con%zwtvmoist_zwt(lindex, i+1) + & 
+                    (soil_con%zwtvmoist_zwt(lindex, i) - soil_con%zwtvmoist_zwt(lindex, i+1)) * &
+                    (moist - soil_con%zwtvmoist_moist(lindex, i+1)) / &
+                    (soil_con%zwtvmoist_moist(lindex, i) - soil_con%zwtvmoist_moist(lindex, i+1))
+        end if
+    end subroutine compute_zwt
+
+
+    ! /******************************************************************************
+    !  * @brief    Function to compute spatial average water table position (zwt) for
+    !  *           individual layers as well as various total-column versions of zwt.
+    !  *           Water table position is measured in cm and is negative below the
+    !  *           soil surface.
+    !  *****************************************************************************/
+    subroutine wrap_compute_zwt(soil_con, cell)
+        use MOD_Hydro_VIC_Variables
+        implicit none
+
+        !-----------------------Arguments---------------------------------------
+        type(soil_con_struct), intent(in) :: soil_con
+        type(cell_data_struct), intent(inout) :: cell
+        !-----------------------Local Variables---------------------------------
+        integer :: lindex
+        integer :: idx
+        real(r8) :: total_depth
+        real(r8) :: tmp_depth
+        real(r8) :: tmp_moist
+        integer, parameter :: CM_PER_M = 100  !/**< centimeters per meter */
+        real(r8), parameter :: DBL_EPSILON = 2.2204460492503131E-16
+        !-----------------------End Variable List-------------------------------
+
+        ! /** Compute total soil column depth **/
+        total_depth = 0.0
+        do lindex = 1, Nlayer
+            total_depth = total_depth + soil_con%depth(lindex)
+        end do
+
+        ! /** Compute each layer's zwt using soil moisture v zwt curve **/
+        do lindex = 1, Nlayer
+            call compute_zwt(soil_con, lindex, cell%layer(lindex)%moist, cell%layer(lindex)%zwt)
+        end do
+        if (cell%layer(Nlayer)%zwt == 999) then
+            cell%layer(Nlayer)%zwt = -total_depth * CM_PER_M
+        end if
+
+        ! /** Compute total soil column's zwt; this will be the zwt of the lowest layer that isn't completely saturated **/
+        idx = Nlayer
+        tmp_depth = total_depth
+        do while (idx >= 1 .and. soil_con%max_moist(idx) - cell%layer(idx)%moist <= DBL_EPSILON)
+            tmp_depth = tmp_depth - soil_con%depth(idx)
+            idx = idx - 1
+        end do
+        if (idx < 1) then
+            cell%zwt = 0.0
+        else if (idx < Nlayer) then
+            if (cell%layer(idx)%zwt /= 999) then
+                cell%zwt = cell%layer(idx)%zwt
+            else
+                cell%zwt = -tmp_depth * CM_PER_M
+            end if
+        else
+            cell%zwt = cell%layer(idx)%zwt
+        end if
+
+        ! /** Compute total soil column's zwt_lumped; this will be the zwt of all N layers lumped together. **/
+        tmp_moist = 0.0
+        do lindex = 1, Nlayer
+            tmp_moist = tmp_moist + cell%layer(lindex)%moist
+        end do
+        call compute_zwt(soil_con, Nlayer + 1, tmp_moist, cell%zwt_lumped)
+
+        if (cell%zwt_lumped == 999) then
+            cell%zwt_lumped = -total_depth * CM_PER_M   ! // in cm;
+        end if
+    end subroutine wrap_compute_zwt
+end module MOD_Hydro_VIC

--- a/main/HYDRO/MOD_Hydro_VIC_Variables.F90
+++ b/main/HYDRO/MOD_Hydro_VIC_Variables.F90
@@ -1,0 +1,287 @@
+module MOD_Hydro_VIC_Variables
+   USE MOD_Precision
+   implicit none
+
+   ! /***** Define the number of layers used in VIC *****/
+   integer, parameter :: Nlayer = 3           !/**< Number of soil moisture layers in model */
+   integer            :: Nfrost = 1           !/**< Number of frost subareas in model */
+
+   ! /***** Define maximum array sizes for model source code *****/
+   integer, parameter :: MAX_LAYERS = 3       !/**< maximum number of soil moisture layers */
+   integer, parameter :: MAX_FROST_AREAS = 3  !/**< maximum number of frost sub-areas */
+   integer, parameter :: MAX_ZWTVMOIST = 11   !/**< maximum number of points in water table vs moisture curve for each soil layer; should include points at lower and upper boundaries of the layer */
+
+   ! /***** colm layers to vic layers *****/
+   integer, parameter, dimension(:) :: colm2vic_lay(Nlayer) = [3, 6, 10]   !/**< colm layers to vic layers */
+
+   ! /******************************************************************************
+   ! * @brief   This structure stores all soil variables for each layer in the
+   ! *          soil column.
+   ! *****************************************************************************/
+   type layer_data_struct
+      real(r8) :: ice(MAX_FROST_AREAS) ! /**< ice content of the frozen sublayer (mm) */
+      real(r8) :: moist                ! /**< moisture content of the unfrozen sublayer (mm) */
+      real(r8) :: evap                 ! /**< evapotranspiration from soil layer (mm) */
+      real(r8) :: zwt                  ! /**< water table position relative to soil surface within the layer (cm) */
+   end type layer_data_struct
+
+   ! /******************************************************************************
+   ! * @brief   This structure stores soil variables for the complete soil column
+   ! *          for each grid cell.
+   ! *****************************************************************************/
+   type cell_data_struct
+      real(r8) :: asat                       ! /**< saturated area fraction */
+      real(r8) :: baseflow                   ! /**< baseflow from current cell (mm/TS) */
+      real(r8) :: runoff                     ! /**< runoff from current cell (mm/TS) */
+      type(layer_data_struct) :: layer(MAX_LAYERS)    ! /**< structure containing soil variables for each layer (see above) */
+      !!! for zwt calcaulation, not used
+      real(r8) :: zwt                       ! /**< average water table position [cm] - using lowest unsaturated layer */
+      real(r8) :: zwt_lumped                ! /**< average water table position [cm] - lumping all layers' moisture together */
+   end type cell_data_struct
+
+   ! /******************************************************************************
+   ! * @brief   This structure stores the soil parameters for a grid cell.
+   ! *****************************************************************************/
+   type soil_con_struct
+      real(r8) :: frost_fract(MAX_FROST_AREAS) ! /**< spatially distributed frost coverage fractions */
+      real(r8) :: max_moist(MAX_LAYERS)        ! /**< Maximum moisture content (mm) per layer */
+      real(r8) :: resid_moist(MAX_LAYERS)      ! /**< Residual moisture content of soil layer (mm) */
+      real(r8) :: Ksat(MAX_LAYERS)             ! /**< Saturated hydraulic conductivity (mm/day) */
+      real(r8) :: expt(MAX_LAYERS)             ! /**< Layer-specific exponent n (=3+2/lambda) in Campbell's equation for hydraulic conductivity, HBH 5.6 */
+      !!!! to be calibrated
+      real(r8) :: b_infilt                     ! /**< Infiltration parameter */
+      real(r8) :: Ds                           ! /**< Fraction of maximum subsurface flow rate */
+      real(r8) :: Ws                           ! /**< Fraction of maximum soil moisture */
+      real(r8) :: Dsmax                        ! /**< Maximum subsurface flow rate (mm/day) */
+      real(r8) :: c                            ! /**< Exponent in ARNO baseflow scheme */
+      real(r8) :: depth(MAX_LAYERS)            ! /**< Thickness of each soil moisture layer (m) */
+      !!! for zwt calcaulation, not used
+      real(r8) :: bubble(MAX_LAYERS)                                  ! /**< Bubbling pressure, HBH 5.15 (cm)
+      real(r8) :: zwtvmoist_zwt(MAX_LAYERS + 2, MAX_ZWTVMOIST)        ! /**< Zwt values in the zwt-v-moist curve for each layer */
+      real(r8) :: zwtvmoist_moist(MAX_LAYERS + 2, MAX_ZWTVMOIST)      ! /**< Moist values in the zwt-v-moist curve for each layer */
+   end type soil_con_struct  
+
+contains
+
+
+   subroutine vic_para(porsl, theta_r, hksati, bsw, wice_soisno, wliq_soisno, fevpg, rootflux, &
+                        b_infilt, Dsmax, Ds, Ws, c, &
+                        soil_con, cell)
+
+      USE MOD_Precision
+      USE MOD_Vars_Global
+      implicit none
+
+      type(soil_con_struct) , intent(inout) :: soil_con
+      type(cell_data_struct), intent(inout) :: cell
+
+      real(r8), intent(in) :: porsl(1:nl_soil), theta_r(1:nl_soil), hksati(1:nl_soil), bsw(1:nl_soil)
+      real(r8), intent(in) :: wice_soisno(1:nl_soil), wliq_soisno(1:nl_soil)
+      real(r8), intent(in) :: fevpg
+      real(r8), intent(in) :: rootflux(1:nl_soil)
+
+      real(r8), intent(in) :: b_infilt, Dsmax, Ds, Ws, c
+      real(r8) :: soil_tmp(Nlayer), ice_tmp(Nlayer)
+      integer  :: lb, lp, k, ilay
+
+      real(r8) :: dltime !int(DEF_simulation_time%timestep)
+      !-----------------------End Variable List-------------------------------
+
+      dltime = DEF_simulation_time%timestep
+
+      call CoLM2VIC(dz_soi, soil_tmp)
+      soil_con%depth = soil_tmp
+
+      call CoLM2VIC_weight(porsl, soil_tmp)
+      ! convert - to mm
+      soil_con%max_moist = soil_tmp*soil_con%depth*1000
+
+      call CoLM2VIC_weight(theta_r, soil_tmp)
+      ! convert - to mm
+      soil_con%resid_moist = soil_tmp*soil_con%depth*1000
+
+      call CoLM2VIC_weight(hksati, soil_tmp)
+      ! convert mm/s to mm/day
+      soil_con%Ksat = soil_tmp*86400
+
+      call CoLM2VIC_weight(bsw, soil_tmp)
+      ! 2*lambda+3
+      soil_con%expt = soil_tmp*2+3
+
+      soil_con%b_infilt = b_infilt
+      soil_con%Dsmax    = Dsmax
+      soil_con%Ds       = Ds
+      soil_con%Ws       = Ws
+      soil_con%c        = c
+
+      soil_con%frost_fract = 1
+      if (sum(wice_soisno)>0) THEN
+         Nfrost = 3 
+         do k = 1, Nfrost
+            if (Nfrost == 1) then
+               soil_con%frost_fract(k) = 1.0
+            else if (Nfrost == 2) then
+               soil_con%frost_fract(k) = 0.5
+            else
+               soil_con%frost_fract(k) = 1.0 / real(Nfrost - 1, kind=8)
+               if (k == 1 .or. k == Nfrost) then
+                   soil_con%frost_fract(k) = soil_con%frost_fract(k) / 2.0
+               endif
+            endif
+         end do
+      endif
+
+      call CoLM2VIC(wliq_soisno, soil_tmp)
+      do ilay = 1, Nlayer
+         ! mm
+         cell%layer(ilay)%moist = soil_tmp(ilay)
+      enddo
+
+      if (sum(wice_soisno)>0) THEN
+         do ilay = 1, Nlayer
+            lp = colm2vic_lay(ilay)
+            if (ilay==1) THEN
+               lb = 1
+            else 
+               lb = colm2vic_lay(ilay-1)+1 
+            endif   
+            call VIC_IceLay(lb, lp, wice_soisno(lb:lp), ice_tmp)
+            cell%layer(ilay)%ice(:) = ice_tmp
+         enddo
+      endif
+
+      call CoLM2VIC(rootflux, soil_tmp)
+      ! mm/s*dltime to convert to  mm
+      do ilay = 1, Nlayer
+         cell%layer(ilay)%evap = soil_tmp(ilay)*dltime
+      enddo
+      cell%layer(1)%evap = cell%layer(1)%evap + fevpg*dltime
+
+   end subroutine vic_para
+
+
+   subroutine VIC_IceLay(lb, lp, colm_ice, vic_ice)
+
+   implicit none
+   !-----------------------Arguments---------------------------------------
+   integer     , intent(in ) :: lb
+   integer     , intent(in ) :: lp
+   real(kind=8), intent(in ) :: colm_ice(lb:lp)
+   real(kind=8), intent(out) :: vic_ice(3)
+   !-----------------------Local variables---------------------------------
+   integer      :: idx, colm_lay
+   real(kind=8) :: totalSum
+   real(kind=8) :: multiplier
+   real(kind=8) :: ice_tmp(lp-lb+1)
+   integer      :: vic_lay=3     
+   !-----------------------End Variable List-------------------------------
+
+      colm_lay = lp - lb + 1
+      ice_tmp  = colm_ice
+      totalSum = sum(ice_tmp)
+
+      if (colm_lay == 1) THEN
+         vic_ice = totalSum / vic_lay
+      elseif (colm_lay == 2) THEN
+         vic_ice(1) = ice_tmp(1) * 2.0 / vic_lay
+         vic_ice(3) = ice_tmp(2) * 2.0 / vic_lay
+      elseif (colm_lay == 3) THEN
+         vic_ice    = ice_tmp
+      else
+         do idx = 1, min(int((colm_lay-1)/vic_lay), vic_lay)
+            multiplier = merge(1.0, 0.0, colm_lay > idx*vic_lay)
+            vic_ice(1) = vic_ice(1) + ice_tmp(idx) * multiplier
+            vic_ice(3) = vic_ice(3) + ice_tmp(colm_lay-idx+1) * multiplier
+         enddo
+         multiplier = merge((colm_lay-idx*vic_lay)/vic_lay, 0, colm_lay <= (idx+1)*vic_lay)
+         vic_ice(1) = vic_ice(1) + ice_tmp(idx+1) * multiplier
+         vic_ice(3) = vic_ice(3) + ice_tmp(colm_lay-idx) * multiplier
+      endif
+      vic_ice(2) = totalSum - vic_ice(1) - vic_ice(3)
+
+   end subroutine VIC_Icelay
+
+
+   subroutine CoLM2VIC(colm_water, vic_water)
+
+   USE MOD_Vars_Global
+   implicit none
+   !-----------------------Arguments---------------------------------------
+   real, intent(in ) :: colm_water(1:nl_soil)
+   real, intent(out) :: vic_water(Nlayer)
+   !-----------------------Local variables---------------------------------
+   integer :: i_colm, i_vic
+   !-----------------------End Variable List-------------------------------
+
+      do i_vic = 1, Nlayer
+         vic_water(i_vic) = 0
+         if (i_vic == 1) then
+            do i_colm = 1, colm2vic_lay(i_vic)
+               vic_water(i_vic) = vic_water(i_vic) + colm_water(i_colm)
+            end do
+         else
+            do i_colm = colm2vic_lay(i_vic-1)+1, colm2vic_lay(i_vic)
+               vic_water(i_vic) = vic_water(i_vic) + colm_water(i_colm)
+            end do
+         endif
+      end do
+
+   end subroutine CoLM2VIC
+
+
+   subroutine CoLM2VIC_weight(colm_water, vic_water)
+
+   USE MOD_Vars_Global
+   implicit none
+   !-----------------------Arguments---------------------------------------
+   real, intent(in ) :: colm_water(1:nl_soil)
+   real, intent(out) :: vic_water(Nlayer)
+   !-----------------------Local variables---------------------------------
+   integer :: i_colm, i_vic
+   !-----------------------End Variable List-------------------------------
+
+      do i_vic = 1, Nlayer
+         vic_water(i_vic) = 0
+         if (i_vic == 1) then
+            do i_colm = 1, colm2vic_lay(i_vic)
+               vic_water(i_vic) = vic_water(i_vic) + colm_water(i_colm)*dz_soi(i_colm)
+            end do
+            vic_water(i_vic) = vic_water(i_vic)/sum(dz_soi(1:colm2vic_lay(i_vic)))
+         else
+            do i_colm = colm2vic_lay(i_vic-1)+1, colm2vic_lay(i_vic)
+               vic_water(i_vic) = vic_water(i_vic) + colm_water(i_colm)*dz_soi(i_colm)
+            end do
+            vic_water(i_vic) = vic_water(i_vic)/sum(dz_soi(colm2vic_lay(i_vic-1)+1:colm2vic_lay(i_vic)))
+         endif
+      end do
+
+   end subroutine CoLM2VIC_weight
+
+
+   subroutine VIC2CoLM(colm_water, vic_water)
+
+   USE MOD_Vars_Global
+   implicit none
+   !-----------------------Arguments---------------------------------------
+   real, intent(in   ) :: vic_water(Nlayer)
+   real, intent(inout) :: colm_water(1:nl_soil)
+   !-----------------------Local variables---------------------------------
+   integer :: i_colm, i_vic
+   !-----------------------End Variable List-------------------------------
+
+      do i_vic = 1, Nlayer
+         if (i_vic == 1) then
+            do i_colm = 1, colm2vic_lay(i_vic)
+               colm_water(i_colm) = vic_water(i_vic)*(dz_soi(i_colm)/sum(dz_soi(1:colm2vic_lay(i_vic))))
+            end do
+         else
+            do i_colm = colm2vic_lay(i_vic-1)+1, colm2vic_lay(i_vic)
+               colm_water(i_colm) = vic_water(i_vic)*(dz_soi(i_colm)/sum(dz_soi(colm2vic_lay(i_vic-1)+1:colm2vic_lay(i_vic))))
+            end do
+         endif
+      end do
+
+   end subroutine VIC2CoLM
+
+
+end module MOD_Hydro_VIC_Variables

--- a/main/MOD_Forcing.F90
+++ b/main/MOD_Forcing.F90
@@ -189,7 +189,11 @@ CONTAINS
 
       IF (DEF_USE_Forcing_Downscaling) THEN
 
-         forc_topo = topoelv
+         IF (p_is_worker) THEN
+            IF (numpatch > 0) THEN
+               forc_topo = topoelv
+            ENDIF
+         ENDIF
 
          IF (p_is_worker) THEN
 #if (defined CROP)

--- a/main/MOD_Forcing.F90
+++ b/main/MOD_Forcing.F90
@@ -189,9 +189,7 @@ CONTAINS
 
       IF (DEF_USE_Forcing_Downscaling) THEN
 
-         write(cyear,'(i4.4)') lc_year
-         lndname = trim(DEF_dir_landdata) // '/topography/'//trim(cyear)//'/topography_patches.nc'
-         CALL ncio_read_vector (lndname, 'topography_patches', landpatch, forc_topo)
+         forc_topo = topoelv
 
          IF (p_is_worker) THEN
 #if (defined CROP)

--- a/main/MOD_Hist.F90
+++ b/main/MOD_Hist.F90
@@ -454,6 +454,16 @@ CONTAINS
             a_rsur, file_hist, 'f_rsur', itime_in_file, sumarea, filter, &
             'surface runoff','mm/s')
 
+         ! saturation excess surface runoff [mm/s]
+         CALL write_history_variable_2d ( DEF_hist_vars%rsur_se, &
+            a_rsur_se, file_hist, 'f_rsur_se', itime_in_file, sumarea, filter, &
+            'saturation excess surface runoff','mm/s')
+
+         ! infiltration excess surface runoff [mm/s]
+         CALL write_history_variable_2d ( DEF_hist_vars%rsur_ie, &
+            a_rsur_ie, file_hist, 'f_rsur_ie', itime_in_file, sumarea, filter, &
+            'infiltration excess surface runoff','mm/s')
+
          ! subsurface runoff [mm/s]
          CALL write_history_variable_2d ( DEF_hist_vars%rsub, &
             a_rsub, file_hist, 'f_rsub', itime_in_file, sumarea, filter, &

--- a/main/MOD_Runoff.F90
+++ b/main/MOD_Runoff.F90
@@ -19,7 +19,8 @@ CONTAINS
 
    SUBROUTINE SurfaceRunoff_SIMTOP (nl_soil,wtfact,wimp,porsl,psi0,hksati,&
                                     z_soisno,dz_soisno,zi_soisno,&
-                                    eff_porosity,icefrac,zwt,gwat,rsur)
+                                    eff_porosity,icefrac,zwt,gwat,&
+                                    rsur,rsur_se,rsur_ie)
 
 !=======================================================================
 ! the original code was provide by Robert E. Dickinson based on following clues:
@@ -51,6 +52,8 @@ CONTAINS
         zwt                        ! the depth from ground (soil) surface to water table [m]
 
    real(r8), intent(out) :: rsur   ! surface runoff (mm h2o/s)
+   real(r8), intent(out), optional :: rsur_se! saturation excess surface runoff (mm h2o/s)
+   real(r8), intent(out), optional :: rsur_ie! infiltration excess surface runoff (mm h2o/s)
 
 !-----------------------Local Variables---------------------------------
 
@@ -71,6 +74,13 @@ CONTAINS
 ! Surface runoff
       rsur = fsat*max(0.0,gwat) + (1.-fsat)*max(0.,gwat-qinmax)
 
+      IF (present(rsur_se)) THEN
+         rsur_se = fsat*max(0.0,gwat)
+      ENDIF
+
+      IF (present(rsur_ie)) THEN
+         rsur_ie = (1.-fsat)*max(0.,gwat-qinmax)
+      ENDIF
 
    END SUBROUTINE SurfaceRunoff_SIMTOP
 

--- a/main/MOD_Runoff.F90
+++ b/main/MOD_Runoff.F90
@@ -1,0 +1,184 @@
+#include <define.h>
+
+MODULE MOD_Runoff
+
+!-----------------------------------------------------------------------
+   USE MOD_Precision
+   IMPLICIT NONE
+   SAVE
+
+!  PUBLIC MEMBER FUNCTIONS:
+   PUBLIC :: SurfaceRunoff_SIMTOP
+   PUBLIC :: SubsurfaceRunoff_SIMTOP
+   PUBLIC :: Runoff_XinAnJiang
+
+
+!-----------------------------------------------------------------------
+
+CONTAINS
+
+   SUBROUTINE SurfaceRunoff_SIMTOP (nl_soil,wtfact,wimp,porsl,psi0,hksati,&
+                                    z_soisno,dz_soisno,zi_soisno,&
+                                    eff_porosity,icefrac,zwt,gwat,rsur)
+
+!=======================================================================
+! the original code was provide by Robert E. Dickinson based on following clues:
+! a water table level determination level added including highland and
+! lowland levels and fractional area of wetland (water table above the surface.
+! Runoff is parametrized from the lowlands in terms of precip incident on
+! wet areas and a base flow, where these are estimated using ideas from TOPMODEL.
+!
+! Author : Yongjiu Dai, 07/29/2002, Guoyue Niu, 06/2012
+!=======================================================================
+
+   IMPLICIT NONE
+
+!-----------------------Arguments---------------------------------------
+
+   integer, intent(in) :: nl_soil   ! number of soil layers
+   real(r8), intent(in) :: &
+        wtfact,                   &! fraction of model area with high water table
+        wimp,                     &! water impremeable if porosity less than wimp
+        porsl(1:nl_soil),         &! saturated volumetric soil water content(porosity)
+        psi0(1:nl_soil),          &! saturated soil suction (mm) (NEGATIVE)
+        hksati(1:nl_soil),        &! hydraulic conductivity at saturation (mm h2o/s)
+        z_soisno(1:nl_soil),      &! layer depth (m)
+        dz_soisno(1:nl_soil),     &! layer thickness (m)
+        zi_soisno(0:nl_soil),     &! interface level below a "z" level (m)
+        eff_porosity(1:nl_soil),  &! effective porosity = porosity - vol_ice
+        icefrac(1:nl_soil),       &! ice fraction (-)
+        gwat,                     &! net water input from top
+        zwt                        ! the depth from ground (soil) surface to water table [m]
+
+   real(r8), intent(out) :: rsur   ! surface runoff (mm h2o/s)
+
+!-----------------------Local Variables---------------------------------
+
+   real(r8) qinmax       ! maximum infiltration capability
+   real(r8) fsat         ! fractional area with water table at surface
+
+   real(r8), parameter :: fff = 0.5   ! runoff decay factor (m-1)
+
+!-----------------------END Variable List-------------------------------
+
+!  fraction of saturated area
+      fsat = wtfact*min(1.0,exp(-0.5*fff*zwt))
+
+! Maximum infiltration capacity
+      qinmax = minval(10.**(-6.0*icefrac(1:min(3,nl_soil)))*hksati(1:min(3,nl_soil)))
+      IF(eff_porosity(1)<wimp) qinmax = 0.
+
+! Surface runoff
+      rsur = fsat*max(0.0,gwat) + (1.-fsat)*max(0.,gwat-qinmax)
+
+
+   END SUBROUTINE SurfaceRunoff_SIMTOP
+
+! -------------------------------------------------------------------------
+   SUBROUTINE SubsurfaceRunoff_SIMTOP (nl_soil, icefrac, dz_soisno, zi_soisno, zwt, rsubst)
+
+! ARGUMENTS:
+   IMPLICIT NONE
+
+   integer,  intent(in) :: nl_soil       !
+   real(r8), intent(in) :: icefrac(1:nl_soil)      ! ice fraction (-)
+
+   real(r8), intent(in) :: dz_soisno  (1:nl_soil)  ! layer depth (m)
+   real(r8), intent(in) :: zi_soisno  (0:nl_soil)  ! interface level below a "z" level (m)
+
+   real(r8), intent(in)  :: zwt    ! the depth from ground (soil) surface to water table [m]
+   real(r8), intent(out) :: rsubst ! subsurface runoff (positive = out of soil column) (mm H2O /s)
+
+! LOCAL ARGUMENTS
+
+   integer  :: j                ! indices
+   integer  :: jwt              ! index of the soil layer right above the water table (-)
+   real(r8) :: dzmm(1:nl_soil)  ! layer thickness (mm)
+
+   real(r8) :: dzsum
+   real(r8) :: icefracsum
+   real(r8) :: fracice_rsub
+   real(r8) :: imped
+
+      DO j = 1,nl_soil
+         dzmm(j) = dz_soisno(j)*1000.
+      ENDDO
+
+      jwt = nl_soil
+      ! allow jwt to equal zero when zwt is in top layer
+      DO j = 1, nl_soil
+         IF(zwt <= zi_soisno(j)) THEN
+            jwt = j-1
+            EXIT
+         ENDIF
+      ENDDO
+
+      !-- Topographic runoff  --
+      dzsum = 0.
+      icefracsum = 0.
+      DO j = max(jwt,1), nl_soil
+         dzsum = dzsum + dzmm(j)
+         icefracsum = icefracsum + icefrac(j) * dzmm(j)
+      ENDDO
+      ! add ice impedance factor to baseflow
+      fracice_rsub = max(0.,exp(-3.*(1.-(icefracsum/dzsum)))-exp(-3.))/(1.0-exp(-3.))
+      imped = max(0.,1.-fracice_rsub)
+      rsubst = imped * 5.5e-3 * exp(-2.5*zwt)  
+
+   END SUBROUTINE SubsurfaceRunoff_SIMTOP
+
+! -------------------------------------------------------------------------
+   SUBROUTINE Runoff_XinAnJiang ( &
+         nl_soil, dz_soisno, eff_porosity, vol_liq, topostd, gwat, deltim, &
+         rsur, rsubst)
+
+   USE MOD_Precision
+   IMPLICIT NONE
+
+   integer,  intent(in) :: nl_soil ! number of soil layers
+
+   real(r8), intent(in) :: &
+        dz_soisno   (1:nl_soil),  &! layer thickness (m)
+        eff_porosity(1:nl_soil),  &! effective porosity = porosity - vol_ice
+        vol_liq     (1:nl_soil),  &! partial volume of liquid water in layer
+        topostd,                  &! standard deviation of elevation (m)
+        gwat,                     &! net water input from top
+        deltim                     ! time step (s)
+
+   real(r8), intent(out) :: rsur   ! surface runoff (mm h2o/s)
+   real(r8), intent(out) :: rsubst ! subsurface runoff (mm h2o/s)
+
+   ! Local Variables
+   real(r8) :: btopo, watin, w_int, wsat_int, wtmp, infil
+   real(r8), parameter :: sigmin = 100.
+   real(r8), parameter :: sigmax = 1000.
+
+      watin = gwat * deltim / 1000.
+
+      IF (watin <= 0.) THEN
+
+         rsur   = 0.
+         rsubst = 0.
+
+      ELSE
+
+         btopo = (topostd - sigmin) / (topostd - sigmax)
+         btopo = min(max(btopo, 0.01), 0.5)
+
+         w_int    = sum(vol_liq     (1:6) * dz_soisno(1:6))
+         wsat_int = sum(eff_porosity(1:6) * dz_soisno(1:6))
+
+         wtmp  = (1-w_int/wsat_int)**(1/(btopo+1)) - watin/((btopo+1)*wsat_int)
+         infil = wsat_int - w_int - wsat_int * (max(0., wtmp))**(btopo+1)
+
+         infil = min(infil, watin)
+
+         rsur   = (watin - infil) * 1000. / deltim 
+         rsubst = 0.
+
+      ENDIF
+
+   END SUBROUTINE Runoff_XinAnJiang
+
+END MODULE MOD_Runoff
+! --------- EOP ----------

--- a/main/MOD_SoilSnowHydrology.F90
+++ b/main/MOD_SoilSnowHydrology.F90
@@ -43,7 +43,7 @@ CONTAINS
 
    SUBROUTINE WATER_2014 (ipatch,patchtype,lb       ,nl_soil ,deltim,&
               z_soisno    ,dz_soisno   ,zi_soisno   ,bsw     ,porsl ,&
-              psi0        ,hksati      ,topostd     ,theta_r ,&
+              psi0        ,hksati      ,theta_r     ,topostd ,&
               rootr       ,rootflux    ,t_soisno    ,&
               wliq_soisno ,wice_soisno ,smp         ,hk      ,pg_rain ,&
               sm,   etr   ,qseva       ,qsdew       ,qsubl   ,qfros ,&

--- a/main/MOD_SoilSnowHydrology.F90
+++ b/main/MOD_SoilSnowHydrology.F90
@@ -43,7 +43,7 @@ CONTAINS
 
    SUBROUTINE WATER_2014 (ipatch,patchtype,lb       ,nl_soil ,deltim,&
               z_soisno    ,dz_soisno   ,zi_soisno   ,bsw     ,porsl ,&
-              psi0        ,hksati      ,topostd     ,&
+              psi0        ,hksati      ,topostd     ,theta_r ,&
               rootr       ,rootflux    ,t_soisno    ,&
               wliq_soisno ,wice_soisno ,smp         ,hk      ,pg_rain ,&
               sm,   etr   ,qseva       ,qsdew       ,qsubl   ,qfros ,&
@@ -79,7 +79,7 @@ CONTAINS
 
    USE MOD_Precision
    USE MOD_Const_Physical,      only : denice, denh2o, tfrz
-   USE MOD_Vars_TimeInvariants, only : theta_r, vic_b_infilt, vic_Dsmax, vic_Ds, vic_Ws, vic_c
+   USE MOD_Vars_TimeInvariants, only : vic_b_infilt, vic_Dsmax, vic_Ds, vic_Ws, vic_c
    USE MOD_Vars_1DFluxes,       only : fevpg
 
    IMPLICIT NONE
@@ -110,6 +110,7 @@ CONTAINS
         porsl(1:nl_soil) , &! saturated volumetric soil water content(porosity)
         psi0(1:nl_soil)  , &! saturated soil suction (mm) (NEGATIVE)
         hksati(1:nl_soil), &! hydraulic conductivity at saturation (mm h2o/s)
+        theta_r(1:nl_soil),&! residual moisture content [-]
         rootr(1:nl_soil) , &! water uptake farction from different layers, all layers add to 1.0
         rootflux(1:nl_soil),&! root uptake from different layer, all layers add to transpiration
 
@@ -298,7 +299,7 @@ IF(patchtype<=1)THEN   ! soil ground only
       ELSEIF (DEF_Runoff_SCHEME  == 1) THEN 
          ! 1: runoff scheme from VIC model
       
-         call vic_para(porsl, theta_r(:,ipatch), hksati, bsw, wice_soisno, wliq_soisno, fevpg(ipatch), rootflux, &
+         call vic_para(porsl, theta_r, hksati, bsw, wice_soisno, wliq_soisno, fevpg(ipatch), rootflux, &
             vic_b_infilt(ipatch), vic_Dsmax(ipatch), vic_Ds(ipatch), vic_Ws(ipatch), vic_c(ipatch),&
             soil_con, cell)
 

--- a/main/MOD_SoilSnowHydrology.F90
+++ b/main/MOD_SoilSnowHydrology.F90
@@ -289,7 +289,7 @@ IF(patchtype<=1)THEN   ! soil ground only
          ! 0: runoff scheme from TOPMODEL
          
          IF (gwat > 0.) THEN
-            CALL surfacerunoff_SIMTOP (nl_soil,wtfact,wimp,porsl,psi0,hksati,&
+            CALL SurfaceRunoff_SIMTOP (nl_soil,wtfact,wimp,porsl,psi0,hksati,&
                z_soisno(1:),dz_soisno(1:),zi_soisno(0:),&
                eff_porosity,icefrac,zwt,gwat,rsur)
          ELSE
@@ -335,7 +335,7 @@ IF(patchtype<=1)THEN   ! soil ground only
             ! surface runoff from inundation, this should not be added to the surface runoff from soil
             ! otherwise, the surface runoff will be double counted.
             ! only the re-infiltration is added to water balance calculation.
-            CALL surfacerunoff_SIMTOP (nl_soil,1.0,wimp,porsl,psi0,hksati,&
+            CALL SurfaceRunoff_SIMTOP (nl_soil,1.0,wimp,porsl,psi0,hksati,&
                        z_soisno(1:),dz_soisno(1:),zi_soisno(0:),&
                        eff_porosity,icefrac,zwt,gfld,rsur_fld)
             ! infiltration into surface soil layer
@@ -754,17 +754,15 @@ IF(patchtype<=1)THEN   ! soil ground only
       IF (DEF_Runoff_SCHEME  == 0) THEN
 
          IF (gwat > 0.) THEN
-            CALL surfacerunoff_SIMTOP (nl_soil,wtfact,wimp,porsl,psi0,hksati,&
+            CALL SurfaceRunoff_SIMTOP (nl_soil,wtfact,wimp,porsl,psi0,hksati,&
                                        z_soisno(1:),dz_soisno(1:),zi_soisno(0:),&
                                        eff_porosity,icefrac,zwt,gwat,rsur)
          ELSE
             rsur = 0.
          ENDIF
       
-         IF (DEF_Runoff_SCHEME == 0) THEN 
-            CALL SubsurfaceRunoff_SIMTOP (nl_soil, icefrac, dz_soisno(1:), zi_soisno(0:), &
-               zwt, rsubst)
-         ENDIF
+         CALL SubsurfaceRunoff_SIMTOP (nl_soil, icefrac, dz_soisno(1:), zi_soisno(0:), &
+            zwt, rsubst)
 
       ELSEIF (DEF_Runoff_SCHEME  == 1) THEN 
          ! 1: runoff scheme from VIC model
@@ -818,7 +816,7 @@ IF(patchtype<=1)THEN   ! soil ground only
             ! surface runoff from inundation, this should not be added to the surface runoff from soil
             ! otherwise, the surface runoff will be double counted.
             ! only the re-infiltration is added to water balance calculation.
-            CALL surfacerunoff_SIMTOP (nl_soil,1.0,wimp,porsl,psi0,hksati,&
+            CALL SurfaceRunoff_SIMTOP (nl_soil,1.0,wimp,porsl,psi0,hksati,&
                z_soisno(1:),dz_soisno(1:),zi_soisno(0:),&
                eff_porosity,icefrac,zwt,gfld,rsur_fld)
             ! infiltration into surface soil layer

--- a/main/MOD_SoilSnowHydrology.F90
+++ b/main/MOD_SoilSnowHydrology.F90
@@ -4,9 +4,9 @@ MODULE MOD_SoilSnowHydrology
 
 !-----------------------------------------------------------------------
    USE MOD_Precision
-   USE MOD_Namelist, only: DEF_USE_PLANTHYDRAULICS, DEF_USE_SNICAR, &
-                          DEF_URBAN_RUN, DEF_USE_IRRIGATION, &
-                          DEF_SPLIT_SOILSNOW
+   USE MOD_Namelist, only: DEF_USE_PLANTHYDRAULICS, DEF_USE_SNICAR,     &
+                           DEF_URBAN_RUN,           DEF_USE_IRRIGATION, &
+                           DEF_SPLIT_SOILSNOW,      DEF_Runoff_SCHEME
 #if(defined CaMa_Flood)
    USE YOS_CMF_INPUT,      only: LWINFILT
 #endif
@@ -15,6 +15,9 @@ MODULE MOD_SoilSnowHydrology
    USE MOD_Irrigation, only: CalIrrigationApplicationFluxes
 #endif
    USE MOD_LandPatch, only: landpatch
+   USE MOD_Runoff
+   USE MOD_Hydro_VIC
+   USE MOD_Hydro_VIC_Variables
    IMPLICIT NONE
    SAVE
 
@@ -27,8 +30,7 @@ MODULE MOD_SoilSnowHydrology
 
 
 !  PRIVATE MEMBER FUNCTIONS:
-   PRIVATE :: surfacerunoff
-   PRIVATE :: subsurfacerunoff
+   PRIVATE :: groundwater
 
 
 !-----------------------------------------------------------------------
@@ -41,7 +43,8 @@ CONTAINS
 
    SUBROUTINE WATER_2014 (ipatch,patchtype,lb       ,nl_soil ,deltim,&
               z_soisno    ,dz_soisno   ,zi_soisno   ,bsw     ,porsl ,&
-              psi0        ,hksati      ,rootr       ,rootflux,t_soisno,&
+              psi0        ,hksati      ,topostd     ,&
+              rootr       ,rootflux    ,t_soisno    ,&
               wliq_soisno ,wice_soisno ,smp         ,hk      ,pg_rain ,&
               sm,   etr   ,qseva       ,qsdew       ,qsubl   ,qfros ,&
               qseva_soil  ,qsdew_soil  ,qsubl_soil  ,qfros_soil     ,&
@@ -68,14 +71,16 @@ CONTAINS
 ! FLOW DIAGRAM FOR WATER_2014.F90
 !
 ! WATER_2014 ===> snowwater
-!                 surfacerunoff
+!                 SurfaceRunoff_SIMTOP
 !                 soilwater
-!                 subsurfacerunoff
+!                 SubsurfaceRunoff_SIMTOP
 !
 !=======================================================================
 
    USE MOD_Precision
-   USE MOD_Const_Physical, only : denice, denh2o, tfrz
+   USE MOD_Const_Physical,      only : denice, denh2o, tfrz
+   USE MOD_Vars_TimeInvariants, only : theta_r, vic_b_infilt, vic_Dsmax, vic_Ds, vic_Ws, vic_c
+   USE MOD_Vars_1DFluxes,       only : fevpg
 
    IMPLICIT NONE
 
@@ -96,6 +101,7 @@ CONTAINS
         ssi              , &! irreducible water saturation of snow
         wimp             , &! water impremeable if porosity less than wimp
         smpmin           , &! restriction for min of soil poten. (mm)
+        topostd          , &! standard deviation of elevation (m)
         z_soisno (lb:nl_soil)   , &! layer depth (m)
         dz_soisno(lb:nl_soil)   , &! layer thickness (m)
         zi_soisno(lb-1:nl_soil) , &! interface level below a "z" level (m)
@@ -190,6 +196,12 @@ CONTAINS
    real(r8) :: qflx_irrig_paddy
 #endif
 
+   ! **
+   type(soil_con_struct ) :: soil_con
+   type(cell_data_struct) :: cell
+   integer  :: ilay
+   real(r8) :: vic_tmp(Nlayer)
+
 !=======================================================================
 ! [1] update the liquid water within snow layer and the water onto soil
 !=======================================================================
@@ -269,13 +281,44 @@ IF(patchtype<=1)THEN   ! soil ground only
 
       ! surface runoff including water table and surface staturated area
 
-      rsur = 0.
-      IF (gwat > 0.) THEN
-         CALL surfacerunoff (nl_soil,wtfact,wimp,porsl,psi0,hksati,&
-                          z_soisno(1:),dz_soisno(1:),zi_soisno(0:),&
-                          eff_porosity,icefrac,zwt,gwat,rsur)
-      ELSE
-         rsur = 0.
+      rsur   = 0.
+      rsubst = 0.
+
+      IF (DEF_Runoff_SCHEME  == 0) THEN
+         ! 0: runoff scheme from TOPMODEL
+         
+         IF (gwat > 0.) THEN
+            CALL surfacerunoff_SIMTOP (nl_soil,wtfact,wimp,porsl,psi0,hksati,&
+               z_soisno(1:),dz_soisno(1:),zi_soisno(0:),&
+               eff_porosity,icefrac,zwt,gwat,rsur)
+         ELSE
+            rsur = 0.
+         ENDIF
+
+      ELSEIF (DEF_Runoff_SCHEME  == 1) THEN 
+         ! 1: runoff scheme from VIC model
+      
+         call vic_para(porsl, theta_r(:,ipatch), hksati, bsw, wice_soisno, wliq_soisno, fevpg(ipatch), rootflux, &
+            vic_b_infilt(ipatch), vic_Dsmax(ipatch), vic_Ds(ipatch), vic_Ws(ipatch), vic_c(ipatch),&
+            soil_con, cell)
+
+         call compute_vic_runoff(soil_con, gwat*deltim, soil_con%frost_fract, cell)
+
+         DO ilay = 1, Nlayer
+            vic_tmp(ilay) = cell%layer(ilay)%moist
+         ENDDO
+         call VIC2CoLM(wliq_soisno, vic_tmp)
+
+         if (gwat > 0.) rsur = cell%runoff/deltim
+         rsubst = cell%baseflow/deltim
+
+      ELSEIF (DEF_Runoff_SCHEME  == 2) THEN 
+         ! 2: runoff scheme from XinAnJiang model
+
+         CALL Runoff_XinAnJiang (&
+            nl_soil, dz_soisno(1:nl_soil), eff_porosity(1:nl_soil), vol_liq(1:nl_soil), &
+            topostd, gwat, deltim, rsur, rsubst)
+
       ENDIF
 
       ! infiltration into surface soil layer
@@ -291,7 +334,7 @@ IF(patchtype<=1)THEN   ! soil ground only
             ! surface runoff from inundation, this should not be added to the surface runoff from soil
             ! otherwise, the surface runoff will be double counted.
             ! only the re-infiltration is added to water balance calculation.
-            CALL surfacerunoff (nl_soil,1.0,wimp,porsl,psi0,hksati,&
+            CALL surfacerunoff_SIMTOP (nl_soil,1.0,wimp,porsl,psi0,hksati,&
                        z_soisno(1:),dz_soisno(1:),zi_soisno(0:),&
                        eff_porosity,icefrac,zwt,gfld,rsur_fld)
             ! infiltration into surface soil layer
@@ -333,11 +376,11 @@ IF(patchtype<=1)THEN   ! soil ground only
 ! [4] subsurface runoff and the corrections
 !=======================================================================
 
-      CALL subsurfacerunoff (nl_soil,deltim,pondmx,&
-                             eff_porosity,icefrac,dz_soisno(1:),zi_soisno(0:),&
-                             wice_soisno(1:),wliq_soisno(1:),&
-                             porsl,psi0,bsw,zwt,wa,&
-                             qcharge,rsubst,errw_rsub)
+      CALL groundwater (nl_soil,deltim,pondmx,&
+                        eff_porosity,icefrac,dz_soisno(1:),zi_soisno(0:),&
+                        wice_soisno(1:),wliq_soisno(1:),&
+                        porsl,psi0,bsw,zwt,wa,&
+                        qcharge,rsubst,errw_rsub)
 
       ! total runoff (mm/s)
       rnof = rsubst + rsur
@@ -423,12 +466,9 @@ ENDIF
 !-----------------------------------------------------------------------
    SUBROUTINE WATER_VSF (ipatch,  patchtype,lb      ,nl_soil ,deltim ,&
               z_soisno    ,dz_soisno   ,zi_soisno                    ,&
-#ifdef Campbell_SOIL_MODEL
-              bsw         ,                                           &
-#endif
+              bsw         ,theta_r     ,topostd                      ,&
 #ifdef vanGenuchten_Mualem_SOIL_MODEL
-              theta_r     ,alpha_vgm   ,n_vgm       ,L_vgm   ,        &
-              sc_vgm      ,fc_vgm      ,                              &
+              alpha_vgm   ,n_vgm       ,L_vgm       ,sc_vgm  ,fc_vgm ,&
 #endif
               porsl       ,psi0        ,hksati      ,rootr   ,rootflux,&
               t_soisno    ,wliq_soisno ,wice_soisno ,smp     ,hk     ,&
@@ -468,7 +508,9 @@ ENDIF
    USE MOD_Precision
    USE MOD_Hydro_SoilWater
    USE MOD_Vars_TimeInvariants, only : wetwatmax
-   USE MOD_Const_Physical, only : denice, denh2o, tfrz
+   USE MOD_Const_Physical,      only : denice, denh2o, tfrz
+   USE MOD_Vars_TimeInvariants, only : vic_b_infilt, vic_Dsmax, vic_Ds, vic_Ws, vic_c
+   USE MOD_Vars_1DFluxes,       only : fevpg
 #ifdef DataAssimilation
    USE MOD_DA_GRACE, only : fslp_k
 #endif
@@ -491,14 +533,13 @@ ENDIF
         ssi              , &! irreducible water saturation of snow
         pondmx           , &! ponding depth (mm)
         wimp             , &! water impremeable IF porosity less than wimp
+        topostd          , &! standard deviation of elevation (m)
         z_soisno (lb:nl_soil)   , &! layer depth (m)
         dz_soisno(lb:nl_soil)   , &! layer thickness (m)
         zi_soisno(lb-1:nl_soil) , &! interface level below a "z" level (m)
-#ifdef Campbell_SOIL_MODEL
         bsw      (1:nl_soil), &! clapp and hornbereger "b" parameter [-]
-#endif
-#ifdef vanGenuchten_Mualem_SOIL_MODEL
         theta_r  (1:nl_soil), & ! residual moisture content [-]
+#ifdef vanGenuchten_Mualem_SOIL_MODEL
         alpha_vgm(1:nl_soil), & ! a parameter corresponding approximately to the inverse of the air-entry value
         n_vgm    (1:nl_soil), & ! a shape parameter [dimensionless]
         L_vgm    (1:nl_soil), & ! pore-connectivity parameter [dimensionless]
@@ -600,10 +641,6 @@ ENDIF
 #endif
 
 #ifdef Campbell_SOIL_MODEL
-   real(r8) :: theta_r(1:nl_soil)
-#endif
-
-#ifdef Campbell_SOIL_MODEL
    integer, parameter :: nprms = 1
 #endif
 #ifdef vanGenuchten_Mualem_SOIL_MODEL
@@ -614,9 +651,10 @@ ENDIF
    real(r8) :: gfld,qinfl_all,rsur_fld, qinfl_fld_subgrid! inundation water input from top (mm/s)
 #endif
 
-#ifdef Campbell_SOIL_MODEL
-      theta_r(1:nl_soil) = 0._r8
-#endif
+   type(soil_con_struct ) :: soil_con
+   type(cell_data_struct) :: cell
+   integer  :: ilay
+   real(r8) :: vic_tmp(Nlayer)
 
 !=======================================================================
 ! [1] update the liquid water within snow layer and the water onto soil
@@ -712,24 +750,61 @@ IF(patchtype<=1)THEN   ! soil ground only
       ! surface runoff including water table and surface staturated area
 
 #ifndef CatchLateralFlow
-      IF (gwat > 0.) THEN
-         CALL surfacerunoff (nl_soil,wtfact,wimp,porsl,psi0,hksati,&
-                             z_soisno(1:),dz_soisno(1:),zi_soisno(0:),&
-                             eff_porosity,icefrac,zwt,gwat,rsur)
-      ELSE
-         rsur = 0.
+      IF (DEF_Runoff_SCHEME  == 0) THEN
+
+         IF (gwat > 0.) THEN
+            CALL surfacerunoff_SIMTOP (nl_soil,wtfact,wimp,porsl,psi0,hksati,&
+                                       z_soisno(1:),dz_soisno(1:),zi_soisno(0:),&
+                                       eff_porosity,icefrac,zwt,gwat,rsur)
+         ELSE
+            rsur = 0.
+         ENDIF
+      
+         IF (DEF_Runoff_SCHEME == 0) THEN 
+            CALL SubsurfaceRunoff_SIMTOP (nl_soil, icefrac, dz_soisno(1:), zi_soisno(0:), &
+               zwt, rsubst)
+         ENDIF
+
+      ELSEIF (DEF_Runoff_SCHEME  == 1) THEN 
+         ! 1: runoff scheme from VIC model
+      
+         call vic_para(porsl, theta_r, hksati, bsw, wice_soisno, wliq_soisno, fevpg(ipatch), rootflux, &
+            vic_b_infilt(ipatch), vic_Dsmax(ipatch), vic_Ds(ipatch), vic_Ws(ipatch), vic_c(ipatch),&
+            soil_con, cell)
+
+         call compute_vic_runoff(soil_con, gwat*deltim, soil_con%frost_fract, cell)
+
+         DO ilay = 1, Nlayer
+            vic_tmp(ilay) = cell%layer(ilay)%moist
+         ENDDO
+         call VIC2CoLM(wliq_soisno, vic_tmp)
+
+         if (gwat > 0.) rsur = cell%runoff/deltim
+         rsubst = cell%baseflow/deltim
+
+      ELSEIF (DEF_Runoff_SCHEME  == 2) THEN 
+         ! 2: runoff scheme from XinAnJiang model
+
+         CALL Runoff_XinAnJiang (&
+            nl_soil, dz_soisno(1:nl_soil), eff_porosity(1:nl_soil), vol_liq(1:nl_soil), &
+            topostd, gwat, deltim, rsur, rsubst)
+
       ENDIF
 
 #ifdef DataAssimilation
       rsur = max(min(rsur * fslp_k(ipatch), gwat), 0.)
+      rsubst = rsubst * fslp_k(ipatch)
 #endif
 
       ! infiltration into surface soil layer
       qgtop = gwat - rsur
 #else
-      ! for lateral flow, "rsur" is calculated in HYDRO/MOD_Hydro_SurfaceFlow.F90
+      ! for lateral flow, 
+      ! "rsur" is calculated in HYDRO/MOD_Hydro_SurfaceFlow.F90
       ! and is removed from surface water there.
       qgtop = gwat
+      ! "rsub" is calculated and removed from soil water in HYDRO/MOD_Hydro_SubsurfaceFlow.F90
+      rsubst = 0
 #endif
 
 #if(defined CaMa_Flood)
@@ -742,7 +817,7 @@ IF(patchtype<=1)THEN   ! soil ground only
             ! surface runoff from inundation, this should not be added to the surface runoff from soil
             ! otherwise, the surface runoff will be double counted.
             ! only the re-infiltration is added to water balance calculation.
-            CALL surfacerunoff (nl_soil,1.0,wimp,porsl,psi0,hksati,&
+            CALL surfacerunoff_SIMTOP (nl_soil,1.0,wimp,porsl,psi0,hksati,&
                z_soisno(1:),dz_soisno(1:),zi_soisno(0:),&
                eff_porosity,icefrac,zwt,gfld,rsur_fld)
             ! infiltration into surface soil layer
@@ -774,39 +849,6 @@ IF(patchtype<=1)THEN   ! soil ground only
             zwtmm = sp_zi(j)
          ENDIF
       ENDDO
-
-#ifndef CatchLateralFlow
-      !-- Topographic runoff  ----------------------------------------------------------
-      imped = 1.0
-      IF (zwtmm < sp_zi(nl_soil)) THEN
-         dzsum = 0.
-         icefracsum = 0.
-         DO j = nl_soil, 1, -1
-            sp_dz(j) = sp_zi(j) - sp_zi(j-1)
-            IF (zwtmm < sp_zi(j)) THEN
-               dz = min(sp_dz(j), sp_zi(j)-zwtmm)
-               dzsum = dzsum + dz
-               icefracsum = icefracsum + icefrac(j) * dz
-            ENDIF
-         ENDDO
-         ! add ice impedance factor to baseflow
-         IF (dzsum > 0) THEN
-            fracice_rsub = max(0.,exp(-3.*(1.-(icefracsum/dzsum)))-exp(-3.))/(1.0-exp(-3.))
-            imped = max(0.,1.-fracice_rsub)
-         ENDIF
-      ENDIF
-
-      rsubst = imped * 5.5e-3 * exp(-2.5*zwt)  ! drainage (positive = out of soil column)
-#ifdef DataAssimilation
-      rsubst = rsubst * fslp_k(ipatch)
-#endif
-
-#else
-      ! for lateral flow:
-      ! "rsub" is calculated and removed from soil water in HYDRO/MOD_Hydro_SubsurfaceFlow.F90
-      rsubst = 0
-#endif
-
 
 #ifdef Campbell_SOIL_MODEL
       prms(1,:) = bsw(1:nl_soil)
@@ -1550,65 +1592,6 @@ ENDIF
 
    END SUBROUTINE SnowWater_snicar
 
-   SUBROUTINE surfacerunoff (nl_soil,wtfact,wimp,porsl,psi0,hksati,&
-                             z_soisno,dz_soisno,zi_soisno,&
-                             eff_porosity,icefrac,zwt,gwat,rsur)
-
-!=======================================================================
-! the original code was provide by Robert E. Dickinson based on following clues:
-! a water table level determination level added including highland and
-! lowland levels and fractional area of wetland (water table above the surface.
-! Runoff is parametrized from the lowlands in terms of precip incident on
-! wet areas and a base flow, where these are estimated using ideas from TOPMODEL.
-!
-! Author : Yongjiu Dai, 07/29/2002, Guoyue Niu, 06/2012
-!=======================================================================
-
-   USE MOD_Precision
-   IMPLICIT NONE
-
-!-----------------------Arguments---------------------------------------
-
-   integer, intent(in) :: nl_soil   ! number of soil layers
-   real(r8), intent(in) :: &
-        wtfact,                   &! fraction of model area with high water table
-        wimp,                     &! water impremeable if porosity less than wimp
-        porsl(1:nl_soil),         &! saturated volumetric soil water content(porosity)
-        psi0(1:nl_soil),          &! saturated soil suction (mm) (NEGATIVE)
-        hksati(1:nl_soil),        &! hydraulic conductivity at saturation (mm h2o/s)
-        z_soisno(1:nl_soil),      &! layer depth (m)
-        dz_soisno(1:nl_soil),     &! layer thickness (m)
-        zi_soisno(0:nl_soil),     &! interface level below a "z" level (m)
-        eff_porosity(1:nl_soil),  &! effective porosity = porosity - vol_ice
-        icefrac(1:nl_soil),       &! ice fraction (-)
-        gwat,                     &! net water input from top
-        zwt                        ! the depth from ground (soil) surface to water table [m]
-
-   real(r8), intent(out) :: rsur   ! surface runoff (mm h2o/s)
-
-!-----------------------Local Variables---------------------------------
-
-   real(r8) qinmax       ! maximum infiltration capability
-   real(r8) fsat         ! fractional area with water table at surface
-
-   real(r8), parameter :: fff = 0.5   ! runoff decay factor (m-1)
-
-!-----------------------END Variable List-------------------------------
-
-!  fraction of saturated area
-      fsat = wtfact*min(1.0,exp(-0.5*fff*zwt))
-
-! Maximum infiltration capacity
-      qinmax = minval(10.**(-6.0*icefrac(1:min(3,nl_soil)))*hksati(1:min(3,nl_soil)))
-      IF(eff_porosity(1)<wimp) qinmax = 0.
-
-! Surface runoff
-      rsur = fsat*max(0.0,gwat) + (1.-fsat)*max(0.,gwat-qinmax)
-
-
-   END SUBROUTINE surfacerunoff
-
-
 
    SUBROUTINE soilwater(patchtype,nl_soil,deltim,wimp,smpmin,&
                         qinfl,etr,z_soisno,dz_soisno,zi_soisno,&
@@ -1973,11 +1956,11 @@ ENDIF
    END SUBROUTINE soilwater
 
 
-   SUBROUTINE subsurfacerunoff(nl_soil,deltim,pondmx,&
-                               eff_porosity,icefrac,&
-                               dz_soisno,zi_soisno,wice_soisno,wliq_soisno,&
-                               porsl,psi0,bsw,zwt,wa,&
-                               qcharge,rsubst,errw_rsub)
+   SUBROUTINE groundwater (nl_soil,deltim,pondmx,&
+                           eff_porosity,icefrac,&
+                           dz_soisno,zi_soisno,wice_soisno,wliq_soisno,&
+                           porsl,psi0,bsw,zwt,wa,&
+                           qcharge,rsubst,errw_rsub)
 
 ! -------------------------------------------------------------------------
 
@@ -2007,7 +1990,7 @@ ENDIF
    real(r8), intent(inout) :: zwt       ! the depth from ground (soil) surface to water table [m]
    real(r8), intent(inout) :: wa        ! water in the unconfined aquifer (mm)
    real(r8), intent(in)    :: qcharge   ! aquifer recharge rate (positive to aquifer) (mm/s)
-   real(r8), intent(out)   :: rsubst    ! drainage drainage (positive = out of soil column) (mm H2O /s)
+   real(r8), intent(inout) :: rsubst    ! subsurface runoff (positive = out of soil column) (mm H2O /s)
    real(r8), intent(out)   :: errw_rsub ! the possible subsurface runoff dificit after PHS is included
 
 !
@@ -2120,16 +2103,22 @@ ENDIF
       ENDIF
 
 !-- Topographic runoff  ----------------------------------------------------------
-      dzsum = 0.
-      icefracsum = 0.
-      DO j = max(jwt,1), nl_soil
-         dzsum = dzsum + dzmm(j)
-         icefracsum = icefracsum + icefrac(j) * dzmm(j)
-      ENDDO
-      ! add ice impedance factor to baseflow
-      fracice_rsub = max(0.,exp(-3.*(1.-(icefracsum/dzsum)))-exp(-3.))/(1.0-exp(-3.))
-      imped = max(0.,1.-fracice_rsub)
-      drainage = imped * 5.5e-3 * exp(-2.5*zwt)  ! drainage (positive = out of soil column)
+      IF (DEF_Runoff_SCHEME == 0) THEN 
+         CALL SubsurfaceRunoff_SIMTOP (nl_soil, icefrac, dz_soisno, zi_soisno, zwt, rsubst)
+      ENDIF
+
+      drainage = rsubst
+
+      ! dzsum = 0.
+      ! icefracsum = 0.
+      ! DO j = max(jwt,1), nl_soil
+      !    dzsum = dzsum + dzmm(j)
+      !    icefracsum = icefracsum + icefrac(j) * dzmm(j)
+      ! ENDDO
+      ! ! add ice impedance factor to baseflow
+      ! fracice_rsub = max(0.,exp(-3.*(1.-(icefracsum/dzsum)))-exp(-3.))/(1.0-exp(-3.))
+      ! imped = max(0.,1.-fracice_rsub)
+      ! drainage = imped * 5.5e-3 * exp(-2.5*zwt)  ! drainage (positive = out of soil column)
 
 !-- Water table is below the soil column  ----------------------------------------
       IF(jwt == nl_soil) THEN
@@ -2268,7 +2257,7 @@ ENDIF
 !     ! Sub-surface runoff and drainage
 !     rsubst = rsubst - xs/deltim
 
-   END SUBROUTINE subsurfacerunoff
+   END SUBROUTINE groundwater
 
 
 END MODULE MOD_SoilSnowHydrology

--- a/main/MOD_Vars_1DAccFluxes.F90
+++ b/main/MOD_Vars_1DAccFluxes.F90
@@ -37,6 +37,8 @@ MODULE MOD_Vars_1DAccFluxes
    real(r8), allocatable :: a_xerr   (:)
    real(r8), allocatable :: a_zerr   (:)
    real(r8), allocatable :: a_rsur   (:)
+   real(r8), allocatable :: a_rsur_se(:)
+   real(r8), allocatable :: a_rsur_ie(:)
    real(r8), allocatable :: a_rsub   (:)
    real(r8), allocatable :: a_rnof   (:)
 #ifdef CatchLateralFlow
@@ -371,6 +373,8 @@ CONTAINS
             allocate (a_xerr      (numpatch))
             allocate (a_zerr      (numpatch))
             allocate (a_rsur      (numpatch))
+            allocate (a_rsur_se   (numpatch))
+            allocate (a_rsur_ie   (numpatch))
             allocate (a_rsub      (numpatch))
             allocate (a_rnof      (numpatch))
 #ifdef CatchLateralFlow
@@ -712,6 +716,8 @@ CONTAINS
             deallocate (a_xerr      )
             deallocate (a_zerr      )
             deallocate (a_rsur      )
+            deallocate (a_rsur_se   )
+            deallocate (a_rsur_ie   )
             deallocate (a_rsub      )
             deallocate (a_rnof      )
 #ifdef CatchLateralFlow
@@ -1052,6 +1058,8 @@ CONTAINS
             a_xerr    (:) = spval
             a_zerr    (:) = spval
             a_rsur    (:) = spval
+            a_rsur_se (:) = spval
+            a_rsur_ie (:) = spval
             a_rsub    (:) = spval
             a_rnof    (:) = spval
 #ifdef CatchLateralFlow
@@ -1455,6 +1463,9 @@ CONTAINS
             CALL acc1d (zerr    , a_zerr   )
             CALL acc1d (rsur    , a_rsur   )
 #ifndef CatchLateralFlow
+            CALL acc1d (rsur_se , a_rsur_se)
+            CALL acc1d (rsur_ie , a_rsur_ie)
+
             WHERE ((rsur /= spval) .and. (rnof /= spval))
                rsub = rnof - rsur
             ELSEWHERE

--- a/main/MOD_Vars_1DFluxes.F90
+++ b/main/MOD_Vars_1DFluxes.F90
@@ -60,6 +60,8 @@ MODULE MOD_Vars_1DFluxes
    real(r8), allocatable :: xerr   (:) !the error of water banace [mm/s]
    real(r8), allocatable :: zerr   (:) !the error of energy balance [W/m2]
    real(r8), allocatable :: rsur   (:) !surface runoff (mm h2o/s)
+   real(r8), allocatable :: rsur_se(:) !saturation excess surface runoff (mm h2o/s)
+   real(r8), allocatable :: rsur_ie(:) !infiltration excess surface runoff (mm h2o/s)
    real(r8), allocatable :: rsub   (:) !subsurface runoff (mm h2o/s)
    real(r8), allocatable :: rnof   (:) !total runoff (mm h2o/s)
    real(r8), allocatable :: qintr  (:) !interception (mm h2o/s)
@@ -135,6 +137,8 @@ CONTAINS
             allocate ( zerr   (numpatch) )  ; zerr   (:) = spval ! the error of energy balance [W/m2]
 
             allocate ( rsur   (numpatch) )  ; rsur   (:) = spval ! surface runoff (mm h2o/s)
+            allocate ( rsur_se(numpatch) )  ; rsur_se(:) = spval ! saturation excess surface runoff (mm h2o/s)
+            allocate ( rsur_ie(numpatch) )  ; rsur_ie(:) = spval ! infiltration excess surface runoff (mm h2o/s)
             allocate ( rsub   (numpatch) )  ; rsub   (:) = spval ! subsurface runoff (mm h2o/s)
             allocate ( rnof   (numpatch) )  ; rnof   (:) = spval ! total runoff (mm h2o/s)
             allocate ( qintr  (numpatch) )  ; qintr  (:) = spval ! interception (mm h2o/s)
@@ -215,6 +219,8 @@ CONTAINS
             deallocate ( xerr    )  ! the error of water banace [mm/s]
             deallocate ( zerr    )  ! the error of energy balance [W/m2]
             deallocate ( rsur    )  ! surface runoff (mm h2o/s)
+            deallocate ( rsur_se )  ! saturation excess surface runoff (mm h2o/s)
+            deallocate ( rsur_ie )  ! infiltration excess surface runoff (mm h2o/s)
             deallocate ( rsub    )  ! subsurface runoff (mm h2o/s)
             deallocate ( rnof    )  ! total runoff (mm h2o/s)
             deallocate ( qintr   )  ! interception (mm h2o/s)

--- a/main/MOD_Vars_TimeInvariants.F90
+++ b/main/MOD_Vars_TimeInvariants.F90
@@ -211,14 +211,22 @@ MODULE MOD_Vars_TimeInvariants
    real(r8), allocatable :: porsl        (:,:)  !fraction of soil that is voids [-]
    real(r8), allocatable :: psi0         (:,:)  !minimum soil suction [mm] (NOTE: "-" valued)
    real(r8), allocatable :: bsw          (:,:)  !clapp and hornbereger "b" parameter [-]
-#ifdef vanGenuchten_Mualem_SOIL_MODEL
    real(r8), allocatable :: theta_r      (:,:)  !residual moisture content [-]
+
+#ifdef vanGenuchten_Mualem_SOIL_MODEL
    real(r8), allocatable :: alpha_vgm    (:,:)  !a parameter corresponding approximately to the inverse of the air-entry value
    real(r8), allocatable :: L_vgm        (:,:)  !pore-connectivity parameter [dimensionless]
    real(r8), allocatable :: n_vgm        (:,:)  !a shape parameter [dimensionless]
    real(r8), allocatable :: sc_vgm       (:,:)  !saturation at the air entry value in the classical vanGenuchten model [-]
    real(r8), allocatable :: fc_vgm       (:,:)  !a scaling factor by using air entry value in the Mualem model [-]
 #endif
+
+   real(r8), allocatable :: vic_b_infilt (:)
+   real(r8), allocatable :: vic_Dsmax    (:)
+   real(r8), allocatable :: vic_Ds       (:)
+   real(r8), allocatable :: vic_Ws       (:)
+   real(r8), allocatable :: vic_c        (:)
+
    real(r8), allocatable :: hksati       (:,:)  !hydraulic conductivity at saturation [mm h2o/s]
    real(r8), allocatable :: csol         (:,:)  !heat capacity of soil solids [J/(m3 K)]
    real(r8), allocatable :: k_solids     (:,:)  !thermal conductivity of soil solids [W/m-K]
@@ -233,6 +241,8 @@ MODULE MOD_Vars_TimeInvariants
    real(r8), allocatable :: dbedrock       (:)  !depth to bedrock
    integer , allocatable :: ibedrock       (:)  !bedrock level
 
+   real(r8), allocatable :: topoelv (:)  !elevation above sea level [m]
+   real(r8), allocatable :: topostd (:)  !standard deviation of elevation [m]
 
    real(r8) :: zlnd                             !roughness length for soil [m]
    real(r8) :: zsno                             !roughness length for snow [m]
@@ -306,26 +316,36 @@ CONTAINS
             allocate (porsl        (nl_soil,numpatch))
             allocate (psi0         (nl_soil,numpatch))
             allocate (bsw          (nl_soil,numpatch))
+            allocate (theta_r      (nl_soil,numpatch))
+
 #ifdef vanGenuchten_Mualem_SOIL_MODEL
-           allocate (theta_r      (nl_soil,numpatch))
-           allocate (alpha_vgm    (nl_soil,numpatch))
-           allocate (L_vgm        (nl_soil,numpatch))
-           allocate (n_vgm        (nl_soil,numpatch))
-           allocate (sc_vgm       (nl_soil,numpatch))
-           allocate (fc_vgm       (nl_soil,numpatch))
+            allocate (alpha_vgm    (nl_soil,numpatch))
+            allocate (L_vgm        (nl_soil,numpatch))
+            allocate (n_vgm        (nl_soil,numpatch))
+            allocate (sc_vgm       (nl_soil,numpatch))
+            allocate (fc_vgm       (nl_soil,numpatch))
 #endif
-           allocate (hksati       (nl_soil,numpatch))
-           allocate (csol         (nl_soil,numpatch))
-           allocate (k_solids     (nl_soil,numpatch))
-           allocate (dksatu       (nl_soil,numpatch))
-           allocate (dksatf       (nl_soil,numpatch))
-           allocate (dkdry        (nl_soil,numpatch))
-           allocate (BA_alpha     (nl_soil,numpatch))
-           allocate (BA_beta      (nl_soil,numpatch))
-           allocate (htop                 (numpatch))
-           allocate (hbot                 (numpatch))
-           allocate (dbedrock             (numpatch))
-           allocate (ibedrock             (numpatch))
+
+            allocate (vic_b_infilt (numpatch))
+            allocate (vic_Dsmax    (numpatch))
+            allocate (vic_Ds       (numpatch))
+            allocate (vic_Ws       (numpatch))
+            allocate (vic_c        (numpatch))
+
+            allocate (hksati       (nl_soil,numpatch))
+            allocate (csol         (nl_soil,numpatch))
+            allocate (k_solids     (nl_soil,numpatch))
+            allocate (dksatu       (nl_soil,numpatch))
+            allocate (dksatf       (nl_soil,numpatch))
+            allocate (dkdry        (nl_soil,numpatch))
+            allocate (BA_alpha     (nl_soil,numpatch))
+            allocate (BA_beta      (nl_soil,numpatch))
+            allocate (htop                 (numpatch))
+            allocate (hbot                 (numpatch))
+            allocate (dbedrock             (numpatch))
+            allocate (ibedrock             (numpatch))
+            allocate (topoelv              (numpatch))
+            allocate (topostd              (numpatch))
       ENDIF
 
 #if (defined LULC_IGBP_PFT || defined LULC_IGBP_PC)
@@ -400,14 +420,23 @@ CONTAINS
       CALL ncio_read_vector (file_restart, 'porsl  ' ,     nl_soil, landpatch, porsl     ) ! fraction of soil that is voids [-]
       CALL ncio_read_vector (file_restart, 'psi0   ' ,     nl_soil, landpatch, psi0      ) ! minimum soil suction [mm] (NOTE: "-" valued)
       CALL ncio_read_vector (file_restart, 'bsw    ' ,     nl_soil, landpatch, bsw       ) ! clapp and hornbereger "b" parameter [-]
-#ifdef vanGenuchten_Mualem_SOIL_MODEL
       CALL ncio_read_vector (file_restart, 'theta_r  ' ,   nl_soil, landpatch, theta_r   ) ! residual moisture content [-]
+
+#ifdef vanGenuchten_Mualem_SOIL_MODEL
       CALL ncio_read_vector (file_restart, 'alpha_vgm' ,   nl_soil, landpatch, alpha_vgm ) ! a parameter corresponding approximately to the inverse of the air-entry value
       CALL ncio_read_vector (file_restart, 'L_vgm    ' ,   nl_soil, landpatch, L_vgm     ) ! pore-connectivity parameter [dimensionless]
       CALL ncio_read_vector (file_restart, 'n_vgm    ' ,   nl_soil, landpatch, n_vgm     ) ! a shape parameter [dimensionless]
       CALL ncio_read_vector (file_restart, 'sc_vgm   ' ,   nl_soil, landpatch, sc_vgm    ) ! saturation at the air entry value in the classical vanGenuchten model [-]
       CALL ncio_read_vector (file_restart, 'fc_vgm   ' ,   nl_soil, landpatch, fc_vgm    ) ! a scaling factor by using air entry value in the Mualem model [-]
 #endif
+
+      
+      CALL ncio_read_vector (file_restart, 'vic_b_infilt', landpatch, vic_b_infilt) 
+      CALL ncio_read_vector (file_restart, 'vic_Dsmax'   , landpatch, vic_Dsmax   )
+      CALL ncio_read_vector (file_restart, 'vic_Ds'      , landpatch, vic_Ds      )
+      CALL ncio_read_vector (file_restart, 'vic_Ws'      , landpatch, vic_Ws      )
+      CALL ncio_read_vector (file_restart, 'vic_c'       , landpatch, vic_c       )
+
       CALL ncio_read_vector (file_restart, 'hksati ' ,     nl_soil, landpatch, hksati )    ! hydraulic conductivity at saturation [mm h2o/s]
       CALL ncio_read_vector (file_restart, 'csol   ' ,     nl_soil, landpatch, csol   )    ! heat capacity of soil solids [J/(m3 K)]
       CALL ncio_read_vector (file_restart, 'k_solids',     nl_soil, landpatch, k_solids)   ! thermal conductivity of soil solids [W/m-K]
@@ -423,6 +452,9 @@ CONTAINS
          CALL ncio_read_vector (file_restart, 'debdrock' ,    landpatch, dbedrock)         !
          CALL ncio_read_vector (file_restart, 'ibedrock' ,    landpatch, ibedrock)         !
       ENDIF
+         
+      CALL ncio_read_vector (file_restart, 'topoelv', landpatch, topoelv)         !
+      CALL ncio_read_vector (file_restart, 'topostd', landpatch, topostd)         !
 
       CALL ncio_read_bcast_serial (file_restart, 'zlnd  ', zlnd  ) ! roughness length for soil [m]
       CALL ncio_read_bcast_serial (file_restart, 'zsno  ', zsno  ) ! roughness length for snow [m]
@@ -546,15 +578,22 @@ CONTAINS
       CALL ncio_write_vector (file_restart, 'porsl     ', 'soil', nl_soil, 'patch', landpatch, porsl     , compress) ! fraction of soil that is voids [-]
       CALL ncio_write_vector (file_restart, 'psi0      ', 'soil', nl_soil, 'patch', landpatch, psi0      , compress) ! minimum soil suction [mm] (NOTE: "-" valued)
       CALL ncio_write_vector (file_restart, 'bsw       ', 'soil', nl_soil, 'patch', landpatch, bsw       , compress) ! clapp and hornbereger "b" parameter [-]
+      CALL ncio_write_vector (file_restart, 'theta_r  ' , 'soil', nl_soil, 'patch', landpatch, theta_r   , compress) ! residual moisture content [-]
 
 #ifdef vanGenuchten_Mualem_SOIL_MODEL
-      CALL ncio_write_vector (file_restart, 'theta_r  ' , 'soil', nl_soil, 'patch', landpatch, theta_r   , compress) ! residual moisture content [-]
       CALL ncio_write_vector (file_restart, 'alpha_vgm' , 'soil', nl_soil, 'patch', landpatch, alpha_vgm , compress) ! a parameter corresponding approximately to the inverse of the air-entry value
       CALL ncio_write_vector (file_restart, 'L_vgm    ' , 'soil', nl_soil, 'patch', landpatch, L_vgm     , compress) ! pore-connectivity parameter [dimensionless]
       CALL ncio_write_vector (file_restart, 'n_vgm    ' , 'soil', nl_soil, 'patch', landpatch, n_vgm     , compress) ! a shape parameter [dimensionless]
       CALL ncio_write_vector (file_restart, 'sc_vgm   ' , 'soil', nl_soil, 'patch', landpatch, sc_vgm    , compress) ! saturation at the air entry value in the classical vanGenuchten model [-]
       CALL ncio_write_vector (file_restart, 'fc_vgm   ' , 'soil', nl_soil, 'patch', landpatch, fc_vgm    , compress) ! a scaling factor by using air entry value in the Mualem model [-]
 #endif
+
+      CALL ncio_write_vector (file_restart, 'vic_b_infilt', 'patch', landpatch, vic_b_infilt)
+      CALL ncio_write_vector (file_restart, 'vic_Dsmax'   , 'patch', landpatch, vic_Dsmax   )
+      CALL ncio_write_vector (file_restart, 'vic_Ds'      , 'patch', landpatch, vic_Ds      )
+      CALL ncio_write_vector (file_restart, 'vic_Ws'      , 'patch', landpatch, vic_Ws      )
+      CALL ncio_write_vector (file_restart, 'vic_c'       , 'patch', landpatch, vic_c       )
+
       CALL ncio_write_vector (file_restart, 'hksati   ' , 'soil', nl_soil, 'patch', landpatch, hksati    , compress) ! hydraulic conductivity at saturation [mm h2o/s]
       CALL ncio_write_vector (file_restart, 'csol     ' , 'soil', nl_soil, 'patch', landpatch, csol      , compress) ! heat capacity of soil solids [J/(m3 K)]
       CALL ncio_write_vector (file_restart, 'k_solids ' , 'soil', nl_soil, 'patch', landpatch, k_solids  , compress) ! thermal conductivity of soil solids [W/m-K]
@@ -568,9 +607,12 @@ CONTAINS
       CALL ncio_write_vector (file_restart, 'hbot' , 'patch', landpatch, hbot)                                       !
 
       IF(DEF_USE_BEDROCK)THEN
-         CALL ncio_write_vector (file_restart, 'debdrock' , 'patch', landpatch, dbedrock)                            !
-         CALL ncio_write_vector (file_restart, 'ibedrock' , 'patch', landpatch, ibedrock)                            !
+         CALL ncio_write_vector (file_restart, 'debdrock' , 'patch', landpatch, dbedrock)
+         CALL ncio_write_vector (file_restart, 'ibedrock' , 'patch', landpatch, ibedrock)
       ENDIF
+         
+      CALL ncio_write_vector (file_restart, 'topoelv', 'patch', landpatch, topoelv)
+      CALL ncio_write_vector (file_restart, 'topostd', 'patch', landpatch, topostd)
 
 #ifdef USEMPI
       CALL mpi_barrier (p_comm_glb, p_err)
@@ -663,14 +705,21 @@ CONTAINS
             deallocate (porsl          )
             deallocate (psi0           )
             deallocate (bsw            )
-#ifdef vanGenuchten_Mualem_SOIL_MODEL
             deallocate (theta_r        )
+
+#ifdef vanGenuchten_Mualem_SOIL_MODEL
             deallocate (alpha_vgm      )
             deallocate (L_vgm          )
             deallocate (n_vgm          )
             deallocate (sc_vgm         )
             deallocate (fc_vgm         )
 #endif
+            deallocate (vic_b_infilt   )
+            deallocate (vic_Dsmax      )
+            deallocate (vic_Ds         )
+            deallocate (vic_Ws         )
+            deallocate (vic_c          )
+
             deallocate (hksati         )
             deallocate (csol           )
             deallocate (k_solids       )
@@ -685,6 +734,9 @@ CONTAINS
 
             deallocate (dbedrock       )
             deallocate (ibedrock       )
+
+            deallocate (topoelv        )
+            deallocate (topostd        )
 
          ENDIF
       ENDIF
@@ -762,6 +814,9 @@ CONTAINS
       IF(DEF_USE_BEDROCK)THEN
          CALL check_vector_data ('dbedrock     [m]     ', dbedrock    ) !
       ENDIF
+         
+      CALL check_vector_data ('topoelv      [m]     ', topoelv     ) !
+      CALL check_vector_data ('topostd      [m]     ', topostd     ) !
 
 #ifdef USEMPI
       CALL mpi_barrier (p_comm_glb, p_err)

--- a/main/URBAN/MOD_Urban_Hydrology.F90
+++ b/main/URBAN/MOD_Urban_Hydrology.F90
@@ -21,6 +21,7 @@ CONTAINS
         froof          ,fgper          ,flake          ,bsw            ,&
         porsl          ,psi0           ,hksati         ,wtfact         ,&
         pondmx         ,ssi            ,wimp           ,smpmin         ,&
+        topostd                                                        ,&
         rootr,rootflux ,etr            ,fseng          ,fgrnd          ,&
         t_gpersno      ,t_lakesno      ,t_lake         ,dz_lake        ,&
         z_gpersno      ,z_lakesno      ,zi_gpersno     ,zi_lakesno     ,&
@@ -92,6 +93,8 @@ CONTAINS
         ssi              ,&! irreducible water saturation of snow
         wimp             ,&! water impremeable IF porosity less than wimp
         smpmin           ,&! restriction for min of soil poten. (mm)
+        
+        topostd          ,&! standard deviation of elevation [m]
 
         bsw   (1:nl_soil),&! Clapp-Hornberger "B"
         porsl (1:nl_soil),&! saturated volumetric soil water content(porosity)
@@ -223,7 +226,8 @@ CONTAINS
       rootflux(:) = rootr(:)*etr
       CALL WATER_2014 (ipatch,patchtype,lbp        ,nl_soil     ,deltim     ,&
              z_gpersno   ,dz_gpersno  ,zi_gpersno  ,bsw         ,porsl      ,&
-             psi0        ,hksati      ,rootr       ,rootflux    ,t_gpersno  ,&
+             psi0        ,hksati      ,topostd     ,&
+             rootr       ,rootflux    ,t_gpersno   ,&
              wliq_gpersno,wice_gpersno,smp         ,hk          ,pgper_rain ,&
              sm_gper     ,etr         ,qseva_gper  ,qsdew_gper  ,qsubl_gper ,&
              qfros_gper  ,&

--- a/main/URBAN/MOD_Urban_Hydrology.F90
+++ b/main/URBAN/MOD_Urban_Hydrology.F90
@@ -21,7 +21,7 @@ CONTAINS
         froof          ,fgper          ,flake          ,bsw            ,&
         porsl          ,psi0           ,hksati         ,wtfact         ,&
         pondmx         ,ssi            ,wimp           ,smpmin         ,&
-        topostd        ,theta_r                                        ,&
+        theta_r        ,topostd                                        ,&
         rootr,rootflux ,etr            ,fseng          ,fgrnd          ,&
         t_gpersno      ,t_lakesno      ,t_lake         ,dz_lake        ,&
         z_gpersno      ,z_lakesno      ,zi_gpersno     ,zi_lakesno     ,&
@@ -227,7 +227,7 @@ CONTAINS
       rootflux(:) = rootr(:)*etr
       CALL WATER_2014 (ipatch,patchtype,lbp        ,nl_soil     ,deltim     ,&
              z_gpersno   ,dz_gpersno  ,zi_gpersno  ,bsw         ,porsl      ,&
-             psi0        ,hksati      ,topostd     ,theta_r     ,&
+             psi0        ,hksati      ,theta_r     ,topostd     ,&
              rootr       ,rootflux    ,t_gpersno   ,&
              wliq_gpersno,wice_gpersno,smp         ,hk          ,pgper_rain ,&
              sm_gper     ,etr         ,qseva_gper  ,qsdew_gper  ,qsubl_gper ,&

--- a/main/URBAN/MOD_Urban_Hydrology.F90
+++ b/main/URBAN/MOD_Urban_Hydrology.F90
@@ -21,7 +21,7 @@ CONTAINS
         froof          ,fgper          ,flake          ,bsw            ,&
         porsl          ,psi0           ,hksati         ,wtfact         ,&
         pondmx         ,ssi            ,wimp           ,smpmin         ,&
-        topostd                                                        ,&
+        topostd        ,theta_r                                        ,&
         rootr,rootflux ,etr            ,fseng          ,fgrnd          ,&
         t_gpersno      ,t_lakesno      ,t_lake         ,dz_lake        ,&
         z_gpersno      ,z_lakesno      ,zi_gpersno     ,zi_lakesno     ,&
@@ -100,6 +100,7 @@ CONTAINS
         porsl (1:nl_soil),&! saturated volumetric soil water content(porosity)
         psi0  (1:nl_soil),&! saturated soil suction (mm) (NEGATIVE)
         hksati(1:nl_soil),&! hydraulic conductivity at saturation (mm h2o/s)
+        theta_r(1:nl_soil),&! residual moisture content [-]
         rootr (1:nl_soil),&! root resistance of a layer, all layers add to 1.0
 
         etr              ,&! vegetation transpiration
@@ -226,7 +227,7 @@ CONTAINS
       rootflux(:) = rootr(:)*etr
       CALL WATER_2014 (ipatch,patchtype,lbp        ,nl_soil     ,deltim     ,&
              z_gpersno   ,dz_gpersno  ,zi_gpersno  ,bsw         ,porsl      ,&
-             psi0        ,hksati      ,topostd     ,&
+             psi0        ,hksati      ,topostd     ,theta_r     ,&
              rootr       ,rootflux    ,t_gpersno   ,&
              wliq_gpersno,wice_gpersno,smp         ,hk          ,pgper_rain ,&
              sm_gper     ,etr         ,qseva_gper  ,qsdew_gper  ,qsubl_gper ,&

--- a/main/URBAN/Urban_CoLMMAIN.F90
+++ b/main/URBAN/Urban_CoLMMAIN.F90
@@ -981,7 +981,7 @@ SUBROUTINE UrbanCoLMMAIN ( &
         froof                ,fgper                ,flake                ,bsw                  ,&
         porsl                ,psi0                 ,hksati               ,wtfact               ,&
         pondmx               ,ssi                  ,wimp                 ,smpmin               ,&
-        topostd              ,theta_r                                                          ,&
+        theta_r              ,topostd                                                          ,&
         rootr,rootflux       ,etrgper              ,fseng                ,fgrnd                ,&
         t_gpersno(lbp:)      ,t_lakesno(:)         ,t_lake               ,dz_lake              ,&
         z_gpersno(lbp:)      ,z_lakesno(:)         ,zi_gpersno(lbp-1:)   ,zi_lakesno(:)        ,&

--- a/main/URBAN/Urban_CoLMMAIN.F90
+++ b/main/URBAN/Urban_CoLMMAIN.F90
@@ -12,7 +12,7 @@ SUBROUTINE UrbanCoLMMAIN ( &
            em_gper      ,cv_roof      ,cv_wall      ,cv_gimp      ,&
            tk_roof      ,tk_wall      ,tk_gimp      ,z_roof       ,&
            z_wall       ,dz_roof      ,dz_wall                    ,&
-           lakedepth    ,dz_lake                                  ,&
+           lakedepth    ,dz_lake      ,topostd      ,&
 
          ! LUCY model input parameters
            fix_holiday  ,week_holiday ,hum_prof     ,pop_den      ,&
@@ -21,9 +21,9 @@ SUBROUTINE UrbanCoLMMAIN ( &
          ! soil ground and wall information
            vf_quartz    ,vf_gravels   ,vf_om        ,vf_sand      ,&
            wf_gravels   ,wf_sand      ,porsl        ,psi0         ,&
-           bsw          ,&
+           bsw          ,theta_r      ,&
 #ifdef vanGenuchten_Mualem_SOIL_MODEL
-           theta_r      ,alpha_vgm    ,n_vgm        ,L_vgm        ,&
+           alpha_vgm    ,n_vgm        ,L_vgm        ,&
            sc_vgm       ,fc_vgm       ,&
 #endif
            hksati       ,csol         ,k_solids     ,dksatu       ,&
@@ -199,9 +199,9 @@ SUBROUTINE UrbanCoLMMAIN ( &
         porsl     (nl_soil),&! fraction of soil that is voids [-]
         psi0      (nl_soil),&! minimum soil suction [mm]
         bsw       (nl_soil),&! clapp and hornbereger "b" parameter [-]
+        theta_r (1:nl_soil),&
 
 #ifdef vanGenuchten_Mualem_SOIL_MODEL
-        theta_r  (1:nl_soil),&
         alpha_vgm(1:nl_soil),&
         n_vgm    (1:nl_soil),&
         L_vgm    (1:nl_soil),&
@@ -335,6 +335,8 @@ SUBROUTINE UrbanCoLMMAIN ( &
         t_lake      (nl_lake) ,&! lake temperature (kelvin)
         lake_icefrac(nl_lake) ,&! lake mass fraction of lake layer that is frozen
         savedtke1             ,&! top level eddy conductivity (W/m K)
+
+        topostd    ,&! standard deviation of elevation [m]
 
         t_grnd     ,&! ground surface temperature [k]
         tleaf      ,&! sunlit leaf temperature [K]
@@ -979,6 +981,7 @@ SUBROUTINE UrbanCoLMMAIN ( &
         froof                ,fgper                ,flake                ,bsw                  ,&
         porsl                ,psi0                 ,hksati               ,wtfact               ,&
         pondmx               ,ssi                  ,wimp                 ,smpmin               ,&
+        topostd                                                                                ,&
         rootr,rootflux       ,etrgper              ,fseng                ,fgrnd                ,&
         t_gpersno(lbp:)      ,t_lakesno(:)         ,t_lake               ,dz_lake              ,&
         z_gpersno(lbp:)      ,z_lakesno(:)         ,zi_gpersno(lbp-1:)   ,zi_lakesno(:)        ,&

--- a/main/URBAN/Urban_CoLMMAIN.F90
+++ b/main/URBAN/Urban_CoLMMAIN.F90
@@ -199,7 +199,7 @@ SUBROUTINE UrbanCoLMMAIN ( &
         porsl     (nl_soil),&! fraction of soil that is voids [-]
         psi0      (nl_soil),&! minimum soil suction [mm]
         bsw       (nl_soil),&! clapp and hornbereger "b" parameter [-]
-        theta_r (1:nl_soil),&
+        theta_r   (nl_soil),&
 
 #ifdef vanGenuchten_Mualem_SOIL_MODEL
         alpha_vgm(1:nl_soil),&
@@ -981,7 +981,7 @@ SUBROUTINE UrbanCoLMMAIN ( &
         froof                ,fgper                ,flake                ,bsw                  ,&
         porsl                ,psi0                 ,hksati               ,wtfact               ,&
         pondmx               ,ssi                  ,wimp                 ,smpmin               ,&
-        topostd                                                                                ,&
+        topostd              ,theta_r                                                          ,&
         rootr,rootflux       ,etrgper              ,fseng                ,fgrnd                ,&
         t_gpersno(lbp:)      ,t_lakesno(:)         ,t_lake               ,dz_lake              ,&
         z_gpersno(lbp:)      ,z_lakesno(:)         ,zi_gpersno(lbp-1:)   ,zi_lakesno(:)        ,&

--- a/mkinidata/MOD_Initialize.F90
+++ b/mkinidata/MOD_Initialize.F90
@@ -49,6 +49,7 @@ CONTAINS
    USE MOD_Grid
    USE MOD_DataType
    USE MOD_NetCDFSerial
+   USE MOD_NetCDFVector
    USE MOD_NetCDFBlock
 #ifdef RangeCheck
    USE MOD_RangeCheck
@@ -102,6 +103,7 @@ CONTAINS
    character(len=256) :: fsoildat
    character(len=256) :: fsnowdat
    character(len=256) :: fcndat
+   character(len=256) :: ftopo
    type(grid_type) :: gsoil
    type(grid_type) :: gsnow
    type(grid_type) :: gcn
@@ -202,6 +204,7 @@ CONTAINS
    real(r8) :: calday                    ! Julian cal day (1.xx to 365.xx)
    integer  :: year, jday                ! Julian day and seconds
    integer  :: month, mday
+   character(len=4) :: cyear
 
    integer  :: i,j,ipatch,nsl,hs,he,ps,pe,ivt,m, u  ! indices
    real(r8) :: totalvolume
@@ -218,6 +221,9 @@ CONTAINS
    real(r8) f_s2s3
    real(r8) t
 #endif
+
+   integer  :: txt_id
+   real(r8) :: vic_b_infilt_, vic_Dsmax_, vic_Ds_, vic_Ws_, vic_c_
 
 ! --------------------------------------------------------------------
 ! Allocates memory for CoLM 1d [numpatch] variables
@@ -317,7 +323,21 @@ CONTAINS
       CALL Urban_readin (dir_landdata, lc_year)
 #endif
 ! ................................
-! 1.5 Initialize TUNABLE constants
+! 1.5 Initialize topography data
+! ................................
+#ifdef SinglePoint
+      topoelv(:) = SITE_topography
+      topostd(:) = SITE_topostd
+#else
+      write(cyear,'(i4.4)') lc_year
+      ftopo = trim(dir_landdata)//'/topography/'//trim(cyear)//'/topography_patches.nc'
+      CALL ncio_read_vector (ftopo, 'topography_patches', landpatch, topoelv)
+      ftopo = trim(dir_landdata)//'/topography/'//trim(cyear)//'/topostd_patches.nc'
+      CALL ncio_read_vector (ftopo, 'topostd_patches', landpatch, topostd)
+#endif
+
+! ................................
+! 1.6 Initialize TUNABLE constants
 ! ................................
       zlnd   = 0.01    !Roughness length for soil [m]
       zsno   = 0.0024  !Roughness length for snow [m]
@@ -334,6 +354,27 @@ CONTAINS
       trsmx0 = 2.e-4   !Max transpiration for moist soil+100% veg. [mm/s]
       tcrit  = 2.5     !critical temp. to determine rain or snow
       wetwatmax = 200.0 !maximum wetland water (mm)
+
+      IF (DEF_Runoff_SCHEME == 1) THEN
+         txt_id = 111
+         open(txt_id, file=trim(DEF_file_VIC_para), status='old', form='formatted')
+
+         READ(txt_id, *)
+         READ(txt_id, *) vic_b_infilt_, vic_Dsmax_, vic_Ds_, vic_Ws_, vic_c_
+
+         close(txt_id)
+         vic_b_infilt = vic_b_infilt_
+         vic_Dsmax    = vic_Dsmax_
+         vic_Ds       = vic_Ds_
+         vic_Ws       = vic_Ws_
+         vic_c        = vic_c_
+      ELSE
+         vic_b_infilt = 0
+         vic_Dsmax    = 0
+         vic_Ds       = 0
+         vic_Ws       = 0
+         vic_c        = 0
+      ENDIF
 
 #ifdef BGC
    ! bgc constant

--- a/mkinidata/MOD_SoilParametersReadin.F90
+++ b/mkinidata/MOD_SoilParametersReadin.F90
@@ -264,8 +264,8 @@ CONTAINS
                   porsl     (nsl,ipatch) = -1.e36
                   psi0      (nsl,ipatch) = -1.e36
                   bsw       (nsl,ipatch) = -1.e36
-#ifdef vanGenuchten_Mualem_SOIL_MODEL
                   theta_r   (nsl,ipatch) = -1.e36
+#ifdef vanGenuchten_Mualem_SOIL_MODEL
                   alpha_vgm (nsl,ipatch) = -1.e36
                   L_vgm     (nsl,ipatch) = -1.e36
                   n_vgm     (nsl,ipatch) = -1.e36
@@ -300,6 +300,8 @@ CONTAINS
                   n_vgm      (nsl,ipatch) = soil_n_vgm_l    (ipatch)
                   wfc        (nsl,ipatch) = soil_theta_r_l  (ipatch)+(soil_theta_s_l(ipatch)-soil_theta_r_l(ipatch))*&
                              (1+(soil_alpha_vgm_l(ipatch)*339.9)**soil_n_vgm_l(ipatch))**(1.0/soil_n_vgm_l(ipatch)-1)
+#else
+                  theta_r    (nsl,ipatch) = 0.
 #endif
                   hksati     (nsl,ipatch) = soil_k_s_l      (ipatch) * 10./86400.  ! cm/day -> mm/s
                   csol       (nsl,ipatch) = soil_csol_l     (ipatch)               ! J/(m2 K)
@@ -369,8 +371,8 @@ CONTAINS
                porsl      (nsl,:) = porsl     (nsl-1,:)
                psi0       (nsl,:) = psi0      (nsl-1,:)
                bsw        (nsl,:) = bsw       (nsl-1,:)
-#ifdef vanGenuchten_Mualem_SOIL_MODEL
                theta_r    (nsl,:) = theta_r   (nsl-1,:)
+#ifdef vanGenuchten_Mualem_SOIL_MODEL
                alpha_vgm  (nsl,:) = alpha_vgm (nsl-1,:)
                L_vgm      (nsl,:) = L_vgm     (nsl-1,:)
                n_vgm      (nsl,:) = n_vgm     (nsl-1,:)
@@ -398,8 +400,8 @@ CONTAINS
                porsl      (nsl,:) = porsl     (9,:)
                psi0       (nsl,:) = psi0      (9,:)
                bsw        (nsl,:) = bsw       (9,:)
-#ifdef vanGenuchten_Mualem_SOIL_MODEL
                theta_r    (nsl,:) = theta_r   (9,:)
+#ifdef vanGenuchten_Mualem_SOIL_MODEL
                alpha_vgm  (nsl,:) = alpha_vgm (9,:)
                L_vgm      (nsl,:) = L_vgm     (9,:)
                n_vgm      (nsl,:) = n_vgm     (9,:)

--- a/mksrfdata/MOD_SingleSrfdata.F90
+++ b/mksrfdata/MOD_SingleSrfdata.F90
@@ -71,8 +71,8 @@ MODULE MOD_SingleSrfdata
    real(r8), allocatable :: SITE_soil_k_solids          (:)
    real(r8), allocatable :: SITE_soil_psi_s             (:)
    real(r8), allocatable :: SITE_soil_lambda            (:)
-#ifdef vanGenuchten_Mualem_SOIL_MODEL
    real(r8), allocatable :: SITE_soil_theta_r           (:)
+#ifdef vanGenuchten_Mualem_SOIL_MODEL
    real(r8), allocatable :: SITE_soil_alpha_vgm         (:)
    real(r8), allocatable :: SITE_soil_L_vgm             (:)
    real(r8), allocatable :: SITE_soil_n_vgm             (:)
@@ -83,6 +83,7 @@ MODULE MOD_SingleSrfdata
    real(r8) :: SITE_dbedrock = 0.
 
    real(r8) :: SITE_topography = 0.
+   real(r8) :: SITE_topostd    = 0.
 
    integer , allocatable :: SITE_urbtyp   (:)
 
@@ -244,6 +245,8 @@ CONTAINS
          CALL ncio_read_serial (fsrfdata, 'soil_alpha_vgm        ', SITE_soil_alpha_vgm        )
          CALL ncio_read_serial (fsrfdata, 'soil_L_vgm            ', SITE_soil_L_vgm            )
          CALL ncio_read_serial (fsrfdata, 'soil_n_vgm            ', SITE_soil_n_vgm            )
+#else
+         SITE_soil_theta_r(:) = 0.
 #endif
          CALL ncio_read_serial (fsrfdata, 'soil_BA_alpha         ', SITE_soil_BA_alpha         )
          CALL ncio_read_serial (fsrfdata, 'soil_BA_beta          ', SITE_soil_BA_beta          )
@@ -259,6 +262,7 @@ CONTAINS
       IF ((.not. mksrfdata) .or. USE_SITE_topography) THEN
          ! otherwise, retrieve from database by Aggregation_Topography.F90
          CALL ncio_read_serial (fsrfdata, 'elevation', SITE_topography)
+         CALL ncio_read_serial (fsrfdata, 'elvstd   ', SITE_topostd   )
       ENDIF
 
    END SUBROUTINE read_surface_data_single
@@ -382,6 +386,8 @@ CONTAINS
          CALL ncio_read_serial (fsrfdata, 'soil_alpha_vgm        ', SITE_soil_alpha_vgm        )
          CALL ncio_read_serial (fsrfdata, 'soil_L_vgm            ', SITE_soil_L_vgm            )
          CALL ncio_read_serial (fsrfdata, 'soil_n_vgm            ', SITE_soil_n_vgm            )
+#else
+         SITE_soil_theta_r(:) = 0.
 #endif
          CALL ncio_read_serial (fsrfdata, 'soil_BA_alpha         ', SITE_soil_BA_alpha         )
          CALL ncio_read_serial (fsrfdata, 'soil_BA_beta          ', SITE_soil_BA_beta          )
@@ -397,6 +403,7 @@ CONTAINS
       IF ((.not. mksrfdata) .or. USE_SITE_topography) THEN
          ! otherwise, retrieve from database by Aggregation_Topography.F90
          CALL ncio_read_serial (fsrfdata, 'elevation', SITE_topography)
+         CALL ncio_read_serial (fsrfdata, 'elvstd   ', SITE_topostd   )
       ENDIF
 
    END SUBROUTINE read_urban_surface_data_single
@@ -559,6 +566,9 @@ CONTAINS
 
       CALL ncio_write_serial (fsrfdata, 'elevation', SITE_topography)
       CALL ncio_put_attr     (fsrfdata, 'elevation', 'source', datasource(USE_SITE_topography))
+
+      CALL ncio_write_serial (fsrfdata, 'elvstd', SITE_topostd)
+      CALL ncio_put_attr     (fsrfdata, 'elvstd', 'source', datasource(USE_SITE_topostd))
 
    END SUBROUTINE write_surface_data_single
 
@@ -737,6 +747,9 @@ CONTAINS
       CALL ncio_write_serial (fsrfdata, 'elevation', SITE_topography)
       CALL ncio_put_attr     (fsrfdata, 'elevation', 'source', datasource(USE_SITE_topography))
 
+      CALL ncio_write_serial (fsrfdata, 'elvstd', SITE_topostd)
+      CALL ncio_put_attr     (fsrfdata, 'elvstd', 'source', datasource(USE_SITE_topostd))
+
    END SUBROUTINE write_urban_surface_data_single
 
    ! ---------
@@ -799,8 +812,8 @@ CONTAINS
       IF (allocated(SITE_soil_k_solids         )) deallocate(SITE_soil_k_solids         )
       IF (allocated(SITE_soil_psi_s            )) deallocate(SITE_soil_psi_s            )
       IF (allocated(SITE_soil_lambda           )) deallocate(SITE_soil_lambda           )
-#ifdef vanGenuchten_Mualem_SOIL_MODEL
       IF (allocated(SITE_soil_theta_r          )) deallocate(SITE_soil_theta_r          )
+#ifdef vanGenuchten_Mualem_SOIL_MODEL
       IF (allocated(SITE_soil_alpha_vgm        )) deallocate(SITE_soil_alpha_vgm        )
       IF (allocated(SITE_soil_L_vgm            )) deallocate(SITE_soil_L_vgm            )
       IF (allocated(SITE_soil_n_vgm            )) deallocate(SITE_soil_n_vgm            )

--- a/run/vic_para.txt
+++ b/run/vic_para.txt
@@ -1,0 +1,2 @@
+vic_b_infilt1, vic_Dsmax, vic_Ds,  vic_Ws, vic_c
+0.2  15  0.5  0.5  2

--- a/share/MOD_Namelist.F90
+++ b/share/MOD_Namelist.F90
@@ -437,6 +437,8 @@ MODULE MOD_Namelist
       logical :: xerr         = .true.
       logical :: zerr         = .true.
       logical :: rsur         = .true.
+      logical :: rsur_se      = .true.
+      logical :: rsur_ie      = .true.
       logical :: rsub         = .true.
       logical :: rnof         = .true.
       logical :: xwsur        = .true.
@@ -1429,6 +1431,8 @@ CONTAINS
       CALL sync_hist_vars_one (DEF_hist_vars%xerr        ,  set_defaults)
       CALL sync_hist_vars_one (DEF_hist_vars%zerr        ,  set_defaults)
       CALL sync_hist_vars_one (DEF_hist_vars%rsur        ,  set_defaults)
+      CALL sync_hist_vars_one (DEF_hist_vars%rsur_se     ,  set_defaults)
+      CALL sync_hist_vars_one (DEF_hist_vars%rsur_ie     ,  set_defaults)
       CALL sync_hist_vars_one (DEF_hist_vars%rsub        ,  set_defaults)
       CALL sync_hist_vars_one (DEF_hist_vars%rnof        ,  set_defaults)
       CALL sync_hist_vars_one (DEF_hist_vars%xwsur       ,  set_defaults)

--- a/share/MOD_Namelist.F90
+++ b/share/MOD_Namelist.F90
@@ -250,6 +250,13 @@ MODULE MOD_Namelist
    ! 5: S92,  Sellers et al (1992)
    integer :: DEF_RSS_SCHEME = 1
 
+   ! Options for runoff parameterization schemes
+   ! 0: scheme from SIMTOP model, also used in CoLM2014
+   ! 1: scheme from VIC model
+   ! 2: scheme from XinAnJiang model, also used in ECMWF model
+   integer :: DEF_Runoff_SCHEME = 0
+   character(len=256) :: DEF_file_VIC_para = 'null'
+
    ! Treat exposed soil and snow surface separatly, including
    ! solar absorption, sensible/latent heat, ground temperature,
    ! ground heat flux and groud evp/dew/subl/fros.
@@ -824,7 +831,9 @@ CONTAINS
       DEF_USE_SUPERCOOL_WATER,         &
       DEF_SOIL_REFL_SCHEME,            &
       DEF_RSS_SCHEME,                  &
+      DEF_Runoff_SCHEME,               & 
       DEF_SPLIT_SOILSNOW,              &
+      DEF_file_VIC_para,               &
 
       DEF_dir_existing_srfdata,        &
       USE_srfdata_from_larger_region,  &
@@ -1250,6 +1259,9 @@ CONTAINS
       CALL mpi_bcast (DEF_SOIL_REFL_SCHEME,             1, mpi_integer, p_root, p_comm_glb, p_err)
       ! 07/2023, added by zhuo liu
       CALL mpi_bcast (DEF_RSS_SCHEME,                   1, mpi_integer, p_root, p_comm_glb, p_err)
+      ! 02/2024, added by Shupeng Zhang 
+      CALL mpi_bcast (DEF_Runoff_SCHEME,   1, mpi_integer,   p_root, p_comm_glb, p_err)
+      CALL mpi_bcast (DEF_file_VIC_para, 256, mpi_character, p_root, p_comm_glb, p_err)
       ! 08/2023, added by hua yuan
       CALL mpi_bcast (DEF_SPLIT_SOILSNOW,      1, mpi_logical, p_root, p_comm_glb, p_err)
 


### PR DESCRIPTION
! Options for runoff parameterization schemes
! 0: scheme from SIMTOP model, also used in CoLM2014
! 1: scheme from VIC model
! 2: scheme from XinAnJiang model, also used in ECMWF model
integer :: DEF_Runoff_SCHEME = 0
character(len=256) :: DEF_file_VIC_para = 'null'