### PR TITLE
Modification to SinglePoint.

### DIFF
--- a/mkinidata/MOD_Initialize.F90
+++ b/mkinidata/MOD_Initialize.F90
@@ -386,15 +386,15 @@ CONTAINS
 ! ......................................
 ! 1.5 Initialize topography factor data
 ! ......................................
-#ifdef SinglePoint
-      slp_type_patches(:,1) = SITE_slp_type
-      asp_type_patches(:,1) = SITE_asp_type
-      area_type_patches(:,1) = SITE_area_type
-      svf_patches(:) = SITE_svf
-      cur_patches(:) = SITE_cur
-      sf_lut_patches(:,:,1) = SITE_sf_lut
-#else
       IF (DEF_USE_Forcing_Downscaling) THEN
+#ifdef SinglePoint
+         slp_type_patches(:,1) = SITE_slp_type
+         asp_type_patches(:,1) = SITE_asp_type
+         area_type_patches(:,1) = SITE_area_type
+         svf_patches(:) = SITE_svf
+         cur_patches(:) = SITE_cur
+         sf_lut_patches(:,:,1) = SITE_sf_lut
+#else
          lndname = trim(DEF_dir_landdata) // '/topography/'//trim(cyear)//'/slp_type_patches.nc'             ! slope
          CALL ncio_read_vector (lndname, 'slp_type_patches', num_type, landpatch, slp_type_patches)
          lndname = trim(DEF_dir_landdata) // '/topography/'//trim(cyear)//'/svf_patches.nc'               ! sky view factor
@@ -407,8 +407,8 @@ CONTAINS
          CALL ncio_read_vector (lndname, 'sf_lut_patches', num_azimuth, num_zenith, landpatch, sf_lut_patches)
          lndname = trim(DEF_dir_landdata) // '/topography/'//trim(cyear)//'/cur_patches.nc'               ! curvature
          CALL ncio_read_vector (lndname, 'cur_patches', landpatch, cur_patches)
-       ENDIF
 #endif
+       ENDIF
 ! ................................
 ! 1.6 Initialize TUNABLE constants
 ! ................................

--- a/mksrfdata/Aggregation_TopographyFactors.F90
+++ b/mksrfdata/Aggregation_TopographyFactors.F90
@@ -105,6 +105,11 @@ SUBROUTINE Aggregation_TopographyFactors ( &
 #ifdef SinglePoint
    IF (USE_SITE_topography) THEN
       RETURN
+   ELSE
+      allocate (SITE_slp_type  (num_type))
+      allocate (SITE_asp_type  (num_type))
+      allocate (SITE_area_type (num_type))
+      allocate (SITE_sf_lut    (num_azimuth, num_zenith))
    ENDIF
 #endif
 

--- a/mksrfdata/MOD_LandCrop.F90
+++ b/mksrfdata/MOD_LandCrop.F90
@@ -67,12 +67,18 @@ CONTAINS
 
          numpatch = count(SITE_pctcrop > 0.)
 
-         allocate (pctshrpch (numpatch))
+         allocate (pctshrpch(numpatch))
          allocate (cropclass(numpatch))
          cropclass = pack(SITE_croptyp, SITE_pctcrop > 0.)
          pctshrpch = pack(SITE_pctcrop, SITE_pctcrop > 0.)
 
          pctshrpch = pctshrpch / sum(pctshrpch)
+
+         IF (allocated(landpatch%eindex))  deallocate(landpatch%eindex)
+         IF (allocated(landpatch%ipxstt))  deallocate(landpatch%ipxstt)
+         IF (allocated(landpatch%ipxend))  deallocate(landpatch%ipxend)
+         IF (allocated(landpatch%settyp))  deallocate(landpatch%settyp)
+         IF (allocated(landpatch%ielm  ))  deallocate(landpatch%ielm  )
 
          allocate (landpatch%eindex (numpatch))
          allocate (landpatch%ipxstt (numpatch))

--- a/mksrfdata/MOD_LandPatch.F90
+++ b/mksrfdata/MOD_LandPatch.F90
@@ -88,37 +88,34 @@ CONTAINS
       ENDIF
 
 #ifdef SinglePoint
-#ifdef CROP
-      IF ((SITE_landtype == CROPLAND) .and. USE_SITE_pctcrop) THEN
+      IF (USE_SITE_landtype) THEN
+
+         numpatch = 1
+
+         allocate (landpatch%eindex (numpatch))
+         allocate (landpatch%ipxstt (numpatch))
+         allocate (landpatch%ipxend (numpatch))
+         allocate (landpatch%settyp (numpatch))
+         allocate (landpatch%ielm   (numpatch))
+
+         landpatch%eindex(:) = 1
+         landpatch%ielm  (:) = 1
+         landpatch%ipxstt(:) = 1
+         landpatch%ipxend(:) = 1
+         landpatch%settyp(:) = SITE_landtype
+
+         landpatch%nset = numpatch
+         CALL landpatch%set_vecgs
+
          RETURN
+
       ENDIF
-#endif
-
-      numpatch = 1
-
-      allocate (landpatch%eindex (numpatch))
-      allocate (landpatch%ipxstt (numpatch))
-      allocate (landpatch%ipxend (numpatch))
-      allocate (landpatch%settyp (numpatch))
-      allocate (landpatch%ielm   (numpatch))
-
-      landpatch%eindex(:) = 1
-      landpatch%ielm  (:) = 1
-      landpatch%ipxstt(:) = 1
-      landpatch%ipxend(:) = 1
-      landpatch%settyp(:) = SITE_landtype
-
-      landpatch%nset = numpatch
-      CALL landpatch%set_vecgs
-
-      RETURN
 #endif
 
 #ifdef USEMPI
       CALL mpi_barrier (p_comm_glb, p_err)
 #endif
 
-#ifndef SinglePoint
       IF (p_is_io) THEN
          CALL allocate_block_data (gpatch, patchdata)
 
@@ -135,7 +132,6 @@ CONTAINS
          CALL aggregation_data_daemon (gpatch, data_i4_2d_in1 = patchdata)
 #endif
       ENDIF
-#endif
 
       IF (p_is_worker) THEN
 
@@ -170,7 +166,6 @@ CONTAINS
 
             allocate (types (ipxstt:ipxend))
 
-#ifndef SinglePoint
 #ifdef CATCHMENT
             CALL aggregation_request_data (landhru, iset, gpatch, zip = .false., &
 #else
@@ -181,8 +176,9 @@ CONTAINS
 
             types(:) = ibuff
             deallocate (ibuff)
-#else
-            types(:) = SITE_landtype
+
+#ifdef SinglePoint
+            SITE_landtype = types(1) 
 #endif
 
 #ifdef CATCHMENT

--- a/run/SiteSYSUAtmos_IGBP_VG.nml
+++ b/run/SiteSYSUAtmos_IGBP_VG.nml
@@ -1,0 +1,53 @@
+&nl_colm
+
+! Author: Shupeng Zhang 
+! Description : an example for SinglePoint with all surface data from database instead of observations.
+
+   DEF_CASE_NAME = 'SiteSYSUAtmos_IGBP_VG'
+   
+   SITE_lon_location = 113.5897
+   SITE_lat_location = 22.3507
+
+   DEF_simulation_time%greenwich    = .TRUE.
+   DEF_simulation_time%start_year   = 1951
+   DEF_simulation_time%start_month  = 1
+   DEF_simulation_time%start_day    = 1
+   DEF_simulation_time%start_sec    = 0
+   DEF_simulation_time%end_year     = 2020
+   DEF_simulation_time%end_month    = 12
+   DEF_simulation_time%end_day      = 31
+   DEF_simulation_time%end_sec      = 86400
+   DEF_simulation_time%spinup_year  = 0
+   DEF_simulation_time%spinup_month = 1
+   DEF_simulation_time%spinup_day   = 365
+   DEF_simulation_time%spinup_sec   = 86400
+   DEF_simulation_time%spinup_repeat = 0
+
+   DEF_simulation_time%timestep     = 1800.
+
+   DEF_dir_rawdata = '/tera07/CoLMrawdata/'
+   DEF_dir_runtime = '/tera07/CoLMruntime/'
+   DEF_dir_output  = '/tera13/zhangsp/cases'
+
+   ! soil state init
+   DEF_USE_SoilInit  = .true.
+   DEF_file_SoilInit = '/tera13/zhangsp/landdata/soilstate/soilstate.nc' 
+
+   ! LAI setting
+   DEF_LAI_MONTHLY = .true.
+   DEF_LAI_CHANGE_YEARLY = .false.
+
+   ! ----- forcing -----
+   ! Options :
+   ! PRINCETON | GSWP3   | QIAN  | CRUNCEPV4 | CRUNCEPV7 | ERA5LAND | ERA5  |  MSWX
+   ! WFDE5     | CRUJRA  | WFDEI | JRA55     | GDAS      | CMFD     | POINT |  JRA3Q
+   DEF_forcing_namelist = '/tera13/zhangsp/work/CoLM2024/run/forcing/ERA5LAND.nml'
+   
+   ! ----- history -----
+   DEF_WRST_FREQ = 'MONTHLY' ! write restart file frequency: HOURLY/DAILY/MONTHLY/YEARLY
+   DEF_HIST_FREQ = 'DAILY' ! write history file frequency: HOURLY/DAILY/MONTHLY/YEARLY
+   DEF_HIST_groupby = 'MONTH' ! history in one file: DAY/MONTH/YEAR
+
+   DEF_hist_vars_out_default = .true.
+
+/

--- a/share/MOD_Namelist.F90
+++ b/share/MOD_Namelist.F90
@@ -58,23 +58,28 @@ MODULE MOD_Namelist
 ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
    character(len=256) :: SITE_fsrfdata   = 'null'
+   
+   real(r8) :: SITE_lon_location = 113.5897
+   real(r8) :: SITE_lat_location = 22.3507
 
-   logical  :: USE_SITE_pctpfts          = .true.
-   logical  :: USE_SITE_pctcrop          = .true.
-   logical  :: USE_SITE_htop             = .true.
-   logical  :: USE_SITE_LAI              = .true.
-   logical  :: USE_SITE_lakedepth        = .true.
-   logical  :: USE_SITE_soilreflectance  = .true.
-   logical  :: USE_SITE_soilparameters   = .true.
-   logical  :: USE_SITE_dbedrock         = .true.
-   logical  :: USE_SITE_topography       = .true.
-   logical  :: USE_SITE_topostd          = .true.
-   logical  :: USE_SITE_BVIC             = .true.   
-   logical  :: USE_SITE_HistWriteBack    = .true.
-   logical  :: USE_SITE_ForcingReadAhead = .true.
-   logical  :: USE_SITE_urban_paras      = .true.
+   logical  :: USE_SITE_landtype         = .false.
+   logical  :: USE_SITE_pctpfts          = .false.
+   logical  :: USE_SITE_pctcrop          = .false.
+   logical  :: USE_SITE_htop             = .false.
+   logical  :: USE_SITE_LAI              = .false.
+   logical  :: USE_SITE_lakedepth        = .false.
+   logical  :: USE_SITE_soilreflectance  = .false.
+   logical  :: USE_SITE_soilparameters   = .false.
+   logical  :: USE_SITE_dbedrock         = .false.
+   logical  :: USE_SITE_topography       = .false.
+   logical  :: USE_SITE_topostd          = .false.
+   logical  :: USE_SITE_BVIC             = .false.   
+   logical  :: USE_SITE_urban_paras      = .false.
    logical  :: USE_SITE_thermal_paras    = .false.
    logical  :: USE_SITE_urban_LAI        = .false.
+
+   logical  :: USE_SITE_HistWriteBack    = .true.
+   logical  :: USE_SITE_ForcingReadAhead = .true.
 
 ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ! ----- Part 4: simulation time type -----
@@ -779,6 +784,9 @@ CONTAINS
       DEF_domain,              &
 
       SITE_fsrfdata,            &
+      SITE_lon_location,        &
+      SITE_lat_location,        &
+      USE_SITE_landtype,        &
       USE_SITE_pctpfts,         &
       USE_SITE_pctcrop,         &
       USE_SITE_htop,            &


### PR DESCRIPTION
By this modification, only 'SITE_lat_location' and 'SITE_lon_location' are necessary for a 'SinglePoint' model run to make surface data. 'Land cover type' can be retrieved from database.