### PR TITLE
Re-fix albedo bug for usgs and code format adjustment and bug fix for SNICAR snow layer aborption calculation [by @Xueqi Cao].

### DIFF
--- a/main/MOD_Albedo.F90
+++ b/main/MOD_Albedo.F90
@@ -1938,11 +1938,11 @@ ENDIF
                   ENDIF
                ELSE
                   IF (ib == 1) THEN
-                     flx_absdv(i) = flx_absd_snw(i,ib)*(1.-albsnd(ib))
-                     flx_absiv(i) = flx_absi_snw(i,ib)*(1.-albsni(ib))
+                     flx_absdv(i) = flx_absd_snw(i,ib)!*(1.-albsnd(ib))
+                     flx_absiv(i) = flx_absi_snw(i,ib)!*(1.-albsni(ib))
                   elseif (ib == 2) THEN
-                     flx_absdn(i) = flx_absd_snw(i,ib)*(1.-albsnd(ib))
-                     flx_absin(i) = flx_absi_snw(i,ib)*(1.-albsni(ib))
+                     flx_absdn(i) = flx_absd_snw(i,ib)!*(1.-albsnd(ib))
+                     flx_absin(i) = flx_absi_snw(i,ib)!*(1.-albsni(ib))
                   ENDIF
                ENDIF
             ENDDO


### PR DESCRIPTION
    -fix(MOD_Albedo.F90):
        set inital value for albv to fix a bug of albedo calculation.
        And code format adjustment.

    -fix(MOD_Albedo.F90):
        flx_abs* do not need to product (1-albedo). [by @Xueqi Cao]
        NOTE: This bug will not affect the modeling results, but from a physical 
        point of view it is a bug.