### PR TITLE
0) Add time log flag for forcing variables and corresponding codes. Mainly for solar radaition reading. 1) Set LAI/SAI data year range for LAI change simulation; 2) Use the building H/L parameter as default to replace the canyon H/W; 3) A bug fix for leaf temperature iteration calculation. [by @Chen Yang] and 4) some other bugs fix (see below).

### DIFF
--- a/main/CoLMDRIVER.F90
+++ b/main/CoLMDRIVER.F90
@@ -140,7 +140,7 @@ SUBROUTINE CoLMDRIVER (idate,deltim,dolai,doalb,dosst,oro)
              ! End ozone stress variables
              ! WUE stomata model parameter
                lambda(m),                                                          &
-             ! End WUE model parameter 
+             ! End WUE model parameter
                zwt(i),          wdsrf(i),        wa(i),           wetwat(i),       &
                t_lake(1:,i),    lake_icefrac(1:,i),               savedtke1(i),    &
 
@@ -172,7 +172,7 @@ SUBROUTINE CoLMDRIVER (idate,deltim,dolai,doalb,dosst,oro)
 
              ! TUNABLE modle constants
                zlnd,            zsno,            csoilc,          dewmx,           &
-               ! 'wtfact' is updated to gridded 'fsatmax' data. 
+               ! 'wtfact' is updated to gridded 'fsatmax' data.
                capr,            cnfac,           ssi,             &
                wimp,            pondmx,          smpmax,          smpmin,          &
                trsmx0,          tcrit,                                             &
@@ -211,7 +211,7 @@ SUBROUTINE CoLMDRIVER (idate,deltim,dolai,doalb,dosst,oro)
             patchlonr(i)    ,patchlatr(i)    ,patchclass(i)   ,patchtype(i)    ,&
 
           ! URBAN PARAMETERS
-            froof(u)        ,flake(u)        ,hroof(u)        ,hwr(u)          ,&
+            froof(u)        ,flake(u)        ,hroof(u)        ,hlr(u)          ,&
             fgper(u)        ,em_roof(u)      ,em_wall(u)      ,em_gimp(u)      ,&
             em_gper(u)      ,cv_roof(:,u)    ,cv_wall(:,u)    ,cv_gimp(:,u)    ,&
             tk_roof(:,u)    ,tk_wall(:,u)    ,tk_gimp(:,u)    ,z_roof(:,u)     ,&
@@ -322,7 +322,7 @@ SUBROUTINE CoLMDRIVER (idate,deltim,dolai,doalb,dosst,oro)
 
           ! TUNABLE modle constants
             zlnd            ,zsno            ,csoilc          ,dewmx           ,&
-            ! 'wtfact' is updated to gridded 'fsatmax' data. 
+            ! 'wtfact' is updated to gridded 'fsatmax' data.
             capr            ,cnfac           ,ssi             ,&
             wimp            ,pondmx          ,smpmax          ,smpmin          ,&
             trsmx0          ,tcrit                                             ,&

--- a/main/MOD_CanopyLayerProfile.F90
+++ b/main/MOD_CanopyLayerProfile.F90
@@ -353,8 +353,8 @@ CONTAINS
          IF (udiff_lb == 0) THEN !root found
             rootn = rootn + 1
             IF (rootn > 2) THEN
-               print *, "U root number > 2, abort!"
-               CALL abort
+               print *, "Warning: U root number > 2, attention!"
+               RETURN !CALL abort
             ENDIF
             roots(rootn) = zmid
          ENDIF
@@ -362,8 +362,8 @@ CONTAINS
          IF (ztop-zmid < 0.01) THEN
             rootn = rootn + 1 !root found
             IF (rootn > 2) THEN
-               print *, "U root number > 2, abort!"
-               CALL abort
+               print *, "Warning: U root number > 2, attention!"
+               RETURN !CALL abort
             ENDIF
             roots(rootn) = (ztop+zmid)/2.
          ELSE
@@ -379,8 +379,8 @@ CONTAINS
          IF (udiff_ub == 0) THEN !root found
             rootn = rootn + 1
             IF (rootn > 2) THEN
-               print *, "U root number > 2, abort!"
-               CALL abort
+               print *, "Warning: U root number > 2, attention!"
+               RETURN !CALL abort
             ENDIF
             roots(rootn) = zmid
          ENDIF
@@ -388,8 +388,8 @@ CONTAINS
          IF (zmid-zbot < 0.01) THEN
             rootn = rootn + 1 !root found
             IF (rootn > 2) THEN
-               print *, "U root number > 2, abort!"
-               CALL abort
+               print *, "Warning: U root number > 2, attention!"
+               RETURN !CALL abort
             ENDIF
             roots(rootn) = (zmid+zbot)/2.
          ELSE
@@ -591,8 +591,8 @@ CONTAINS
          IF (kdiff_lb == 0) THEN !root found
             rootn = rootn + 1
             IF (rootn > 2) THEN
-               print *, "K root number > 2, abort!"
-               CALL abort
+               print *, "Warning: K root number > 2, attention!"
+               RETURN !CALL abort
             ENDIF
             roots(rootn) = zmid
          ENDIF
@@ -600,8 +600,8 @@ CONTAINS
          IF (ztop-zmid < 0.01) THEN
             rootn = rootn + 1 !root found
             IF (rootn > 2) THEN
-               print *, "K root number > 2, abort!"
-               CALL abort
+               print *, "Warning: K root number > 2, attention!"
+               RETURN !CALL abort
             ENDIF
             roots(rootn) = (ztop+zmid)/2.
          ELSE
@@ -617,8 +617,8 @@ CONTAINS
          IF (kdiff_ub == 0) THEN !root found
             rootn = rootn + 1
             IF (rootn > 2) THEN
-               print *, "K root number > 2, abort!"
-               CALL abort
+               print *, "Warning: K root number > 2, attention!"
+               RETURN !CALL abort
             ENDIF
             roots(rootn) = zmid
          ENDIF
@@ -626,8 +626,8 @@ CONTAINS
          IF (zmid-zbot < 0.01) THEN
             rootn = rootn + 1 !root found
             IF (rootn > 2) THEN
-               print *, "K root number > 2, abort!"
-               CALL abort
+               print *, "Warning: K root number > 2, attention!"
+               RETURN !CALL abort
             ENDIF
             roots(rootn) = (zmid+zbot)/2.
          ELSE

--- a/main/MOD_Forcing.F90
+++ b/main/MOD_Forcing.F90
@@ -1306,9 +1306,6 @@ CONTAINS
          sec    = (time_i-1)*dtime(var_i) + offset(var_i) - 86400*(day-1)
          tstamp_LB(var_i)%sec = sec
 
-         ! A trick, set one second backward
-         IF (trim(timelog(var_i)) == 'backward') sec = sec - 1
-
          ! set time stamp (ststamp_LB)
          IF (sec < 0) THEN
             tstamp_LB(var_i)%sec = 86400 + sec
@@ -1375,9 +1372,6 @@ CONTAINS
          sec    = (time_i-1)*dtime(var_i) + offset(var_i) - 86400*(mday-1)
          tstamp_LB(var_i)%sec  = sec
 
-         ! A trick, set one second backward
-         IF (trim(timelog(var_i)) == 'backward') sec = sec - 1
-
          ! set time stamp (ststamp_LB)
          IF (sec < 0) THEN
             tstamp_LB(var_i)%sec = 86400 + sec
@@ -1440,9 +1434,6 @@ CONTAINS
          time_i = floor( (sec-offset(var_i)) *1. / dtime(var_i) ) + 1
          sec    = (time_i-1)*dtime(var_i) + offset(var_i)
          tstamp_LB(var_i)%sec  = sec
-
-         ! A trick, set one second backward
-         IF (trim(timelog(var_i)) == 'backward') sec = sec - 1
 
          ! set time stamp (ststamp_LB)
          IF (sec < 0) THEN
@@ -1664,14 +1655,14 @@ CONTAINS
    real(r8) :: calday, cosz
    type(timestamp) :: tstamp
 
-      tstamp = tstamp_LB(7)
+      tstamp = idate !tstamp_LB(7)
       ntime = 0
       DO WHILE (tstamp < tstamp_UB(7))
          ntime  = ntime + 1
          tstamp = tstamp + deltim_int
       ENDDO
 
-      tstamp = tstamp_LB(7)
+      tstamp = idate !tstamp_LB(7)
       CALL flush_block_data (avgcos, 0._r8)
 
       DO WHILE (tstamp < tstamp_UB(7))

--- a/main/MOD_LAIReadin.F90
+++ b/main/MOD_LAIReadin.F90
@@ -69,7 +69,7 @@ CONTAINS
 
 #ifdef SinglePoint
 #ifndef URBAN_MODEL
-      iyear = findloc_ud(SITE_LAI_year == year)
+      iyear = findloc_ud(SITE_LAI_year == min(DEF_LAI_END_YEAR, max(DEF_LAI_START_YEAR,year) )
       IF (.not. DEF_LAI_MONTHLY) THEN
          itime = (time-1)/8 + 1
       ENDIF
@@ -90,7 +90,7 @@ CONTAINS
 #endif
 #else
       IF (DEF_LAI_MONTHLY) THEN
-         write(cyear,'(i4.4)') year
+         write(cyear,'(i4.4)') min(DEF_LAI_END_YEAR, max(DEF_LAI_START_YEAR,year) )
          write(ctime,'(i2.2)') time
 
          lndname = trim(landdir)//'/'//trim(cyear)//'/LAI_patches'//trim(ctime)//'.nc'
@@ -99,7 +99,7 @@ CONTAINS
          lndname = trim(landdir)//'/'//trim(cyear)//'/SAI_patches'//trim(ctime)//'.nc'
          CALL ncio_read_vector (lndname, 'SAI_patches',  landpatch, tsai)
       ELSE
-         write(cyear,'(i4.4)') year
+         write(cyear,'(i4.4)') min(DEF_LAI_END_YEAR, max(DEF_LAI_START_YEAR,year) )
          write(ctime,'(i3.3)') time
          lndname = trim(landdir)//'/'//trim(cyear)//'/LAI_patches'//trim(ctime)//'.nc'
          CALL ncio_read_vector (lndname, 'LAI_patches',  landpatch, tlai)
@@ -163,7 +163,7 @@ CONTAINS
 #endif
 #else
 
-      write(cyear,'(i4.4)') year
+      write(cyear,'(i4.4)') min(DEF_LAI_END_YEAR, max(DEF_LAI_START_YEAR,year) )
       write(ctime,'(i2.2)') time
       IF (.not. DEF_USE_LAIFEEDBACK)THEN
          lndname = trim(landdir)//'/'//trim(cyear)//'/LAI_patches'//trim(ctime)//'.nc'

--- a/main/MOD_LeafTemperature.F90
+++ b/main/MOD_LeafTemperature.F90
@@ -870,7 +870,7 @@ ENDIF
 !-----------------------------------------------------------------------
 
          del  = sqrt( dtl(it)*dtl(it) )
-         dele = dtl(it) * dtl(it) * ( dirab_dtl**2 + fsenl_dtl**2 + hvap*fevpl_dtl**2 )
+         dele = dtl(it) * dtl(it) * ( dirab_dtl**2 + fsenl_dtl**2 + (hvap*fevpl_dtl)**2 )
          dele = sqrt(dele)
 
 !-----------------------------------------------------------------------

--- a/main/MOD_LeafTemperaturePC.F90
+++ b/main/MOD_LeafTemperaturePC.F90
@@ -1549,7 +1549,7 @@ ENDIF
 
                del(i)  = sqrt( dtl(it,i)*dtl(it,i) )
                dele(i) = dtl(it,i) * dtl(it,i) * &
-                       ( dirab_dtl(i)**2 + fsenl_dtl(i)**2 + hvap*fevpl_dtl(i)**2 )
+                       ( dirab_dtl(i)**2 + fsenl_dtl(i)**2 + (hvap*fevpl_dtl(i))**2 )
                dele(i) = sqrt(dele(i))
 
 !-----------------------------------------------------------------------

--- a/main/MOD_Thermal.F90
+++ b/main/MOD_Thermal.F90
@@ -598,7 +598,11 @@ ENDIF
 #endif
                             dz_soisno,t_soisno,wliq_soisno,wice_soisno,fsno,qg,rss)
       ELSE
-         rss = 0.
+         IF (DEF_RSS_SCHEME == 4) THEN
+            rss = 1.        !LP92
+         ELSE
+            rss = 0.        !the other RSS schemes
+         ENDIF
       ENDIF
 
 !=======================================================================

--- a/main/MOD_UserSpecifiedForcing.F90
+++ b/main/MOD_UserSpecifiedForcing.F90
@@ -70,6 +70,7 @@ MODULE MOD_UserSpecifiedForcing
 
    character(len=256), allocatable :: fprefix(:)   ! file prefix
    character(len=256), allocatable :: vname(:)     ! variable name
+   character(len=256), allocatable :: timelog(:)   ! variable time log info
    character(len=256), allocatable :: tintalgo(:)  ! interpolation algorithm
 
    ! ----- public subroutines -----
@@ -101,9 +102,11 @@ CONTAINS
 
       IF (allocated(fprefix )) deallocate(fprefix )
       IF (allocated(vname   )) deallocate(vname   )
+      IF (allocated(timelog )) deallocate(timelog )
       IF (allocated(tintalgo)) deallocate(tintalgo)
       allocate (fprefix  (NVAR))
       allocate (vname    (NVAR))
+      allocate (timelog  (NVAR))
       allocate (tintalgo (NVAR))
 
       solarin_all_band = DEF_forcing%solarin_all_band ! whether solar radiation in all bands is available
@@ -129,16 +132,17 @@ CONTAINS
       groupby          = DEF_forcing%groupby          ! file grouped by year/month
 
       DO ivar = 1, NVAR_default
-         fprefix (ivar) = DEF_forcing%fprefix(ivar)  ! file prefix
-         vname   (ivar) = DEF_forcing%vname(ivar)    ! variable name
-         tintalgo(ivar) = DEF_forcing%tintalgo(ivar) ! interpolation algorithm
+         fprefix (ivar) = DEF_forcing%fprefix(ivar)   ! file prefix
+         vname   (ivar) = DEF_forcing%vname(ivar)     ! variable name
+         timelog (ivar) = DEF_forcing%timelog(ivar)   ! variable name
+         tintalgo(ivar) = DEF_forcing%tintalgo(ivar)  ! interpolation algorithm
       END DO
       IF (DEF_USE_CBL_HEIGHT) THEN
          fprefix (NVAR) = DEF_forcing%CBL_fprefix
          vname   (NVAR) = DEF_forcing%CBL_vname
          tintalgo(NVAR) = DEF_forcing%CBL_tintalgo
-         dtime(NVAR)    = DEF_forcing%CBL_dtime
-         offset(NVAR)   = DEF_forcing%CBL_offset
+         dtime   (NVAR) = DEF_forcing%CBL_dtime
+         offset  (NVAR) = DEF_forcing%CBL_offset
       ENDIF
    END SUBROUTINE init_user_specified_forcing
 
@@ -435,7 +439,7 @@ CONTAINS
       !References:
       !-------------------
          !---Kosaka Y., S. Kobayashi, Y. Harada, C. Kobayashi, H. Naoe, K. Yoshimoto, M. Harada, N. Goto, J. Chiba, K. Miyaoka, R. Sekiguchi,
-         !   M. Deushi, H. Kamahori, T. Nakaegawa; T. Y.Tanaka, T. Tokuhiro, Y. Sato, Y. Matsushita, and K. Onogi, 2024: 
+         !   M. Deushi, H. Kamahori, T. Nakaegawa; T. Y.Tanaka, T. Tokuhiro, Y. Sato, Y. Matsushita, and K. Onogi, 2024:
          !   The JRA-3Q reanalysis. J. Meteor. Soc. Japan, 102, https://doi.org/10.2151/jmsj.2024-004.
 
 
@@ -448,11 +452,11 @@ CONTAINS
          !DESCRIPTION
          !===========
             !---the Japanese 55-year Reanalysis
-   
+
          !data source:
          !-------------------
             !---https://jra.kishou.go.jp/JRA-55/index_en.html
-   
+
          !References:
          !-------------------
             !---Kobayashi, S., Y. Ota, Y. Harada, A. Ebita, M. Moriya, H. Onoda, K. Onogi,
@@ -463,12 +467,12 @@ CONTAINS
             !   K. Onogi, K. Miyaoka, and K. Takahashi, 2016: The JRA-55 Reanalysis:
             !   Representation of atmospheric circulation and climate variability, J. Meteor. Soc. Japan,
             !   94, 269-302, doi:10.2151/jmsj.2016-015.
-   
+
          !REVISION HISTORY
          !----------------
             !---2021.11.01   Zhongwang Wei @ SYSU: zip file to reduce the size of the data; remove offset and scale_factor
-   
-   
+
+
 
          metfilename = '/'//trim(fprefix(var_i))//'_'//trim(yearstr)//'.nc'
 
@@ -564,24 +568,24 @@ CONTAINS
          !DESCRIPTION
          !===========
             !---CMA’s first-generation global atmospheric reanalysis (RA) covering 1979–2018 (CRA-40)
-   
+
          !data source:
          !-------------------
             !---https://data.cma.cn/en
-   
+
          !References:
          !-------------------
-            !---Liu, Z., Jiang, L., Shi, C. et al. CRA-40/Atmosphere—The First-Generation Chinese Atmospheric Reanalysis (1979–2018): 
+            !---Liu, Z., Jiang, L., Shi, C. et al. CRA-40/Atmosphere—The First-Generation Chinese Atmospheric Reanalysis (1979–2018):
             !   System Description and Performance Evaluation. J Meteorol Res 37, 1–19 (2023). https://doi.org/10.1007/s13351-023-2086-x
 
 
-   
+
             !REVISION HISTORY
          !----------------
             !---2024.04.10   Zhongwang Wei @ SYSU: regroup the data into annual file;
             !   zip file to reduce the size of the data; remove offset and scale_factor
-   
-   
+
+
             metfilename = '/'//trim(fprefix(var_i))//'_'//trim(yearstr)//'.nc'
       CASE ('TPMFD')
       !DESCRIPTION

--- a/main/URBAN/CoLMMAIN_Urban.F90
+++ b/main/URBAN/CoLMMAIN_Urban.F90
@@ -62,7 +62,7 @@
            patchlonr    ,patchlatr    ,patchclass   ,patchtype    ,&
 
          ! urban and lake depth
-           froof        ,flake        ,hroof        ,hwr          ,&
+           froof        ,flake        ,hroof        ,hlr          ,&
            fgper        ,em_roof      ,em_wall      ,em_gimp      ,&
            em_gper      ,cv_roof      ,cv_wall      ,cv_gimp      ,&
            tk_roof      ,tk_wall      ,tk_gimp      ,z_roof       ,&
@@ -230,7 +230,7 @@
         fgper                 ,&! impervious fraction to ground area [-]
         flake                 ,&! lake fraction to ground area [-]
         hroof                 ,&! average building height [m]
-        hwr                   ,&! average building height to their distance [-]
+        hlr                   ,&! average building height to their side length [-]
         em_roof               ,&! emissivity of roof [-]
         em_wall               ,&! emissivity of walls [-]
         em_gimp               ,&! emissivity of impervious [-]
@@ -256,8 +256,8 @@
         psi0        (nl_soil) ,&! minimum soil suction [mm]
         bsw         (nl_soil) ,&! clapp and hornbereger "b" parameter [-]
         theta_r     (nl_soil) ,&! residual water content (cm3/cm3)
-        fsatmax               ,&! maximum saturated area fraction [-] 
-        fsatdcf               ,&! decay factor in calucation of saturated area fraction [1/m] 
+        fsatmax               ,&! maximum saturated area fraction [-]
+        fsatdcf               ,&! decay factor in calucation of saturated area fraction [1/m]
 
 #ifdef vanGenuchten_Mualem_SOIL_MODEL
         alpha_vgm (1:nl_soil) ,&! the parameter corresponding approximately to the inverse of the air-entry value
@@ -969,7 +969,7 @@
          vehicle            ,weh_prof           ,wdh_prof           ,idate              ,&
          patchlonr                                                                      ,&
          ! GROUND PARAMETERS
-         froof              ,flake              ,hroof              ,hwr                ,&
+         froof              ,flake              ,hroof              ,hlr                ,&
          fgper              ,pondmx             ,em_roof            ,em_wall            ,&
          em_gimp            ,em_gper            ,trsmx0             ,zlnd               ,&
          zsno               ,capr               ,cnfac              ,vf_quartz          ,&
@@ -1295,7 +1295,7 @@
       ! we supposed call it every time-step, because
       ! other vegeation related parameters are needed to create
 
-      CALL alburban (ipatch,froof,fgper,flake,hwr,hroof,&
+      CALL alburban (ipatch,froof,fgper,flake,hlr,hroof,&
                      alb_roof,alb_wall,alb_gimp,alb_gper,&
                      rho,tau,fveg,(htop+hbot)/2.,lai,sai,fwet_snow,coszen,fwsun,tlake,&
                      fsno_roof,fsno_gimp,fsno_gper,fsno_lake,&

--- a/main/URBAN/MOD_Urban_Albedo.F90
+++ b/main/URBAN/MOD_Urban_Albedo.F90
@@ -33,7 +33,7 @@ CONTAINS
 
 !-----------------------------------------------------------------------
 
-   SUBROUTINE alburban (ipatch,froof,fgper,flake,hwr,hroof,&
+   SUBROUTINE alburban (ipatch,froof,fgper,flake,hlr,hroof,&
                         alb_roof,alb_wall,alb_gimp,alb_gper,&
                         rho,tau,fveg,hveg,lai,sai,fwet_snow,coszen,fwsun,tlake,&
                         fsno_roof,fsno_gimp,fsno_gper,fsno_lake,&
@@ -73,7 +73,7 @@ CONTAINS
       froof,         &! roof fraction
       fgper,         &! impervious ground weight fraction
       flake,         &! lake fraction
-      hwr,           &! average building height to their distance
+      hlr,           &! average building height to their side length
       hroof           ! average building height
 
    real(r8), intent(in) :: &
@@ -328,14 +328,14 @@ CONTAINS
       IF (lai+sai>1.e-6 .and. fveg>0.) THEN
 
          CALL UrbanVegShortwave ( &
-            theta, hwr, froof, fgper, hroof, &
+            theta, hlr, froof, fgper, hroof, &
             albroof(1,1), alb_wall(1,1), albgimp(1,1), albgper(1,1), &
             lai, sai, fveg, hveg, erho(1), etau(1), &
             fwsun_, sroof(1,:), swsun(1,:), swsha(1,:), sgimp(1,:), &
             sgper(1,:), ssun(1,:), alb(1,:))
 
          CALL UrbanVegShortwave ( &
-            theta, hwr, froof, fgper, hroof, &
+            theta, hlr, froof, fgper, hroof, &
             albroof(2,1), alb_wall(2,1), albgimp(2,1), albgper(2,1), &
             lai, sai, fveg, hveg, erho(2), etau(2), &
             fwsun_, sroof(2,:), swsun(2,:), swsha(2,:), sgimp(2,:), &
@@ -343,13 +343,13 @@ CONTAINS
       ELSE
 
          CALL UrbanOnlyShortwave ( &
-            theta, hwr, froof, fgper, hroof, &
+            theta, hlr, froof, fgper, hroof, &
             albroof(1,1), alb_wall(1,1), albgimp(1,1), albgper(1,1), &
             fwsun_, sroof(1,:), swsun(1,:), swsha(1,:), sgimp(1,:), &
             sgper(1,:), alb(1,:))
 
          CALL UrbanOnlyShortwave ( &
-            theta, hwr, froof, fgper, hroof, &
+            theta, hlr, froof, fgper, hroof, &
             albroof(2,1), alb_wall(2,1), albgimp(2,1), albgper(2,1), &
             fwsun_, sroof(2,:), swsun(2,:), swsha(2,:), sgimp(2,:), &
             sgper(2,:), alb(2,:))

--- a/main/URBAN/MOD_Urban_Flux.F90
+++ b/main/URBAN/MOD_Urban_Flux.F90
@@ -87,7 +87,7 @@ CONTAINS
          qm             ,psrf           ,rhoair         ,Fhac           ,&
          Fwst           ,Fach           ,vehc           ,meta           ,&
          ! Urban parameters
-         hroof          ,hwr            ,nurb           ,fcover         ,&
+         hroof          ,hlr            ,nurb           ,fcover         ,&
          ! Status of surface
          z0h_g          ,obug           ,ustarg         ,zlnd           ,&
          zsno           ,fsno_roof      ,fsno_gimp      ,fsno_gper      ,&
@@ -148,7 +148,7 @@ CONTAINS
 
    real(r8), intent(in) :: &
         hroof,        &! average building height [m]
-        hwr,          &! average building height to their distance [-]
+        hlr,          &! average building height to their side length [-]
         fcover(0:4)    ! coverage of aboveground urban components [-]
 
    real(r8), intent(in) :: &
@@ -283,7 +283,7 @@ CONTAINS
         fg,           &! ground fractional cover
         fgimp,        &! weight of impervious ground
         fgper,        &! weight of pervious ground
-        hlr,          &! average building height to their length of edge [-]
+        hwr,          &! average building height to their distance [-]
         sqrtdragc,    &! sqrt(drag coefficient)
         lm,           &! mix length within canopy
         fai,          &! frontal area index
@@ -355,7 +355,8 @@ CONTAINS
       fg     = 1 - fcover(0)
       fgimp  = fcover(3)/fg
       fgper  = fcover(4)/fg
-      hlr    = hwr*(1-sqrt(fcover(0)))/sqrt(fcover(0))
+      !hlr   = hwr*(1-sqrt(fcover(0)))/sqrt(fcover(0))
+      hwr    = hlr*sqrt(fcover(0))/(1-sqrt(fcover(0)))
       canlev = (/3, 2, 2/)
       numlay = 2
 
@@ -842,7 +843,7 @@ CONTAINS
          rstfac         ,Fhac           ,Fwst           ,Fach           ,&
          vehc           ,meta                                           ,&
          ! Urban and vegetation parameters
-         hroof          ,hwr            ,nurb           ,fcover         ,&
+         hroof          ,hlr            ,nurb           ,fcover         ,&
          ewall          ,egimp          ,egper          ,ev             ,&
          htop           ,hbot           ,lai            ,sai            ,&
          sqrtdi         ,effcon         ,vmax25         ,slti           ,&
@@ -929,7 +930,7 @@ CONTAINS
 
    real(r8), intent(in) :: &
         hroof,        &! average building height [m]
-        hwr,          &! average building height to their distance [-]
+        hlr,          &! average building height to their side length [-]
         fcover(0:5)    ! coverage of aboveground urban components [-]
 
    real(r8), intent(in) :: &
@@ -1171,7 +1172,7 @@ CONTAINS
         fg,           &! ground fractional cover
         fgimp,        &! weight of impervious ground
         fgper,        &! weight of pervious ground
-        hlr,          &! average building height to their length of edge [-]
+        hwr,          &! average building height to their distance [-]
         sqrtdragc,    &! sqrt(drag coefficient)
         lm,           &! mix length within canopy
         fai,          &! frontal area index for urban
@@ -1299,7 +1300,8 @@ CONTAINS
       fc(3)  = fcover(5)
       fgimp  = fcover(3)/fg
       fgper  = fcover(4)/fg
-      hlr    = hwr*(1-sqrt(fcover(0)))/sqrt(fcover(0))
+      !hlr   = hwr*(1-sqrt(fcover(0)))/sqrt(fcover(0))
+      hwr    = hlr*sqrt(fcover(0))/(1-sqrt(fcover(0)))
       canlev = (/3, 2, 2, 1/)
 
       B_5    = B(5)

--- a/main/URBAN/MOD_Urban_Flux.F90
+++ b/main/URBAN/MOD_Urban_Flux.F90
@@ -1958,7 +1958,7 @@ ENDIF
 
          del  = sqrt( dtl(it)*dtl(it) )
          dele = dtl(it) * dtl(it) * &
-                ( dirab_dtl**2 + fsenl_dtl**2 + hvap*fevpl_dtl**2 )
+                ( dirab_dtl**2 + fsenl_dtl**2 + (hvap*fevpl_dtl)**2 )
          dele = sqrt(dele)
 
 !-----------------------------------------------------------------------

--- a/main/URBAN/MOD_Urban_LAIReadin.F90
+++ b/main/URBAN/MOD_Urban_LAIReadin.F90
@@ -54,10 +54,10 @@ CONTAINS
 
       ! READ in Leaf area index and stem area index
       write(ctime,'(i2.2)') time
-      write(cyear,'(i4.4)') year
+      write(cyear,'(i4.4)') min(DEF_LAI_END_YEAR, max(DEF_LAI_START_YEAR,year) )
 
 #ifdef SinglePoint
-      iyear = findloc_ud(SITE_LAI_year == year)
+      iyear = findloc_ud(SITE_LAI_year == min(DEF_LAI_END_YEAR, max(DEF_LAI_START_YEAR,year) )
       urb_lai(:) = SITE_LAI_monthly(time,iyear)
       urb_sai(:) = SITE_SAI_monthly(time,iyear)
 #else

--- a/main/URBAN/MOD_Urban_Longwave.F90
+++ b/main/URBAN/MOD_Urban_Longwave.F90
@@ -91,7 +91,7 @@ CONTAINS
    real(r8) ::    &
         W,          &! Urban ground average width [m]
         L,          &! Urban building average length [m]
-        HW,         &! Ratio of H to L, H/L [-]
+        HW,         &! Ratio of H to W, H/W [-]
         fg,         &! Fraction of ground [-]
         fgimp,      &! Fraction of snow ground [-]
 
@@ -122,7 +122,6 @@ CONTAINS
       !W  = H/HW
       !L  = W*sqrt(fb)/(1-sqrt(fb))
       !HL = H/L !NOTE: Same as HL = HW*(1-sqrt(fb))/sqrt(fb)
-      L  = H/HL
       fg = 1. - fb
       fgimp = 1. - fgper
 
@@ -316,7 +315,7 @@ CONTAINS
    real(r8) :: &
         W,          &! Urban ground average width [m]
         L,          &! Urban building average length [m]
-        HW,         &! Ratio of H to L, H/L [-]
+        HW,         &! Ratio of H to W, H/W [-]
         fg,         &! Fraction of ground [-]
         fgimp,      &! Fraction of pervious ground [-]
 

--- a/main/URBAN/MOD_Urban_Shortwave.F90
+++ b/main/URBAN/MOD_Urban_Shortwave.F90
@@ -23,7 +23,7 @@ MODULE MOD_Urban_Shortwave
 CONTAINS
 
 
-   SUBROUTINE UrbanOnlyShortwave ( theta, HW, fb, fgper, H, &
+   SUBROUTINE UrbanOnlyShortwave ( theta, HL, fb, fgper, H, &
         aroof, awall, agimp, agper, fwsun, sroof, swsun, swsha, sgimp, sgper, albu)
 
 !-----------------------------------------------------------------------
@@ -60,7 +60,7 @@ CONTAINS
 
    real(r8), intent(in) :: &
         theta,      &! Sun zenith angle [radian]
-        HW,         &! Ratio of building height to ground width [-]
+        HL,         &! Ratio of building height to their side length [-]
         fb,         &! Fraction of building area [-]
         fgper,      &! Fraction of impervious ground [-]
         H            ! Building average height [m]
@@ -85,7 +85,7 @@ CONTAINS
    real(r8) ::    &
         W,          &! Urban ground average width [m]
         L,          &! Urban building average length [m]
-        HL,         &! Ratio of H to L, H/L [-]
+        HW,         &! Ratio of H to W, H/W [-]
         fg,         &! Fraction of ground [-]
         fgimp,      &! Weight of pervious ground [-]
 
@@ -115,9 +115,9 @@ CONTAINS
 
       ! Claculate urban structure parameters
       !-------------------------------------------------
-      W  = H/HW
-      L  = W*sqrt(fb)/(1-sqrt(fb))
-      HL = H/L !NOTE: Same as: HL = HW*(1-sqrt(fb))/sqrt(fb)
+      !W  = H/HW
+      !L  = W*sqrt(fb)/(1-sqrt(fb))
+      !HL = H/L !NOTE: Same as: HL = HW*(1-sqrt(fb))/sqrt(fb)
       fg = 1. - fb
 
       fgimp = 1. - fgper
@@ -255,7 +255,7 @@ CONTAINS
    END SUBROUTINE UrbanOnlyShortwave
 
 
-   SUBROUTINE UrbanVegShortwave ( theta, HW, fb, fgper, H, &
+   SUBROUTINE UrbanVegShortwave ( theta, HL, fb, fgper, H, &
          aroof, awall, agimp, agper, lai, sai, fv, hv, rho, tau, &
          fwsun, sroof, swsun, swsha, sgimp, sgper, sveg, albu )
 
@@ -295,7 +295,7 @@ CONTAINS
 
    real(r8), intent(in) :: &
         theta,      &! Sun zenith angle [radian]
-        HW,         &! Ratio of building height to ground width [-]
+        HL,         &! Ratio of building height to their side length [-]
         fb,         &! Fraction of building area [-]
         fgper,      &! Fraction of impervious ground [-]
         H            ! Building average height [m]
@@ -331,7 +331,7 @@ CONTAINS
    real(r8) :: &
         W,          &! Urban ground average width
         L,          &! Urban building average length
-        HL,         &! Ratio of H to L, H/L [-]
+        HW,         &! Ratio of H to W, H/W [-]
         fg,         &! Fraction of ground [-]
         fgimp,      &! Weight of pervious ground [-]
 
@@ -398,9 +398,9 @@ CONTAINS
 
       ! Claculate urban structure parameters
       !-------------------------------------------------
-      W  = H/HW
-      L  = W*sqrt(fb)/(1-sqrt(fb))
-      HL = H/L !NOTE: Same as: HL = HW*(1-sqrt(fb))/sqrt(fb)
+      !W  = H/HW
+      !L  = W*sqrt(fb)/(1-sqrt(fb))
+      !HL = H/L !NOTE: Same as: HL = HW*(1-sqrt(fb))/sqrt(fb)
       fg = 1. - fb
 
       fgimp = 1. - fgper

--- a/main/URBAN/MOD_Urban_Thermal.F90
+++ b/main/URBAN/MOD_Urban_Thermal.F90
@@ -39,7 +39,7 @@ CONTAINS
         vehicle        ,weh_prof       ,wdh_prof       ,idate          ,&
         patchlonr                                                      ,&
         ! surface parameters
-        froof          ,flake          ,hroof          ,hwr            ,&
+        froof          ,flake          ,hroof          ,hlr            ,&
         fgper          ,pondmx         ,eroof          ,ewall          ,&
         egimp          ,egper          ,trsmx0         ,zlnd           ,&
         zsno           ,capr           ,cnfac          ,vf_quartz      ,&
@@ -187,7 +187,7 @@ CONTAINS
         froof                          ,&! roof fractional cover [-]
         flake                          ,&! urban lake fractional cover [-]
         hroof                          ,&! average building height [m]
-        hwr                            ,&! average building height to their distance [-]
+        hlr                            ,&! average building height to their side length [-]
         fgper                          ,&! impervious road fractional cover [-]
         pondmx                         ,&! maximum ponding for soil [mm]
         eroof                          ,&! emissivity of roof
@@ -756,7 +756,7 @@ CONTAINS
 
          ! call longwave function (vegetation)
          CALL UrbanVegLongwave ( &
-                                theta, hwr, froof, fgper, hroof, forc_frl, &
+                                theta, hlr, froof, fgper, hroof, forc_frl, &
                                 twsun, twsha, tgimp, tgper, ewall, egimp, &
                                 egper, lai, sai, fveg, (htop+hbot)/2., &
                                 ev, Ainv, B, B1, dBdT, SkyVF, VegVF, fcover)
@@ -774,7 +774,7 @@ CONTAINS
 
          ! call longwave function, calculate Ainv, B, B1, dBdT
          CALL UrbanOnlyLongwave ( &
-                                 theta, hwr, froof, fgper, hroof, forc_frl, &
+                                 theta, hlr, froof, fgper, hroof, forc_frl, &
                                  twsun, twsha, tgimp, tgper, ewall, egimp, egper, &
                                  Ainv, B, B1, dBdT, SkyVF, fcover)
 
@@ -867,7 +867,7 @@ CONTAINS
             rstfac         ,Fhac           ,Fwst           ,Fach           ,&
             vehc           ,meta                                           ,&
             ! urban and vegetation parameters
-            hroof          ,hwr            ,nurb           ,fcover         ,&
+            hroof          ,hlr            ,nurb           ,fcover         ,&
             ewall          ,egimp          ,egper          ,ev             ,&
             htop           ,hbot           ,lai            ,sai            ,&
             sqrtdi         ,effcon         ,vmax25         ,slti           ,&
@@ -914,7 +914,7 @@ CONTAINS
             forc_q         ,forc_psrf      ,forc_rhoair    ,Fhac           ,&
             Fwst           ,Fach           ,vehc           ,meta           ,&
             ! surface parameters
-            hroof          ,hwr            ,nurb           ,fcover         ,&
+            hroof          ,hlr            ,nurb           ,fcover         ,&
             ! surface status
             z0h_g          ,obu_g          ,ustar_g        ,zlnd           ,&
             zsno           ,fsno_roof      ,fsno_gimp      ,fsno_gper      ,&

--- a/main/URBAN/MOD_Urban_Vars_TimeInvariants.F90
+++ b/main/URBAN/MOD_Urban_Vars_TimeInvariants.F90
@@ -37,7 +37,7 @@ MODULE MOD_Urban_Vars_TimeInvariants
    real(r8), allocatable :: fgper         (:) !impervious fraction to ground area [-]
    real(r8), allocatable :: flake         (:) !lake fraction to ground area [-]
    real(r8), allocatable :: hroof         (:) !average building height [m]
-   real(r8), allocatable :: hwr           (:) !average building height to their distance [-]
+   real(r8), allocatable :: hlr           (:) !average building height to their side length [-]
 
    real(r8), allocatable :: z_roof      (:,:) !depth of each roof layer [m]
    real(r8), allocatable :: z_wall      (:,:) !depth of each wall layer [m]
@@ -102,7 +102,7 @@ CONTAINS
             allocate (fgper                (numurban))
             allocate (flake                (numurban))
             allocate (hroof                (numurban))
-            allocate (hwr                  (numurban))
+            allocate (hlr                  (numurban))
 
             allocate (alb_roof         (2,2,numurban))
             allocate (alb_wall         (2,2,numurban))
@@ -171,7 +171,7 @@ CONTAINS
       ! morphological paras
       CALL ncio_read_vector (file_restart, 'WT_ROOF'       , landurban, froof    )
       CALL ncio_read_vector (file_restart, 'HT_ROOF'       , landurban, hroof    )
-      CALL ncio_read_vector (file_restart, 'CANYON_HWR'    , landurban, hwr      )
+      CALL ncio_read_vector (file_restart, 'BUILDING_HLR'  , landurban, hlr      )
       CALL ncio_read_vector (file_restart, 'WTROAD_PERV'   , landurban, fgper    )
       CALL ncio_read_vector (file_restart, 'EM_ROOF'       , landurban, em_roof  )
       CALL ncio_read_vector (file_restart, 'EM_WALL'       , landurban, em_wall  )
@@ -252,7 +252,7 @@ CONTAINS
       ! morphological paras
       CALL ncio_write_vector (file_restart, 'WT_ROOF'       , 'urban', landurban, froof    , DEF_REST_CompressLevel)
       CALL ncio_write_vector (file_restart, 'HT_ROOF'       , 'urban', landurban, hroof    , DEF_REST_CompressLevel)
-      CALL ncio_write_vector (file_restart, 'CANYON_HWR'    , 'urban', landurban, hwr      , DEF_REST_CompressLevel)
+      CALL ncio_write_vector (file_restart, 'BUILDING_HWR'  , 'urban', landurban, hlr      , DEF_REST_CompressLevel)
       CALL ncio_write_vector (file_restart, 'WTROAD_PERV'   , 'urban', landurban, fgper    , DEF_REST_CompressLevel)
       CALL ncio_write_vector (file_restart, 'EM_ROOF'       , 'urban', landurban, em_roof  , DEF_REST_CompressLevel)
       CALL ncio_write_vector (file_restart, 'EM_WALL'       , 'urban', landurban, em_wall  , DEF_REST_CompressLevel)
@@ -297,7 +297,7 @@ CONTAINS
             deallocate (fgper        )
             deallocate (flake        )
             deallocate (hroof        )
-            deallocate (hwr          )
+            deallocate (hlr          )
 
             deallocate (alb_roof     )
             deallocate (alb_wall     )

--- a/mkinidata/MOD_Initialize.F90
+++ b/mkinidata/MOD_Initialize.F90
@@ -196,7 +196,7 @@ CONTAINS
    integer, parameter :: nprms = 5
 #endif
    real(r8) :: prms(nprms, 1:nl_soil)
-   
+
    real(r8) :: wdsrfm, depthratio
    real(r8), dimension(10) :: dzlak = (/0.1, 1., 2., 3., 4., 5., 7., 7., 10.45, 10.45/)  ! m
 
@@ -227,7 +227,7 @@ CONTAINS
 
    integer  :: txt_id
    real(r8) :: vic_b_infilt_, vic_Dsmax_, vic_Ds_, vic_Ws_, vic_c_
-   
+
    ! for SimTop model parameters
    character(len=256) :: file_simtop_para
    logical            :: fexist
@@ -304,7 +304,7 @@ CONTAINS
       IF (p_is_worker .and. (numpatch > 0)) THEN
          WHERE (patchtype == 4) wdsrf = lakedepth * 1.e3
       ENDIF
-         
+
 ! ...............................................................
 ! 1.3 Read in the soil parameters of the patches of the gridcells
 ! ...............................................................
@@ -477,7 +477,7 @@ CONTAINS
 #ifdef USEMPI
             CALL mpi_bcast (filval, 1, MPI_REAL8, p_address_master, p_comm_glb, p_err)
 #endif
-            
+
             CALL map_simtop_para%build_arealweighted (g_simtop_para, landpatch)
             CALL map_simtop_para%set_missing_value   (fsatmax_grid, filval)
 
@@ -1357,7 +1357,7 @@ CONTAINS
                meta          (u) = 0.   !flux from metabolic [W/m2]
                vehc          (u) = 0.   !flux from vehicle [W/m2]
 
-               CALL UrbanIniTimeVar(i,froof(u),fgper(u),flake(u),hwr(u),hroof(u),&
+               CALL UrbanIniTimeVar(i,froof(u),fgper(u),flake(u),hlr(u),hroof(u),&
                   alb_roof(:,:,u),alb_wall(:,:,u),alb_gimp(:,:,u),alb_gper(:,:,u),&
                   rho(:,:,m),tau(:,:,m),fveg(i),htop(i),hbot(i),lai(i),sai(i),coszen(i),&
                   fsno_roof(u),fsno_gimp(u),fsno_gper(u),fsno_lake(u),&

--- a/mkinidata/MOD_UrbanIniTimeVariable.F90
+++ b/mkinidata/MOD_UrbanIniTimeVariable.F90
@@ -25,7 +25,7 @@ MODULE MOD_UrbanIniTimeVariable
 
 CONTAINS
 
-   SUBROUTINE UrbanIniTimeVar(ipatch,froof,fgper,flake,hwr,hroof,&
+   SUBROUTINE UrbanIniTimeVar(ipatch,froof,fgper,flake,hlr,hroof,&
                     alb_roof,alb_wall,alb_gimp,alb_gper,&
                     rho,tau,fveg,htop,hbot,lai,sai,coszen,&
                     fsno_roof,fsno_gimp,fsno_gper,fsno_lake,&
@@ -46,7 +46,7 @@ CONTAINS
          froof,         &! roof fraction
          fgper,         &! impervious ground weight fraction
          flake,         &! lake fraction
-         hwr,           &! average building height to their distance
+         hlr,           &! average building height to their side length
          hroof           ! average building height
 
    real(r8), intent(in) :: &
@@ -118,7 +118,7 @@ CONTAINS
       hveg        = min(hroof, (htop+hbot)/2.)
 
       ! urban surface albedo
-      CALL alburban (ipatch,froof,fgper,flake,hwr,hroof,&
+      CALL alburban (ipatch,froof,fgper,flake,hlr,hroof,&
                      alb_roof,alb_wall,alb_gimp,alb_gper,&
                      rho,tau,fveg,hveg,lai,sai,fwet_snow,max(0.01,coszen),fwsun,tlake,&
                      fsno_roof,fsno_gimp,fsno_gper,fsno_lake,&

--- a/mkinidata/MOD_UrbanReadin.F90
+++ b/mkinidata/MOD_UrbanReadin.F90
@@ -82,7 +82,7 @@ IF (DEF_URBAN_type_scheme == 1) THEN
 
 #ifdef SinglePoint
       lucyid(:) = SITE_lucyid
-      hwr   (:) = SITE_hwr
+      hlr   (:) = SITE_hlr
       fgper (:) = SITE_fgper
 
       em_roof(:) = SITE_em_roof
@@ -111,7 +111,7 @@ IF (DEF_URBAN_type_scheme == 1) THEN
       ! READ in urban data
       lndname = trim(dir_landdata)//'/urban/'//trim(cyear)//'/urban.nc'
 
-      CALL ncio_read_vector (lndname, 'CANYON_HWR  '  , landurban, hwr    ) ! average building height to their distance
+      CALL ncio_read_vector (lndname, 'BUILDING_HLR'  , landurban, hlr    ) ! average building height to their side length
       CALL ncio_read_vector (lndname, 'WTROAD_PERV'   , landurban, fgper  ) ! pervious fraction to ground area
       CALL ncio_read_vector (lndname, 'EM_ROOF'       , landurban, em_roof) ! emissivity of roof
       CALL ncio_read_vector (lndname, 'EM_WALL'       , landurban, em_wall) ! emissivity of wall
@@ -220,10 +220,10 @@ IF (DEF_URBAN_type_scheme == 1) THEN
 ELSEIF (DEF_URBAN_type_scheme == 2) THEN
             ! read in LCZ constants
 #ifdef SinglePoint
-            hwr  (:) = SITE_hwr
+            hlr  (:) = SITE_hlr
             fgper(:) = SITE_fgper
 #else
-            hwr  (u) = canyonhwr_lcz (landurban%settyp(u))  !average building height to their distance
+            hlr  (u) = canyonhwr_lcz (landurban%settyp(u))  !average building height to their distance
             fgper(u) = wtperroad_lcz (landurban%settyp(u)) &
                      / (1-wtroof_lcz (landurban%settyp(u)))!pervious fraction to ground area
             fgper(u) = min(fgper(u), 1.)
@@ -330,6 +330,12 @@ ENDIF
             !NOTE: USE global lake depth right now, the below set to 1m
             !lakedepth(npatch) = 1.
             !dz_lake(:,npatch) = lakedepth(npatch) / nl_lake
+
+            ! IF the parameter read is canyon H/W ratio, convert it to H/R ratio
+            IF (DEF_USE_CANYON_HWR) THEN
+               hlr(u) = hrl(u)*(1-sqrt(froof(u)))/sqrt(froof(u))
+            ENDIF
+
          ENDDO
       ENDIF
 

--- a/mkinidata/MOD_UrbanReadin.F90
+++ b/mkinidata/MOD_UrbanReadin.F90
@@ -333,7 +333,7 @@ ENDIF
 
             ! IF the parameter read is canyon H/W ratio, convert it to H/R ratio
             IF (DEF_USE_CANYON_HWR) THEN
-               hlr(u) = hrl(u)*(1-sqrt(froof(u)))/sqrt(froof(u))
+               hlr(u) = hlr(u)*(1-sqrt(froof(u)))/sqrt(froof(u))
             ENDIF
 
          ENDDO

--- a/mksrfdata/Aggregation_LAI.F90
+++ b/mksrfdata/Aggregation_LAI.F90
@@ -147,8 +147,8 @@ SUBROUTINE Aggregation_LAI (gridlai, dir_rawdata, dir_model_landdata, lc_year)
          ntime      = 12
 #else
          IF (DEF_LAI_CHANGE_YEARLY) THEN
-            start_year = simulation_lai_year_start
-            end_year   = simulation_lai_year_end
+            start_year = max(simulation_lai_year_start, DEF_LAI_START_YEAR)
+            end_year   = min(simulation_lai_year_end,   DEF_LAI_END_YEAR  )
             ntime      = 12
          ELSE
             start_year = lc_year
@@ -158,8 +158,8 @@ SUBROUTINE Aggregation_LAI (gridlai, dir_rawdata, dir_model_landdata, lc_year)
 #endif
       ! 8-day LAI
       ELSE
-         start_year = simulation_lai_year_start
-         end_year   = simulation_lai_year_end
+         start_year = max(simulation_lai_year_start, DEF_LAI_START_YEAR)
+         end_year   = min(simulation_lai_year_end,   DEF_LAI_END_YEAR  )
          ntime      = 46
       ENDIF
 
@@ -392,8 +392,8 @@ SUBROUTINE Aggregation_LAI (gridlai, dir_rawdata, dir_model_landdata, lc_year)
          ntime      = 12
 #else
       IF (DEF_LAI_CHANGE_YEARLY) THEN
-         start_year = simulation_lai_year_start
-         end_year   = simulation_lai_year_end
+         start_year = max(simulation_lai_year_start, DEF_LAI_START_YEAR)
+         end_year   = min(simulation_lai_year_end,   DEF_LAI_END_YEAR  )
          ntime      = 12
       ELSE
          start_year = lc_year

--- a/mksrfdata/Aggregation_Urban.F90
+++ b/mksrfdata/Aggregation_Urban.F90
@@ -105,7 +105,7 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
 
    ! urban morphological and thermal paras of NCAR data
    ! input variables, look-up-table data
-   real(r8), allocatable, dimension(:,:)     :: hwrcan, wtrd, emroof, emwall, ncar_wt
+   real(r8), allocatable, dimension(:,:)     :: hlrbld, wtrd, emroof, emwall, ncar_wt
    real(r8), allocatable, dimension(:,:)     :: emimrd, emperd, ncar_ht
    real(r8), allocatable, dimension(:,:)     :: throof, thwall, tbmin, tbmax
    real(r8), allocatable, dimension(:,:,:)   :: cvroof, cvwall, cvimrd, &
@@ -121,7 +121,7 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
    real(r8), ALLOCATABLE, dimension(:)     :: area_tb
    real(r8), ALLOCATABLE, dimension(:)     :: area_hd
    real(r8), ALLOCATABLE, dimension(:)     :: area_md
-   real(r8), ALLOCATABLE, dimension(:)     :: hwr_can
+   real(r8), ALLOCATABLE, dimension(:)     :: hlr_bld
    real(r8), ALLOCATABLE, dimension(:)     :: wt_rd
    real(r8), ALLOCATABLE, dimension(:)     :: em_roof
    real(r8), ALLOCATABLE, dimension(:)     :: em_wall
@@ -761,7 +761,7 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
          ! look up table of NCAR urban properties (using look-up tables)
          landname = TRIM(dir_rawdata)//'urban/NCAR_urban_properties.nc'
 
-         CALL ncio_read_bcast_serial (landname,  "CANYON_HWR"    , hwrcan   )
+         CALL ncio_read_bcast_serial (landname,  "CANYON_HWR"    , hlrbld   )
          CALL ncio_read_bcast_serial (landname,  "WTROAD_PERV"   , wtrd     )
          CALL ncio_read_bcast_serial (landname,  "EM_ROOF"       , emroof   )
          CALL ncio_read_bcast_serial (landname,  "EM_WALL"       , emwall   )
@@ -798,7 +798,7 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
             allocate (area_tb          (numurban))
             allocate (area_hd          (numurban))
             allocate (area_md          (numurban))
-            allocate (hwr_can          (numurban))
+            allocate (hlr_bld          (numurban))
             allocate (wt_rd            (numurban))
             allocate (em_roof          (numurban))
             allocate (em_wall          (numurban))
@@ -827,7 +827,7 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
             area_tb  (:)     = 0.
             area_hd  (:)     = 0.
             area_md  (:)     = 0.
-            hwr_can  (:)     = 0.
+            hlr_bld  (:)     = 0.
             wt_rd    (:)     = 0.
             em_roof  (:)     = 0.
             em_wall  (:)     = 0.
@@ -878,7 +878,7 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
                   DO ipxl = 1, size(area_one) ! ipxstt, ipxend
 
                      urb_regidx = reg_typid_one(ipxl)
-                     hwr_can (iurban) = hwr_can (iurban) + hwrcan (urb_typidx,urb_regidx) * area_one(ipxl)
+                     hlr_bld (iurban) = hlr_bld (iurban) + hlrbld (urb_typidx,urb_regidx) * area_one(ipxl)
                      wt_rd   (iurban) = wt_rd   (iurban) + wtrd   (urb_typidx,urb_regidx) * area_one(ipxl)
                      em_roof (iurban) = em_roof (iurban) + emroof (urb_typidx,urb_regidx) * area_one(ipxl)
                      em_wall (iurban) = em_wall (iurban) + emwall (urb_typidx,urb_regidx) * area_one(ipxl)
@@ -915,7 +915,7 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
 
                   ENDDO
 
-                  hwr_can  (iurban) = hwr_can   (iurban) / sumarea
+                  hlr_bld  (iurban) = hlr_bld   (iurban) / sumarea
                   wt_rd    (iurban) = wt_rd     (iurban) / sumarea
                   em_roof  (iurban) = em_roof   (iurban) / sumarea
                   em_wall  (iurban) = em_wall   (iurban) / sumarea
@@ -988,7 +988,7 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
 
          CALL ncio_write_vector (landname, 'URBAN_PCT'     , 'urban', landurban, urb_pct, DEF_Srfdata_CompressLevel)
          CALL ncio_write_vector (landname, 'URBAN_FRAC'    , 'urban', landurban, urb_frc, DEF_Srfdata_CompressLevel)
-         CALL ncio_write_vector (landname, 'CANYON_HWR'    , 'urban', landurban, hwr_can, DEF_Srfdata_CompressLevel)
+         CALL ncio_write_vector (landname, 'BUILDING_HLR'  , 'urban', landurban, hlr_bld, DEF_Srfdata_CompressLevel)
          CALL ncio_write_vector (landname, 'WTROAD_PERV'   , 'urban', landurban, wt_rd  , DEF_Srfdata_CompressLevel)
          CALL ncio_write_vector (landname, 'EM_ROOF'       , 'urban', landurban, em_roof, DEF_Srfdata_CompressLevel)
          CALL ncio_write_vector (landname, 'EM_WALL'       , 'urban', landurban, em_wall, DEF_Srfdata_CompressLevel)
@@ -1013,9 +1013,9 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
 
 #ifdef SrfdataDiag
          typindex = (/(ityp, ityp = 1, N_URB)/)
-         landname  = trim(dir_srfdata) // '/diag/hwr.nc'
-         CALL srfdata_map_and_write (hwr_can, landurban%settyp, typindex, m_urb2diag, &
-            -1.0e36_r8, landname, 'CANYON_HWR_'//trim(cyear), compress = 0, write_mode = 'one')
+         landname  = trim(dir_srfdata) // '/diag/hlr.nc'
+         CALL srfdata_map_and_write (hlr_bld, landurban%settyp, typindex, m_urb2diag, &
+            -1.0e36_r8, landname, 'BUILDING_HLR_'//trim(cyear), compress = 0, write_mode = 'one')
 
          typindex = (/(ityp, ityp = 1, N_URB)/)
          landname  = trim(dir_srfdata) // '/diag/cv_imrd' // trim(cyear) // '.nc'
@@ -1063,14 +1063,14 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
          SITE_alb_gper  (:,:) = alb_perd(:,:,1)
 
          IF (.not. USE_SITE_urban_paras) THEN
-            SITE_hwr   (:) = hwr_can
+            SITE_hlr   (:) = hlr_bld
             SITE_fgper (:) = wt_rd
             SITE_fgimp (:) = 1 - SITE_fgper
          ENDIF
 #endif
 
 #ifdef RangeCheck
-         CALL check_vector_data ('CANYON_HWR '    , hwr_can  )
+         CALL check_vector_data ('BUILDING_HLR '  , hlr_bld  )
          CALL check_vector_data ('WTROAD_PERV '   , wt_rd    )
          CALL check_vector_data ('EM_ROOF '       , em_roof  )
          CALL check_vector_data ('EM_WALL '       , em_wall  )
@@ -1117,7 +1117,7 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
             IF ( allocated (ncar_ht  ) ) deallocate (ncar_ht   )
             IF ( allocated (ncar_wt  ) ) deallocate (ncar_wt   )
             IF ( allocated (area_urb ) ) deallocate (area_urb  )
-            IF ( allocated (hwr_can  ) ) deallocate (hwr_can   )
+            IF ( allocated (hlr_bld  ) ) deallocate (hlr_bld   )
             IF ( allocated (wt_rd    ) ) deallocate (wt_rd     )
             IF ( allocated (em_roof  ) ) deallocate (em_roof   )
             IF ( allocated (em_wall  ) ) deallocate (em_wall   )

--- a/mksrfdata/Aggregation_Urban.F90
+++ b/mksrfdata/Aggregation_Urban.F90
@@ -623,8 +623,8 @@ SUBROUTINE Aggregation_Urban (dir_rawdata, dir_srfdata, lc_year, &
       ! ******* LAI, SAI *******
 #ifndef LULCC
       IF (DEF_LAI_CHANGE_YEARLY) THEN
-         start_year = DEF_simulation_time%start_year
-         end_year   = DEF_simulation_time%end_year
+         start_year = max(DEF_LAI_START_YEAR, DEF_simulation_time%start_year)
+         end_year   = min(DEF_LAI_END_YEAR,   DEF_simulation_time%end_year  )
       ELSE
          start_year = lc_year
          end_year   = lc_year

--- a/mksrfdata/MOD_LandUrban.F90
+++ b/mksrfdata/MOD_LandUrban.F90
@@ -353,7 +353,7 @@ IF (.not. USE_SITE_urban_paras) THEN
       allocate  ( SITE_popden    (numurban) )
       allocate  ( SITE_froof     (numurban) )
       allocate  ( SITE_hroof     (numurban) )
-      allocate  ( SITE_hwr       (numurban) )
+      allocate  ( SITE_hlr       (numurban) )
       allocate  ( SITE_fgper     (numurban) )
       allocate  ( SITE_fgimp     (numurban) )
 ENDIF

--- a/mksrfdata/MOD_SingleSrfdata.F90
+++ b/mksrfdata/MOD_SingleSrfdata.F90
@@ -101,7 +101,7 @@ MODULE MOD_SingleSrfdata
    real(r8), allocatable :: SITE_hroof    (:)
    real(r8), allocatable :: SITE_fgimp    (:)
    real(r8), allocatable :: SITE_fgper    (:)
-   real(r8), allocatable :: SITE_hwr      (:)
+   real(r8), allocatable :: SITE_hlr      (:)
    real(r8), allocatable :: SITE_popden   (:)
 
    real(r8), allocatable :: SITE_em_roof  (:)
@@ -161,7 +161,7 @@ CONTAINS
          ENDIF
          SITE_lon_location = lon_in
       ENDIF
-      
+
       CALL normalize_longitude (SITE_lon_location)
 
       IF (USE_SITE_landtype) THEN
@@ -173,7 +173,7 @@ CONTAINS
 #endif
          ENDIF
       ENDIF
-         
+
       IF (SITE_landtype < 0) THEN
          write(*,*) 'Error! Please set namelist SITE_landtype first!'
          CALL CoLM_stop()
@@ -338,7 +338,7 @@ CONTAINS
          ENDIF
          SITE_lon_location = lon_in
       ENDIF
-      
+
       CALL normalize_longitude (SITE_lon_location)
 
       IF (trim(fsrfdata) /= 'null') THEN
@@ -366,7 +366,7 @@ CONTAINS
             CALL ncio_read_serial (fsrfdata, 'roof_area_fraction'         , SITE_froof     )
             CALL ncio_read_serial (fsrfdata, 'building_mean_height'       , SITE_hroof     )
             CALL ncio_read_serial (fsrfdata, 'impervious_area_fraction'   , SITE_fgimp     )
-            CALL ncio_read_serial (fsrfdata, 'canyon_height_width_ratio'  , SITE_hwr       )
+            CALL ncio_read_serial (fsrfdata, 'canyon_height_width_ratio'  , SITE_hlr       )
             CALL ncio_read_serial (fsrfdata, 'resident_population_density', SITE_popden    )
 
             SITE_fgper     = 1 - (SITE_fgimp-SITE_froof)/(1-SITE_froof-SITE_flake_urb)
@@ -386,7 +386,7 @@ CONTAINS
          CALL ncio_read_serial (fsrfdata, 'WT_ROOF'       , SITE_froof      )
          CALL ncio_read_serial (fsrfdata, 'HT_ROOF'       , SITE_hroof      )
          CALL ncio_read_serial (fsrfdata, 'WTROAD_PERV'   , SITE_fgper      )
-         CALL ncio_read_serial (fsrfdata, 'CANYON_HWR'    , SITE_hwr        )
+         CALL ncio_read_serial (fsrfdata, 'BUILDING_HLR'  , SITE_hlr        )
          CALL ncio_read_serial (fsrfdata, 'POP_DEN'       , SITE_popden     )
 
          CALL ncio_read_serial (fsrfdata, 'EM_ROOF'       , SITE_em_roof    )
@@ -645,7 +645,7 @@ CONTAINS
       CALL ncio_put_attr     (fsrfdata, 'elvstd', 'source', datasource(USE_SITE_topostd))
 
       ! used for downscaling
-      IF (DEF_USE_Forcing_Downscaling) THEN   
+      IF (DEF_USE_Forcing_Downscaling) THEN
          CALL ncio_write_serial (fsrfdata, 'SITE_svf', SITE_svf)
          CALL ncio_write_serial (fsrfdata, 'SITE_cur', SITE_cur)
          CALL ncio_write_serial (fsrfdata, 'SITE_sf_lut'   , SITE_sf_lut, 'azi', 'zen')
@@ -713,7 +713,7 @@ CONTAINS
       CALL ncio_write_serial (fsrfdata, 'WT_ROOF'       , SITE_froof      , 'patch')
       CALL ncio_write_serial (fsrfdata, 'HT_ROOF'       , SITE_hroof      , 'patch')
       CALL ncio_write_serial (fsrfdata, 'WTROAD_PERV'   , SITE_fgper      , 'patch')
-      CALL ncio_write_serial (fsrfdata, 'CANYON_HWR'    , SITE_hwr        , 'patch')
+      CALL ncio_write_serial (fsrfdata, 'BUILDING_HLR'  , SITE_hlr        , 'patch')
       CALL ncio_write_serial (fsrfdata, 'POP_DEN'       , SITE_popden     , 'patch')
 
       CALL ncio_put_attr     (fsrfdata, 'PCT_Tree'      , 'source', source)
@@ -722,7 +722,7 @@ CONTAINS
       CALL ncio_put_attr     (fsrfdata, 'WT_ROOF'       , 'source', source)
       CALL ncio_put_attr     (fsrfdata, 'HT_ROOF'       , 'source', source)
       CALL ncio_put_attr     (fsrfdata, 'WTROAD_PERV'   , 'source', source)
-      CALL ncio_put_attr     (fsrfdata, 'CANYON_HWR'    , 'source', source)
+      CALL ncio_put_attr     (fsrfdata, 'BUILDING_HLR'  , 'source', source)
       CALL ncio_put_attr     (fsrfdata, 'POP_DEN'       , 'source', source)
 
       source = datasource(USE_SITE_thermal_paras)
@@ -850,7 +850,7 @@ CONTAINS
       ENDIF
 
       ! used for downscaling
-      IF (DEF_USE_Forcing_Downscaling) THEN   
+      IF (DEF_USE_Forcing_Downscaling) THEN
          CALL ncio_write_serial (fsrfdata, 'SITE_svf', SITE_svf)
          CALL ncio_write_serial (fsrfdata, 'SITE_cur', SITE_cur)
          CALL ncio_write_serial (fsrfdata, 'SITE_sf_lut', SITE_sf_lut, 'azi', 'zen')
@@ -929,7 +929,7 @@ CONTAINS
 #endif
       IF (allocated(SITE_soil_BA_alpha         )) deallocate(SITE_soil_BA_alpha         )
       IF (allocated(SITE_soil_BA_beta          )) deallocate(SITE_soil_BA_beta          )
-      
+
       IF (allocated(SITE_sf_lut                )) deallocate(SITE_sf_lut                )
       IF (allocated(SITE_slp_type              )) deallocate(SITE_slp_type              )
       IF (allocated(SITE_asp_type              )) deallocate(SITE_asp_type              )

--- a/run/forcing/CLDAS.nml
+++ b/run/forcing/CLDAS.nml
@@ -1,38 +1,38 @@
 &nl_colm_forcing
 
    ! ----- forcing -----
-   DEF_dir_forcing  = '/tera06/zhwei/CoLM_Forcing/CLDAS/'
+   DEF_dir_forcing  = '/shr03/CoLM_Forcing/CLDAS/'
 
-   DEF_forcing%dataset           = 'CLDAS' 
-   DEF_forcing%solarin_all_band  = .true.  
-   DEF_forcing%HEIGHT_V          = 50.0    
-   DEF_forcing%HEIGHT_T          = 40.
-   DEF_forcing%HEIGHT_Q          = 40.
+   DEF_forcing%dataset            = 'CLDAS'
+   DEF_forcing%solarin_all_band   = .true.
+   DEF_forcing%HEIGHT_V           = 50.0
+   DEF_forcing%HEIGHT_T           = 40.
+   DEF_forcing%HEIGHT_Q           = 40.
 
-   DEF_forcing%regional          = .true.
-   DEF_forcing%regbnd            = 0.0 65.0 60.0 160.0
-   DEF_forcing%has_missing_value = .true.
-   DEF_forcing%missing_value_name            = 'missing_value'
-   
-   DEF_forcing%NVAR              = 8        ! variable number of forcing data
-   DEF_forcing%startyr           = 2008     ! start year of forcing data  
-   DEF_forcing%startmo           = 1        ! start month of forcing data
-   DEF_forcing%endyr             = 2020     ! end year of forcing data
-   DEF_forcing%endmo             = 12       ! end month of forcing data
-   DEF_forcing%dtime             = 3600 3600 3600 3600 3600 3600 3600 3600
-   DEF_forcing%offset            = 0 0 0 0 0 0 0 0
-   DEF_forcing%nlands            = 1        ! land grid number in 1d
-   
-   DEF_forcing%leapyear          = .true.   ! leapyear calendar
-   DEF_forcing%data2d            = .true.   ! data in 2 dimension (lon, lat)
-   DEF_forcing%hightdim          = .false.  ! have "z" dimension
-   DEF_forcing%dim2d             = .false.  ! lat/lon value in 2 dimension (lon, lat)
-   
-   DEF_forcing%latname           = 'LAT'  ! dimension name of latitude
-   DEF_forcing%lonname           = 'LON' ! dimension name of longitude
-   
-   DEF_forcing%groupby           = 'month'  ! file grouped by year/month
-   
+   DEF_forcing%regional           = .true.
+   DEF_forcing%regbnd             = 0.0 65.0 60.0 160.0
+   DEF_forcing%has_missing_value  = .true.
+   DEF_forcing%missing_value_name = 'missing_value'
+
+   DEF_forcing%NVAR               = 8       ! variable number of forcing data
+   DEF_forcing%startyr            = 2008    ! start year of forcing data
+   DEF_forcing%startmo            = 1       ! start month of forcing data
+   DEF_forcing%endyr              = 2020    ! end year of forcing data
+   DEF_forcing%endmo              = 12      ! end month of forcing data
+   DEF_forcing%dtime              = 3600 3600 3600 3600 3600 3600 3600 3600
+   DEF_forcing%offset             = 0 0 0 0 0 0 0 0
+   DEF_forcing%nlands             = 1       ! land grid number in 1d
+
+   DEF_forcing%leapyear           = .true.  ! leapyear calendar
+   DEF_forcing%data2d             = .true.  ! data in 2 dimension (lon, lat)
+   DEF_forcing%hightdim           = .false. ! have "z" dimension
+   DEF_forcing%dim2d              = .false. ! lat/lon value in 2 dimension (lon, lat)
+
+   DEF_forcing%latname            = 'LAT'   ! dimension name of latitude
+   DEF_forcing%lonname            = 'LON'   ! dimension name of longitude
+
+   DEF_forcing%groupby            = 'month' ! file grouped by year/month
+
    DEF_forcing%fprefix(1) = 'TMP/CLDAS_NRT_ASI_0P0625_HOR-TMP-'
    DEF_forcing%fprefix(2) = 'SHU/CLDAS_NRT_ASI_0P0625_HOR-SHU-'
    DEF_forcing%fprefix(3) = 'PRS/CLDAS_NRT_ASI_0P0625_HOR-PRS-'
@@ -42,8 +42,9 @@
    DEF_forcing%fprefix(7) = 'SSRA/CLDAS_NRT_ASI_0P0625_HOR-SSRA-'
    DEF_forcing%fprefix(8) = 'tstr/CLDAS_NRT_ASI_0P0625_HOR-tstr-'
 
-   
-   DEF_forcing%vname    = 'TAIR' 'QAIR' 'PAIR' 'PRCP' 'NULL' 'WIND' 'SWDN' 'tstr' 
+
+   DEF_forcing%vname    = 'TAIR' 'QAIR' 'PAIR' 'PRCP' 'NULL' 'WIND' 'SWDN' 'tstr'
+   DEF_forcing%timelog  = 'instant' 'instant' 'instant' 'foreward' 'instant' 'instant' 'foreward' 'foreward'
    DEF_forcing%tintalgo = 'linear' 'linear' 'linear' 'nearest' 'NULL' 'linear' 'coszen' 'linear'
 
 /

--- a/run/forcing/CMFD.nml
+++ b/run/forcing/CMFD.nml
@@ -1,39 +1,39 @@
 &nl_colm_forcing
-   
+
   ! ----- forcing -----
-   DEF_dir_forcing  = '/tera06/zhwei/CoLM_Forcing/CMFD/' 
+   DEF_dir_forcing  = '/shr03/CoLM_Forcing/CMFD/'
 
-   DEF_forcing%dataset           = 'CMFD' 
-   DEF_forcing%solarin_all_band  = .true.  
-   DEF_forcing%HEIGHT_V          = 50.0    
-   DEF_forcing%HEIGHT_T          = 40.0
-   DEF_forcing%HEIGHT_Q          = 40.0
+   DEF_forcing%dataset            = 'CMFD'
+   DEF_forcing%solarin_all_band   = .true.
+   DEF_forcing%HEIGHT_V           = 50.0
+   DEF_forcing%HEIGHT_T           = 40.0
+   DEF_forcing%HEIGHT_Q           = 40.0
 
-   DEF_forcing%regional          = .true.
-   DEF_forcing%regbnd            = 15.0 55.0 70.0 140.0
-   DEF_forcing%has_missing_value = .true.
-   DEF_forcing%missing_value_name= 'missing_value'
+   DEF_forcing%regional           = .true.
+   DEF_forcing%regbnd             = 15.0 55.0 70.0 140.0
+   DEF_forcing%has_missing_value  = .true.
+   DEF_forcing%missing_value_name = 'missing_value'
 
-  
-   DEF_forcing%NVAR              = 8        ! variable number of forcing data
-   DEF_forcing%startyr           = 1979     ! start year of forcing data  
-   DEF_forcing%startmo           = 1        ! start month of forcing data
-   DEF_forcing%endyr             = 2018     ! end year of forcing data
-   DEF_forcing%endmo             = 12       ! end month of forcing data
-   DEF_forcing%dtime             = 10800 10800 10800 10800 0 10800 10800 10800
-   DEF_forcing%offset            = 5400 5400 5400 5400 0 5400 0 5400
-   DEF_forcing%nlands            = 1        ! land grid number in 1d
-   
-   DEF_forcing%leapyear          = .true.   ! leapyear calendar
-   DEF_forcing%data2d            = .true.   ! data in 2 dimension (lon, lat)
-   DEF_forcing%hightdim          = .false.  ! have "z" dimension
-   DEF_forcing%dim2d             = .false.  ! lat/lon value in 2 dimension (lon, lat)
-   
-   DEF_forcing%latname           = 'lat'  ! dimension name of latitude
-   DEF_forcing%lonname           = 'lon' ! dimension name of longitude
-  
-   DEF_forcing%groupby           = 'month'  ! file grouped by year/month
-  
+
+   DEF_forcing%NVAR               = 8       ! variable number of forcing data
+   DEF_forcing%startyr            = 1979    ! start year of forcing data
+   DEF_forcing%startmo            = 1       ! start month of forcing data
+   DEF_forcing%endyr              = 2018    ! end year of forcing data
+   DEF_forcing%endmo              = 12      ! end month of forcing data
+   DEF_forcing%dtime              = 10800 10800 10800 10800 0 10800 10800 10800
+   DEF_forcing%offset             = 5400 5400 5400 5400 0 5400 0 5400
+   DEF_forcing%nlands             = 1       ! land grid number in 1d
+
+   DEF_forcing%leapyear           = .true.  ! leapyear calendar
+   DEF_forcing%data2d             = .true.  ! data in 2 dimension (lon, lat)
+   DEF_forcing%hightdim           = .false. ! have "z" dimension
+   DEF_forcing%dim2d              = .false. ! lat/lon value in 2 dimension (lon, lat)
+
+   DEF_forcing%latname            = 'lat'   ! dimension name of latitude
+   DEF_forcing%lonname            = 'lon'   ! dimension name of longitude
+
+   DEF_forcing%groupby            = 'month' ! file grouped by year/month
+
    DEF_forcing%fprefix(1) = 'temp/temp_CMFD_V0106_B-01_03hr_010deg_'
    DEF_forcing%fprefix(2) = 'shum/shum_CMFD_V0106_B-01_03hr_010deg_'
    DEF_forcing%fprefix(3) = 'pres/pres_CMFD_V0106_B-01_03hr_010deg_'
@@ -43,8 +43,9 @@
    DEF_forcing%fprefix(7) = 'srad/srad_CMFD_V0106_B-01_03hr_010deg_'
    DEF_forcing%fprefix(8) = 'lrad/lrad_CMFD_V0106_B-01_03hr_010deg_'
 
-   
-   DEF_forcing%vname    = 'temp' 'shum' 'pres' 'prec' 'NULL' 'wind' 'srad' 'lrad' 
+
+   DEF_forcing%vname    = 'temp' 'shum' 'pres' 'prec' 'NULL' 'wind' 'srad' 'lrad'
+   DEF_forcing%timelog  = 'instant' 'instant' 'instant' 'foreward' 'instant' 'instant' 'foreward' 'foreward'
    DEF_forcing%tintalgo = 'linear' 'linear' 'linear' 'nearest' 'NULL' 'linear' 'coszen' 'linear'
 
 /

--- a/run/forcing/CRA40.nml
+++ b/run/forcing/CRA40.nml
@@ -1,35 +1,35 @@
 &nl_colm_forcing
-   
+
    ! ----- forcing -----
    DEF_dir_forcing  ='/share/home/dq013/zhwei/colm/data/CoLM_Forcing/CRA40/'
 
-   DEF_forcing%dataset           = 'CRA40' 
-   DEF_forcing%solarin_all_band  = .true.  
-   DEF_forcing%HEIGHT_V          = 50.0    
-   DEF_forcing%HEIGHT_T          = 40.
-   DEF_forcing%HEIGHT_Q           = 40.
+   DEF_forcing%dataset             = 'CRA40'
+   DEF_forcing%solarin_all_band    = .true.
+   DEF_forcing%HEIGHT_V            = 50.0
+   DEF_forcing%HEIGHT_T            = 40.
+   DEF_forcing%HEIGHT_Q            = 40.
    !DEF_forcing%has_missing_value  = .true.
    !DEF_forcing%missing_value_name = 'missing_value'
 
-   DEF_forcing%NVAR              = 8        ! variable number of forcing data
-   DEF_forcing%startyr           = 1950     ! start year of forcing data  
-   DEF_forcing%startmo           = 1        ! start month of forcing data
-   DEF_forcing%endyr             = 2021     ! end year of forcing data
-   DEF_forcing%endmo             = 12       ! end month of forcing data
-   DEF_forcing%dtime             = 21600 21600 21600 21600 21600 21600 21600 21600
-   DEF_forcing%offset            = 10800 10800 10800 10800 10800 10800 0 10800
-   DEF_forcing%nlands            = 1        ! land grid number in 1d
-   
-   DEF_forcing%leapyear          = .true.   ! leapyear calendar
-   DEF_forcing%data2d            = .true.   ! data in 2 dimension (lon, lat)
-   DEF_forcing%hightdim          = .false.  ! have "z" dimension
-   DEF_forcing%dim2d             = .false.  ! lat/lon value in 2 dimension (lon, lat)
-   
-   DEF_forcing%latname           = 'g0_lat_0'  ! dimension name of latitude
-   DEF_forcing%lonname           = 'g0_lon_1' ! dimension name of longitude
-   
-   DEF_forcing%groupby           = 'year'  ! file grouped by year/month
-   
+   DEF_forcing%NVAR                = 8          ! variable number of forcing data
+   DEF_forcing%startyr             = 1950       ! start year of forcing data
+   DEF_forcing%startmo             = 1          ! start month of forcing data
+   DEF_forcing%endyr               = 2021       ! end year of forcing data
+   DEF_forcing%endmo               = 12         ! end month of forcing data
+   DEF_forcing%dtime               = 21600 21600 21600 21600 21600 21600 21600 21600
+   DEF_forcing%offset              = 10800 10800 10800 10800 10800 10800 0 10800
+   DEF_forcing%nlands              = 1          ! land grid number in 1d
+
+   DEF_forcing%leapyear            = .true.     ! leapyear calendar
+   DEF_forcing%data2d              = .true.     ! data in 2 dimension (lon, lat)
+   DEF_forcing%hightdim            = .false.    ! have "z" dimension
+   DEF_forcing%dim2d               = .false.    ! lat/lon value in 2 dimension (lon, lat)
+
+   DEF_forcing%latname             = 'g0_lat_0' ! dimension name of latitude
+   DEF_forcing%lonname             = 'g0_lon_1' ! dimension name of longitude
+
+   DEF_forcing%groupby             = 'year'     ! file grouped by year/month
+
 
 
    DEF_forcing%fprefix(1) = 'CRA40_sp_t_u_v'
@@ -43,6 +43,7 @@
 
 
    DEF_forcing%vname    = 'TMP_GDS0_HTGL' 'SPF_H_GDS0_HTGL' 'PRES_P0_L1_GLL0' 'PRATE_P8_L1_GLL0_avg' 'U_GRD_GDS0_HTGL' 'V_GRD_GDS0_HTGL' 'DSWRF_P8_L1_GLL0_avg' 'DLWRF_P8_L1_GLL0_avg'
+   DEF_forcing%timelog  = 'instant' 'instant' 'instant' 'foreward' 'instant' 'instant' 'foreward' 'foreward'
    DEF_forcing%tintalgo = 'linear' 'linear' 'linear' 'nearest' 'NULL' 'linear' 'coszen' 'linear'
 
 

--- a/run/forcing/CRUJRA.nml
+++ b/run/forcing/CRUJRA.nml
@@ -1,36 +1,36 @@
 &nl_colm_forcing
-   
+
   ! ----- forcing -----
-   DEF_dir_forcing  = '/tera06/zhwei/CoLM_Forcing/crujra/' 
+   DEF_dir_forcing  = '/shr03/CoLM_Forcing/crujra/'
 
-   DEF_forcing%dataset           = 'CRUJRA' 
-   DEF_forcing%solarin_all_band  = .true.  
-   DEF_forcing%HEIGHT_V          = 50.0  
-   DEF_forcing%HEIGHT_T          = 40.
-   DEF_forcing%HEIGHT_Q          = 40.
+   DEF_forcing%dataset            = 'CRUJRA'
+   DEF_forcing%solarin_all_band   = .true.
+   DEF_forcing%HEIGHT_V           = 50.0
+   DEF_forcing%HEIGHT_T           = 40.
+   DEF_forcing%HEIGHT_Q           = 40.
 
-   DEF_forcing%has_missing_value = .true.
+   DEF_forcing%has_missing_value  = .true.
    DEF_forcing%missing_value_name = 'missing_value'
-   
-   DEF_forcing%NVAR              = 8        ! variable number of forcing data
-   DEF_forcing%startyr           = 1901     ! start year of forcing data  
-   DEF_forcing%startmo           = 1        ! start month of forcing data
-   DEF_forcing%endyr             = 2022     ! end year of forcing data
-   DEF_forcing%endmo             = 12      ! end month of forcing data
-   DEF_forcing%dtime             = 21600 21600 21600 21600 21600 21600 21600 21600
-   DEF_forcing%offset            = 10800 10800 10800 10800 10800 10800 0 10800
-   DEF_forcing%nlands            = 1        ! land grid number in 1d
-   
-   DEF_forcing%leapyear          = .false.   ! leapyear calendar
-   DEF_forcing%data2d            = .true.   ! data in 2 dimension (lon, lat)
-   DEF_forcing%hightdim          = .false.  ! have "z" dimension
-   DEF_forcing%dim2d             = .false.  ! lat/lon value in 2 dimension (lon, lat)
-   
-   DEF_forcing%latname           = 'lat'  ! dimension name of latitude
-   DEF_forcing%lonname           = 'lon' ! dimension name of longitude
-   
-   DEF_forcing%groupby           = 'year'  ! file grouped by year/month
-   
+
+   DEF_forcing%NVAR               = 8       ! variable number of forcing data
+   DEF_forcing%startyr            = 1901    ! start year of forcing data
+   DEF_forcing%startmo            = 1       ! start month of forcing data
+   DEF_forcing%endyr              = 2022    ! end year of forcing data
+   DEF_forcing%endmo              = 12      ! end month of forcing data
+   DEF_forcing%dtime              = 21600 21600 21600 21600 21600 21600 21600 21600
+   DEF_forcing%offset             = 10800 10800 10800 10800 10800 10800 0 10800
+   DEF_forcing%nlands             = 1       ! land grid number in 1d
+
+   DEF_forcing%leapyear           = .false. ! leapyear calendar
+   DEF_forcing%data2d             = .true.  ! data in 2 dimension (lon, lat)
+   DEF_forcing%hightdim           = .false. ! have "z" dimension
+   DEF_forcing%dim2d              = .false. ! lat/lon value in 2 dimension (lon, lat)
+
+   DEF_forcing%latname            = 'lat'   ! dimension name of latitude
+   DEF_forcing%lonname            = 'lon'   ! dimension name of longitude
+
+   DEF_forcing%groupby            = 'year'  ! file grouped by year/month
+
    DEF_forcing%fprefix(1) = 'tmp/crujra.v2.4.5d.tmp.'
    DEF_forcing%fprefix(2) = 'spfh/crujra.v2.4.5d.spfh.'
    DEF_forcing%fprefix(3) = 'pres/crujra.v2.4.5d.pres.'
@@ -40,8 +40,9 @@
    DEF_forcing%fprefix(7) = 'dswrf/crujra.v2.4.5d.dswrf.'
    DEF_forcing%fprefix(8) = 'dlwrf/crujra.v2.4.5d.dlwrf.'
 
-   
-   DEF_forcing%vname    = 'tmp' 'spfh' 'pres' 'pre' 'ugrd' 'vgrd' 'dswrf' 'dlwrf' 
+
+   DEF_forcing%vname    = 'tmp' 'spfh' 'pres' 'pre' 'ugrd' 'vgrd' 'dswrf' 'dlwrf'
+   DEF_forcing%timelog  = 'instant' 'instant' 'instant' 'foreward' 'instant' 'instant' 'foreward' 'foreward'
    DEF_forcing%tintalgo = 'linear' 'linear' 'linear' 'nearest' 'linear' 'linear' 'coszen' 'linear'
 
 /

--- a/run/forcing/CRUNCEPV4.nml
+++ b/run/forcing/CRUNCEPV4.nml
@@ -1,33 +1,33 @@
 &nl_colm_forcing
-   
-  ! ----- forcing -----
-   DEF_dir_forcing  = '/tera06/zhwei/CoLM_Forcing/cruncep_v4/cruncep/' 
 
-   DEF_forcing%dataset           = 'CRUNCEPV4' 
-   DEF_forcing%solarin_all_band  = .true.  
-   DEF_forcing%HEIGHT_V          = 50.0    
+  ! ----- forcing -----
+   DEF_dir_forcing  = '/shr03/CoLM_Forcing/cruncep_v4/cruncep/'
+
+   DEF_forcing%dataset           = 'CRUNCEPV4'
+   DEF_forcing%solarin_all_band  = .true.
+   DEF_forcing%HEIGHT_V          = 50.0
    DEF_forcing%HEIGHT_T          = 40.
    DEF_forcing%HEIGHT_Q          = 40.
-   
+
    DEF_forcing%NVAR              = 8        ! variable number of forcing data
-   DEF_forcing%startyr           = 1950     ! start year of forcing data  
+   DEF_forcing%startyr           = 1950     ! start year of forcing data
    DEF_forcing%startmo           = 1        ! start month of forcing data
    DEF_forcing%endyr             = 2016     ! end year of forcing data
    DEF_forcing%endmo             = 12       ! end month of forcing data
    DEF_forcing%dtime             = 21600 21600 21600 21600 0 21600 21600 21600
    DEF_forcing%offset            = 10800 10800 10800 10800 10800 10800 0 10800
    DEF_forcing%nlands            = 1        ! land grid number in 1d
-   
-   DEF_forcing%leapyear          = .false.   ! leapyear calendar
+
+   DEF_forcing%leapyear          = .false.  ! leapyear calendar
    DEF_forcing%data2d            = .true.   ! data in 2 dimension (lon, lat)
    DEF_forcing%hightdim          = .false.  ! have "z" dimension
-   DEF_forcing%dim2d             = .true.  ! lat/lon value in 2 dimension (lon, lat)
-   
-   DEF_forcing%latname           = 'LATIXY'  ! dimension name of latitude
+   DEF_forcing%dim2d             = .true.   ! lat/lon value in 2 dimension (lon, lat)
+
+   DEF_forcing%latname           = 'LATIXY' ! dimension name of latitude
    DEF_forcing%lonname           = 'LONGXY' ! dimension name of longitude
-   
+
    DEF_forcing%groupby           = 'month'  ! file grouped by year/month
-   
+
    DEF_forcing%fprefix(1) = 'TPHWL6Hrly/clmforc.cruncep.V4.c2011.0.5d.TPQWL.'
    DEF_forcing%fprefix(2) = 'TPHWL6Hrly/clmforc.cruncep.V4.c2011.0.5d.TPQWL.'
    DEF_forcing%fprefix(3) = 'TPHWL6Hrly/clmforc.cruncep.V4.c2011.0.5d.TPQWL.'
@@ -37,8 +37,9 @@
    DEF_forcing%fprefix(7) = 'Solar6Hrly/clmforc.cruncep.V4.c2011.0.5d.Solr.'
    DEF_forcing%fprefix(8) = 'TPHWL6Hrly/clmforc.cruncep.V4.c2011.0.5d.TPQWL.'
 
-   
-   DEF_forcing%vname    = 'TBOT' 'QBOT' 'PSRF' 'PRECTmms' 'NULL' 'WIND' 'FSDS' 'FLDS' 
+
+   DEF_forcing%vname    = 'TBOT' 'QBOT' 'PSRF' 'PRECTmms' 'NULL' 'WIND' 'FSDS' 'FLDS'
+   DEF_forcing%timelog  = 'instant' 'instant' 'instant' 'foreward' 'instant' 'instant' 'foreward' 'foreward'
    DEF_forcing%tintalgo = 'linear' 'linear' 'linear' 'nearest' 'NULL' 'linear' 'coszen' 'linear'
 
 /

--- a/run/forcing/CRUNCEPV7.nml
+++ b/run/forcing/CRUNCEPV7.nml
@@ -1,33 +1,33 @@
 &nl_colm_forcing
-   
-  ! ----- forcing -----
-   DEF_dir_forcing  ='/tera06/zhwei/CoLM_Forcing/cruncep_v7/' 
 
-   DEF_forcing%dataset           = 'CRUNCEPV7' 
-   DEF_forcing%solarin_all_band  = .true.  
-   DEF_forcing%HEIGHT_V          = 50.0    
+  ! ----- forcing -----
+   DEF_dir_forcing  ='/shr03/CoLM_Forcing/cruncep_v7/'
+
+   DEF_forcing%dataset           = 'CRUNCEPV7'
+   DEF_forcing%solarin_all_band  = .true.
+   DEF_forcing%HEIGHT_V          = 50.0
    DEF_forcing%HEIGHT_T          = 40.
    DEF_forcing%HEIGHT_Q          = 40.
-   
+
    DEF_forcing%NVAR              = 8        ! variable number of forcing data
-   DEF_forcing%startyr           = 1950     ! start year of forcing data  
+   DEF_forcing%startyr           = 1950     ! start year of forcing data
    DEF_forcing%startmo           = 1        ! start month of forcing data
    DEF_forcing%endyr             = 2016     ! end year of forcing data
    DEF_forcing%endmo             = 12       ! end month of forcing data
    DEF_forcing%dtime             = 21600 21600 21600 21600 0 21600 21600 21600
    DEF_forcing%offset            = 10800 10800 10800 10800 10800 10800 0 10800
    DEF_forcing%nlands            = 1        ! land grid number in 1d
-   
-   DEF_forcing%leapyear          = .false.   ! leapyear calendar
+
+   DEF_forcing%leapyear          = .false.  ! leapyear calendar
    DEF_forcing%data2d            = .true.   ! data in 2 dimension (lon, lat)
    DEF_forcing%hightdim          = .false.  ! have "z" dimension
-   DEF_forcing%dim2d             = .true.  ! lat/lon value in 2 dimension (lon, lat)
-   
-   DEF_forcing%latname           = 'LATIXY'  ! dimension name of latitude
+   DEF_forcing%dim2d             = .true.   ! lat/lon value in 2 dimension (lon, lat)
+
+   DEF_forcing%latname           = 'LATIXY' ! dimension name of latitude
    DEF_forcing%lonname           = 'LONGXY' ! dimension name of longitude
-   
+
    DEF_forcing%groupby           = 'month'  ! file grouped by year/month
-   
+
    DEF_forcing%fprefix(1) = 'TPHWL6Hrly/clmforc.cruncep.V7.c2016.0.5d.TPQWL.'
    DEF_forcing%fprefix(2) = 'TPHWL6Hrly/clmforc.cruncep.V7.c2016.0.5d.TPQWL.'
    DEF_forcing%fprefix(3) = 'TPHWL6Hrly/clmforc.cruncep.V7.c2016.0.5d.TPQWL.'
@@ -37,8 +37,9 @@
    DEF_forcing%fprefix(7) = 'Solar6Hrly/clmforc.cruncep.V7.c2016.0.5d.Solr.'
    DEF_forcing%fprefix(8) = 'TPHWL6Hrly/clmforc.cruncep.V7.c2016.0.5d.TPQWL.'
 
-   
-   DEF_forcing%vname    = 'TBOT' 'QBOT' 'PSRF' 'PRECTmms' 'NULL' 'WIND' 'FSDS' 'FLDS' 
+
+   DEF_forcing%vname    = 'TBOT' 'QBOT' 'PSRF' 'PRECTmms' 'NULL' 'WIND' 'FSDS' 'FLDS'
+   DEF_forcing%timelog  = 'instant' 'instant' 'instant' 'foreward' 'instant' 'instant' 'foreward' 'foreward'
    DEF_forcing%tintalgo = 'linear' 'linear' 'linear' 'nearest' 'NULL' 'linear' 'coszen' 'linear'
 
 /

--- a/run/forcing/ERA5.nml
+++ b/run/forcing/ERA5.nml
@@ -1,7 +1,7 @@
 &nl_colm_forcing
 
   ! ----- forcing -----
-   DEF_dir_forcing  = '/tera06/zhwei/CoLM_Forcing/ERA5/'
+   DEF_dir_forcing  = '/shr03/CoLM_Forcing/ERA5/'
 
    DEF_forcing%dataset           = 'ERA5'
    DEF_forcing%solarin_all_band  = .true.
@@ -9,24 +9,24 @@
    DEF_forcing%HEIGHT_T          = 40.0
    DEF_forcing%HEIGHT_Q          = 40.0
 
-   DEF_forcing%NVAR              = 8        ! variable number of forcing data
-   DEF_forcing%startyr           = 1979     ! start year of forcing data
-   DEF_forcing%startmo           = 1        ! start month of forcing data
-   DEF_forcing%endyr             = 2021     ! end year of forcing data
-   DEF_forcing%endmo             = 12       ! end month of forcing data
+   DEF_forcing%NVAR              = 8           ! variable number of forcing data
+   DEF_forcing%startyr           = 1979        ! start year of forcing data
+   DEF_forcing%startmo           = 1           ! start month of forcing data
+   DEF_forcing%endyr             = 2021        ! end year of forcing data
+   DEF_forcing%endmo             = 12          ! end month of forcing data
    DEF_forcing%dtime             = 3600 3600 3600 3600 3600 3600 3600 3600
-   DEF_forcing%offset            = 3600 3600 3600 3600 3600 3600 3600 3600
-   DEF_forcing%nlands            = 1        ! land grid number in 1d
+   DEF_forcing%offset            = 1800 1800 1800 1800 1800 1800    0 1800
+   DEF_forcing%nlands            = 1           ! land grid number in 1d
 
-   DEF_forcing%leapyear          = .true.   ! leapyear calendar
-   DEF_forcing%data2d            = .true.   ! data in 2 dimension (lon, lat)
-   DEF_forcing%hightdim          = .false.  ! have "z" dimension
-   DEF_forcing%dim2d             = .false.  ! lat/lon value in 2 dimension (lon, lat)
+   DEF_forcing%leapyear          = .true.      ! leapyear calendar
+   DEF_forcing%data2d            = .true.      ! data in 2 dimension (lon, lat)
+   DEF_forcing%hightdim          = .false.     ! have "z" dimension
+   DEF_forcing%dim2d             = .false.     ! lat/lon value in 2 dimension (lon, lat)
 
    DEF_forcing%latname           = 'latitude'  ! dimension name of latitude
    DEF_forcing%lonname           = 'longitude' ! dimension name of longitude
 
-   DEF_forcing%groupby           = 'month'  ! file grouped by year/month
+   DEF_forcing%groupby           = 'month'     ! file grouped by year/month
 
    DEF_forcing%fprefix(1) = '2m_temperature/ERA5'
    DEF_forcing%fprefix(2) = 'Specific_Humdity/ERA5'

--- a/run/forcing/ERA5.nml
+++ b/run/forcing/ERA5.nml
@@ -1,33 +1,33 @@
 &nl_colm_forcing
-   
-  ! ----- forcing -----
-   DEF_dir_forcing  = '/tera06/zhwei/CoLM_Forcing/ERA5/' 
 
-   DEF_forcing%dataset           = 'ERA5' 
-   DEF_forcing%solarin_all_band  = .true.  
-   DEF_forcing%HEIGHT_V          = 50.0    
+  ! ----- forcing -----
+   DEF_dir_forcing  = '/tera06/zhwei/CoLM_Forcing/ERA5/'
+
+   DEF_forcing%dataset           = 'ERA5'
+   DEF_forcing%solarin_all_band  = .true.
+   DEF_forcing%HEIGHT_V          = 50.0
    DEF_forcing%HEIGHT_T          = 40.0
    DEF_forcing%HEIGHT_Q          = 40.0
-   
+
    DEF_forcing%NVAR              = 8        ! variable number of forcing data
-   DEF_forcing%startyr           = 1979     ! start year of forcing data  
+   DEF_forcing%startyr           = 1979     ! start year of forcing data
    DEF_forcing%startmo           = 1        ! start month of forcing data
    DEF_forcing%endyr             = 2021     ! end year of forcing data
    DEF_forcing%endmo             = 12       ! end month of forcing data
    DEF_forcing%dtime             = 3600 3600 3600 3600 3600 3600 3600 3600
    DEF_forcing%offset            = 3600 3600 3600 3600 3600 3600 3600 3600
    DEF_forcing%nlands            = 1        ! land grid number in 1d
-   
+
    DEF_forcing%leapyear          = .true.   ! leapyear calendar
    DEF_forcing%data2d            = .true.   ! data in 2 dimension (lon, lat)
    DEF_forcing%hightdim          = .false.  ! have "z" dimension
    DEF_forcing%dim2d             = .false.  ! lat/lon value in 2 dimension (lon, lat)
-   
+
    DEF_forcing%latname           = 'latitude'  ! dimension name of latitude
    DEF_forcing%lonname           = 'longitude' ! dimension name of longitude
-   
+
    DEF_forcing%groupby           = 'month'  ! file grouped by year/month
-   
+
    DEF_forcing%fprefix(1) = '2m_temperature/ERA5'
    DEF_forcing%fprefix(2) = 'Specific_Humdity/ERA5'
    DEF_forcing%fprefix(3) = 'surface_pressure/ERA5'
@@ -39,6 +39,7 @@
 
 
    DEF_forcing%vname    = 't2m' 'q' 'sp' 'mtpr' 'u10' 'v10' 'msdwswrf' 'msdwlwrf'
+   DEF_forcing%timelog  = 'instant' 'instant' 'instant' 'backward' 'instant' 'instant' 'backward' 'backward'
    DEF_forcing%tintalgo = 'linear' 'linear' 'linear' 'nearest' 'linear' 'linear' 'coszen' 'linear'
 
    DEF_forcing%CBL_fprefix        = 'boundary_layer_height/ERA5'

--- a/run/forcing/ERA5LAND.nml
+++ b/run/forcing/ERA5LAND.nml
@@ -1,36 +1,36 @@
 &nl_colm_forcing
 
   ! ----- forcing -----
-   DEF_dir_forcing  = '/shr03/CoLM_Forcing/ERA5LAND/' 
+   DEF_dir_forcing  = '/shr03/CoLM_Forcing/ERA5LAND/'
 
-   DEF_forcing%dataset           = 'ERA5LAND' 
-   DEF_forcing%solarin_all_band  = .true.  
-   DEF_forcing%HEIGHT_V          = 50.0    
-   DEF_forcing%HEIGHT_T          = 40.
-   DEF_forcing%HEIGHT_Q          = 40.
+   DEF_forcing%dataset            = 'ERA5LAND'
+   DEF_forcing%solarin_all_band   = .true.
+   DEF_forcing%HEIGHT_V           = 50.0
+   DEF_forcing%HEIGHT_T           = 40.
+   DEF_forcing%HEIGHT_Q           = 40.
 
-   DEF_forcing%has_missing_value = .true.
-   DEF_forcing%missing_value_name            = 'missing_value'
+   DEF_forcing%has_missing_value  = .true.
+   DEF_forcing%missing_value_name = 'missing_value'
 
-   DEF_forcing%NVAR              = 8        ! variable number of forcing data
-   DEF_forcing%startyr           = 1950     ! start year of forcing data  
-   DEF_forcing%startmo           = 1        ! start month of forcing data
-   DEF_forcing%endyr             = 2021     ! end year of forcing data
-   DEF_forcing%endmo             = 11       ! end month of forcing data
-   DEF_forcing%dtime             = 3600 3600 3600 3600 3600 3600 3600 3600
-   DEF_forcing%offset            = 1800 1800 1800 1800 1800 1800 0 1800
-   DEF_forcing%nlands            = 1        ! land grid number in 1d
+   DEF_forcing%NVAR               = 8           ! variable number of forcing data
+   DEF_forcing%startyr            = 1950        ! start year of forcing data
+   DEF_forcing%startmo            = 1           ! start month of forcing data
+   DEF_forcing%endyr              = 2021        ! end year of forcing data
+   DEF_forcing%endmo              = 11          ! end month of forcing data
+   DEF_forcing%dtime              = 3600 3600 3600 3600 3600 3600 3600 3600
+   DEF_forcing%offset             = 1800 1800 1800 1800 1800 1800 0 1800
+   DEF_forcing%nlands             = 1           ! land grid number in 1d
 
-   DEF_forcing%leapyear          = .true.   ! leapyear calendar
-   DEF_forcing%data2d            = .true.   ! data in 2 dimension (lon, lat)
-   DEF_forcing%hightdim          = .false.  ! have "z" dimension
-   DEF_forcing%dim2d             = .false.  ! lat/lon value in 2 dimension (lon, lat)
+   DEF_forcing%leapyear           = .true.      ! leapyear calendar
+   DEF_forcing%data2d             = .true.      ! data in 2 dimension (lon, lat)
+   DEF_forcing%hightdim           = .false.     ! have "z" dimension
+   DEF_forcing%dim2d              = .false.     ! lat/lon value in 2 dimension (lon, lat)
 
-   DEF_forcing%latname           = 'latitude'  ! dimension name of latitude
-   DEF_forcing%lonname           = 'longitude' ! dimension name of longitude
+   DEF_forcing%latname            = 'latitude'  ! dimension name of latitude
+   DEF_forcing%lonname            = 'longitude' ! dimension name of longitude
 
-   DEF_forcing%groupby           = 'month'  ! file grouped by year/month
- 
+   DEF_forcing%groupby            = 'month'     ! file grouped by year/month
+
    DEF_forcing%fprefix(1) = '2m_temperature/ERA5LAND'
    DEF_forcing%fprefix(2) = 'specific_humidity/ERA5LAND'
    DEF_forcing%fprefix(3) = 'surface_pressure/ERA5LAND'
@@ -40,7 +40,8 @@
    DEF_forcing%fprefix(7) = 'surface_solar_radiation_downwards_w_m2/ERA5LAND'
    DEF_forcing%fprefix(8) = 'surface_thermal_radiation_downwards_w_m2/ERA5LAND'
 
-   DEF_forcing%vname    = 't2m' 'Q' 'sp' 'tp' 'u10' 'v10' 'ssrd' 'strd' 
+   DEF_forcing%vname    = 't2m' 'Q' 'sp' 'tp' 'u10' 'v10' 'ssrd' 'strd'
+   DEF_forcing%timelog  = 'instant' 'instant' 'instant' 'foreward' 'instant' 'instant' 'foreward' 'foreward'
    DEF_forcing%tintalgo = 'linear' 'linear' 'linear' 'nearest' 'linear' 'linear' 'coszen' 'linear'
 
 /

--- a/run/forcing/ERA5_LEddy.nml
+++ b/run/forcing/ERA5_LEddy.nml
@@ -1,33 +1,33 @@
 &nl_colm_forcing
-   
-  ! ----- forcing -----
-   DEF_dir_forcing  = '/tera06/zhwei/CoLM_Forcing/ERA5/' 
 
-   DEF_forcing%dataset           = 'ERA5' 
-   DEF_forcing%solarin_all_band  = .true.  
-   DEF_forcing%HEIGHT_V          = 50.0    
+  ! ----- forcing -----
+   DEF_dir_forcing  = '/shr03/CoLM_Forcing/ERA5/'
+
+   DEF_forcing%dataset           = 'ERA5'
+   DEF_forcing%solarin_all_band  = .true.
+   DEF_forcing%HEIGHT_V          = 50.0
    DEF_forcing%HEIGHT_T          = 40.0
    DEF_forcing%HEIGHT_Q          = 40.0
-   
-   DEF_forcing%NVAR              = 8        ! variable number of forcing data
-   DEF_forcing%startyr           = 1979     ! start year of forcing data  
-   DEF_forcing%startmo           = 1        ! start month of forcing data
-   DEF_forcing%endyr             = 2021     ! end year of forcing data
-   DEF_forcing%endmo             = 12       ! end month of forcing data
+
+   DEF_forcing%NVAR              = 8           ! variable number of forcing data
+   DEF_forcing%startyr           = 1979        ! start year of forcing data
+   DEF_forcing%startmo           = 1           ! start month of forcing data
+   DEF_forcing%endyr             = 2021        ! end year of forcing data
+   DEF_forcing%endmo             = 12          ! end month of forcing data
    DEF_forcing%dtime             = 3600 3600 3600 3600 3600 3600 3600 3600
    DEF_forcing%offset            = 3600 3600 3600 3600 3600 3600 3600 3600
-   DEF_forcing%nlands            = 1        ! land grid number in 1d
-   
-   DEF_forcing%leapyear          = .true.   ! leapyear calendar
-   DEF_forcing%data2d            = .true.   ! data in 2 dimension (lon, lat)
-   DEF_forcing%hightdim          = .false.  ! have "z" dimension
-   DEF_forcing%dim2d             = .false.  ! lat/lon value in 2 dimension (lon, lat)
-   
+   DEF_forcing%nlands            = 1           ! land grid number in 1d
+
+   DEF_forcing%leapyear          = .true.      ! leapyear calendar
+   DEF_forcing%data2d            = .true.      ! data in 2 dimension (lon, lat)
+   DEF_forcing%hightdim          = .false.     ! have "z" dimension
+   DEF_forcing%dim2d             = .false.     ! lat/lon value in 2 dimension (lon, lat)
+
    DEF_forcing%latname           = 'latitude'  ! dimension name of latitude
    DEF_forcing%lonname           = 'longitude' ! dimension name of longitude
-   
-   DEF_forcing%groupby           = 'month'  ! file grouped by year/month
-   
+
+   DEF_forcing%groupby           = 'month'     ! file grouped by year/month
+
    DEF_forcing%fprefix(1) = '2m_temperature/ERA5'
    DEF_forcing%fprefix(2) = 'Specific_Humdity/ERA5'
    DEF_forcing%fprefix(3) = 'surface_pressure/ERA5'
@@ -39,6 +39,7 @@
 
 
    DEF_forcing%vname    = 't2m' 'q' 'sp' 'mtpr' 'u10' 'v10' 'msdwswrf' 'msdwlwrf'
+   DEF_forcing%timelog  = 'instant' 'instant' 'instant' 'foreward' 'instant' 'instant' 'foreward' 'foreward'
    DEF_forcing%tintalgo = 'linear' 'linear' 'linear' 'nearest' 'linear' 'linear' 'coszen' 'linear'
 
    DEF_forcing%CBL_fprefix        = 'boundary_layer_height/ERA5'

--- a/run/forcing/GDAS.nml
+++ b/run/forcing/GDAS.nml
@@ -1,41 +1,39 @@
 &nl_colm_forcing
-   
-  ! ----- forcing -----
-   DEF_dir_forcing  = '/tera06/zhwei/CoLM_Forcing/GDAS_GPCP/' 
 
-   DEF_forcing%dataset           = 'GDAS' 
-   DEF_forcing%solarin_all_band  = .true.  
-   DEF_forcing%HEIGHT_V          = 50.0    
+  ! ----- forcing -----
+   DEF_dir_forcing  = '/shr03/CoLM_Forcing/GDAS_GPCP/'
+
+   DEF_forcing%dataset           = 'GDAS'
+   DEF_forcing%solarin_all_band  = .true.
+   DEF_forcing%HEIGHT_V          = 50.0
    DEF_forcing%HEIGHT_T          = 40.
    DEF_forcing%HEIGHT_Q          = 40.
-   
+
    DEF_forcing%regional          = .true.
    DEF_forcing%regbnd            = -60.0 90.0 -180.0 180.0
 
    DEF_forcing%has_missing_value = .true.
    missing_value_name            = 'missing_value'
 
-
-   
-   DEF_forcing%NVAR              = 8        ! variable number of forcing data
-   DEF_forcing%startyr           = 2002     ! start year of forcing data  
-   DEF_forcing%startmo           = 1        ! start month of forcing data
-   DEF_forcing%endyr             = 2021     ! end year of forcing data
-   DEF_forcing%endmo             = 12       ! end month of forcing data
+   DEF_forcing%NVAR              = 8       ! variable number of forcing data
+   DEF_forcing%startyr           = 2002    ! start year of forcing data
+   DEF_forcing%startmo           = 1       ! start month of forcing data
+   DEF_forcing%endyr             = 2021    ! end year of forcing data
+   DEF_forcing%endmo             = 12      ! end month of forcing data
    DEF_forcing%dtime             = 10800 10800 10800 10800 0 10800 10800 10800
    DEF_forcing%offset            = 5400 5400 5400 5400 0 5400 0 5400
-   DEF_forcing%nlands            = 1        ! land grid number in 1d
-   
-   DEF_forcing%leapyear          = .true.   ! leapyear calendar
-   DEF_forcing%data2d            = .true.   ! data in 2 dimension (lon, lat)
-   DEF_forcing%hightdim          = .false.  ! have "z" dimension
-   DEF_forcing%dim2d             = .false.  ! lat/lon value in 2 dimension (lon, lat)
-   
-   DEF_forcing%latname           = 'lat'  ! dimension name of latitude
-   DEF_forcing%lonname           = 'lon' ! dimension name of longitude
-   
-   DEF_forcing%groupby           = 'month'  ! file grouped by year/month
-   
+   DEF_forcing%nlands            = 1       ! land grid number in 1d
+
+   DEF_forcing%leapyear          = .true.  ! leapyear calendar
+   DEF_forcing%data2d            = .true.  ! data in 2 dimension (lon, lat)
+   DEF_forcing%hightdim          = .false. ! have "z" dimension
+   DEF_forcing%dim2d             = .false. ! lat/lon value in 2 dimension (lon, lat)
+
+   DEF_forcing%latname           = 'lat'   ! dimension name of latitude
+   DEF_forcing%lonname           = 'lon'   ! dimension name of longitude
+
+   DEF_forcing%groupby           = 'month' ! file grouped by year/month
+
    DEF_forcing%fprefix(1) = 'GLDAS_GDAS_3H_Tair.'
    DEF_forcing%fprefix(2) = 'GLDAS_GDAS_3H_Qair.'
    DEF_forcing%fprefix(3) = 'GLDAS_GDAS_3H_Psurf.'
@@ -45,8 +43,9 @@
    DEF_forcing%fprefix(7) = 'GLDAS_GDAS_3H_SWdown.'
    DEF_forcing%fprefix(8) = 'GLDAS_GDAS_3H_LWdown.'
 
-   
-   DEF_forcing%vname    = 'Tair_f_inst' 'Qair_f_inst' 'Psurf_f_inst' 'Rainf_f_tavg' 'NULL' 'Wind_f_inst' 'SWdown_f_tavg' 'LWdown_f_tavg' 
+
+   DEF_forcing%vname    = 'Tair_f_inst' 'Qair_f_inst' 'Psurf_f_inst' 'Rainf_f_tavg' 'NULL' 'Wind_f_inst' 'SWdown_f_tavg' 'LWdown_f_tavg'
+   DEF_forcing%timelog  = 'instant' 'instant' 'instant' 'foreward' 'instant' 'instant' 'foreward' 'foreward'
    DEF_forcing%tintalgo = 'linear' 'linear' 'linear' 'nearest' 'NULL' 'linear' 'coszen' 'linear'
 
 /

--- a/run/forcing/GSWP3.nml
+++ b/run/forcing/GSWP3.nml
@@ -1,33 +1,33 @@
 &nl_colm_forcing
-   
-   ! ----- forcing -----
-   DEF_dir_forcing  = '/tera06/zhwei/CoLM_Forcing/GSWP3/' 
 
-   DEF_forcing%dataset           = 'GSWP3' 
-   DEF_forcing%solarin_all_band  = .true.  
-   DEF_forcing%HEIGHT_V          = 50.0    
+   ! ----- forcing -----
+   DEF_dir_forcing  = '/shr03/CoLM_Forcing/GSWP3/'
+
+   DEF_forcing%dataset           = 'GSWP3'
+   DEF_forcing%solarin_all_band  = .true.
+   DEF_forcing%HEIGHT_V          = 50.0
    DEF_forcing%HEIGHT_T          = 40.
    DEF_forcing%HEIGHT_Q          = 40.
-   
+
    DEF_forcing%NVAR              = 8        ! variable number of forcing data
-   DEF_forcing%startyr           = 1950     ! start year of forcing data  
+   DEF_forcing%startyr           = 1950     ! start year of forcing data
    DEF_forcing%startmo           = 1        ! start month of forcing data
    DEF_forcing%endyr             = 2014     ! end year of forcing data
    DEF_forcing%endmo             = 12       ! end month of forcing data
    DEF_forcing%dtime             = 10800 10800 10800 10800 0 10800 10800 10800
    DEF_forcing%offset            = 5400 5400 5400 5400 0 5400 0 5400
    DEF_forcing%nlands            = 1        ! land grid number in 1d
-   
-   DEF_forcing%leapyear          = .false.   ! leapyear calendar
+
+   DEF_forcing%leapyear          = .false.  ! leapyear calendar
    DEF_forcing%data2d            = .true.   ! data in 2 dimension (lon, lat)
    DEF_forcing%hightdim          = .false.  ! have "z" dimension
-   DEF_forcing%dim2d             = .true.  ! lat/lon value in 2 dimension (lon, lat)
-   
-   DEF_forcing%latname           = 'LATIXY'  ! dimension name of latitude
+   DEF_forcing%dim2d             = .true.   ! lat/lon value in 2 dimension (lon, lat)
+
+   DEF_forcing%latname           = 'LATIXY' ! dimension name of latitude
    DEF_forcing%lonname           = 'LONGXY' ! dimension name of longitude
-   
+
    DEF_forcing%groupby           = 'month'  ! file grouped by year/month
-   
+
    DEF_forcing%fprefix(1) = 'TPHWL/clmforc.GSWP3.c2011.0.5x0.5.TPQWL.'
    DEF_forcing%fprefix(2) = 'TPHWL/clmforc.GSWP3.c2011.0.5x0.5.TPQWL.'
    DEF_forcing%fprefix(3) = 'TPHWL/clmforc.GSWP3.c2011.0.5x0.5.TPQWL.'
@@ -36,8 +36,9 @@
    DEF_forcing%fprefix(6) = 'TPHWL/clmforc.GSWP3.c2011.0.5x0.5.TPQWL.'
    DEF_forcing%fprefix(7) = 'Solar/clmforc.GSWP3.c2011.0.5x0.5.Solr.'
    DEF_forcing%fprefix(8) = 'TPHWL/clmforc.GSWP3.c2011.0.5x0.5.TPQWL.'
-   
-   DEF_forcing%vname    = 'TBOT' 'QBOT' 'PSRF' 'PRECTmms' 'NULL' 'WIND' 'FSDS' 'FLDS' 
+
+   DEF_forcing%vname    = 'TBOT' 'QBOT' 'PSRF' 'PRECTmms' 'NULL' 'WIND' 'FSDS' 'FLDS'
+   DEF_forcing%timelog  = 'instant' 'instant' 'instant' 'foreward' 'instant' 'instant' 'foreward' 'foreward'
    DEF_forcing%tintalgo = 'linear' 'linear' 'linear' 'nearest' 'NULL' 'linear' 'coszen' 'linear'
 
 /

--- a/run/forcing/JRA3Q.nml
+++ b/run/forcing/JRA3Q.nml
@@ -1,33 +1,33 @@
 &nl_colm_forcing
-   
+
    ! ----- forcing -----
    DEF_dir_forcing  ='/share/home/dq013/zhwei/colm/data/CoLM_Forcing/JRA3Q/'
 
-   DEF_forcing%dataset           = 'JRA3Q' 
-   DEF_forcing%solarin_all_band  = .true.  
-   DEF_forcing%HEIGHT_V          = 50.0    
+   DEF_forcing%dataset           = 'JRA3Q'
+   DEF_forcing%solarin_all_band  = .true.
+   DEF_forcing%HEIGHT_V          = 50.0
    DEF_forcing%HEIGHT_T          = 40.
    DEF_forcing%HEIGHT_Q          = 40.
-   
+
    DEF_forcing%NVAR              = 8        ! variable number of forcing data
-   DEF_forcing%startyr           = 2003     ! start year of forcing data  
+   DEF_forcing%startyr           = 2003     ! start year of forcing data
    DEF_forcing%startmo           = 1        ! start month of forcing data
    DEF_forcing%endyr             = 2023     ! end year of forcing data
    DEF_forcing%endmo             = 12       ! end month of forcing data
    DEF_forcing%dtime             = 3600 3600 3600 3600 3600 3600 3600 3600
    DEF_forcing%offset            = 1800 1800 1800 1800 1800 1800 1800 1800
    DEF_forcing%nlands            = 1        ! land grid number in 1d
-   
+
    DEF_forcing%leapyear          = .true.   ! leapyear calendar
    DEF_forcing%data2d            = .true.   ! data in 2 dimension (lon, lat)
    DEF_forcing%hightdim          = .false.  ! have "z" dimension
    DEF_forcing%dim2d             = .false.  ! lat/lon value in 2 dimension (lon, lat)
-   
+
    DEF_forcing%latname           = 'lat'    ! dimension name of latitude
    DEF_forcing%lonname           = 'lon'    ! dimension name of longitude
-   
+
    DEF_forcing%groupby           = 'month'  ! file grouped by year/month
-   
+
    DEF_forcing%fprefix(1) = 'tmp2m/tmp2m'
    DEF_forcing%fprefix(2) = 'spfh2m/spfh2m'
    DEF_forcing%fprefix(3) = 'pres/pres'
@@ -40,6 +40,7 @@
 
 
    DEF_forcing%vname    = 'tmp2m-hgt-fc-gauss' 'spfh2m-hgt-fc-gauss' 'pres-sfc-fc-gauss' 'tprate1have-sfc-fc-gauss' 'ugrd10m-hgt-fc-gauss' 'vgrd10m-hgt-fc-gauss' 'dswrf1have-sfc-fc-gauss' 'dlwrf1have-sfc-fc-gauss'
+   DEF_forcing%timelog  = 'instant' 'instant' 'instant' 'foreward' 'instant' 'instant' 'foreward' 'foreward'
    DEF_forcing%tintalgo = 'linear' 'linear' 'linear' 'linear' 'NULL' 'linear' 'coszen' 'linear'
 
 

--- a/run/forcing/JRA55.nml
+++ b/run/forcing/JRA55.nml
@@ -1,33 +1,33 @@
 &nl_colm_forcing
-   
+
    ! ----- forcing -----
    DEF_dir_forcing  ='/share/home/dq013/zhwei/colm/data/CoLM_Forcing/JRA55_org'
 
-   DEF_forcing%dataset           = 'JRA55' 
-   DEF_forcing%solarin_all_band  = .true.  
-   DEF_forcing%HEIGHT_V          = 50.0    
+   DEF_forcing%dataset           = 'JRA55'
+   DEF_forcing%solarin_all_band  = .true.
+   DEF_forcing%HEIGHT_V          = 50.0
    DEF_forcing%HEIGHT_T          = 40.
    DEF_forcing%HEIGHT_Q          = 40.
-   
-   DEF_forcing%NVAR              = 8        ! variable number of forcing data
-   DEF_forcing%startyr           = 1979     ! start year of forcing data  
-   DEF_forcing%startmo           = 1        ! start month of forcing data
-   DEF_forcing%endyr             = 2022     ! end year of forcing data
-   DEF_forcing%endmo             = 12       ! end month of forcing data
+
+   DEF_forcing%NVAR              = 8       ! variable number of forcing data
+   DEF_forcing%startyr           = 1979    ! start year of forcing data
+   DEF_forcing%startmo           = 1       ! start month of forcing data
+   DEF_forcing%endyr             = 2022    ! end year of forcing data
+   DEF_forcing%endmo             = 12      ! end month of forcing data
    DEF_forcing%dtime             = 10800 10800 10800 10800 10800 10800 10800 10800
    DEF_forcing%offset            = 5400 5400 5400 5400 5400 5400 0 5400
-   DEF_forcing%nlands            = 1        ! land grid number in 1d
-   
-   DEF_forcing%leapyear          = .true.   ! leapyear calendar
-   DEF_forcing%data2d            = .true.   ! data in 2 dimension (lon, lat)
-   DEF_forcing%hightdim          = .false.  ! have "z" dimension
-   DEF_forcing%dim2d             = .false.  ! lat/lon value in 2 dimension (lon, lat)
-   
-   DEF_forcing%latname           = 'lat'  ! dimension name of latitude
-   DEF_forcing%lonname           = 'lon' ! dimension name of longitude
-   
+   DEF_forcing%nlands            = 1       ! land grid number in 1d
+
+   DEF_forcing%leapyear          = .true.  ! leapyear calendar
+   DEF_forcing%data2d            = .true.  ! data in 2 dimension (lon, lat)
+   DEF_forcing%hightdim          = .false. ! have "z" dimension
+   DEF_forcing%dim2d             = .false. ! lat/lon value in 2 dimension (lon, lat)
+
+   DEF_forcing%latname           = 'lat'   ! dimension name of latitude
+   DEF_forcing%lonname           = 'lon'   ! dimension name of longitude
+
    DEF_forcing%groupby           = 'year'  ! file grouped by year/month
-   
+
    DEF_forcing%fprefix(1) = 't2m/tmp'
    DEF_forcing%fprefix(2) = 'spfh/spfh'
    DEF_forcing%fprefix(3) = 'pres/pres'
@@ -37,9 +37,8 @@
    DEF_forcing%fprefix(7) = 'dswrf/dswrf'
    DEF_forcing%fprefix(8) = 'dlwrf/dlwrf'
 
-   
+
    DEF_forcing%vname    = 'var11' 'var51' 'var1' 'var61' 'var33' 'var34' 'var204' 'var205'
+   DEF_forcing%timelog  = 'instant' 'instant' 'instant' 'foreward' 'instant' 'instant' 'foreward' 'foreward'
    DEF_forcing%tintalgo = 'linear' 'linear' 'linear' 'nearest' 'linear' 'linear' 'coszen' 'linear'
-
-
 /

--- a/run/forcing/MPI-ESM1-2-HR_ssp585.nml
+++ b/run/forcing/MPI-ESM1-2-HR_ssp585.nml
@@ -1,33 +1,33 @@
 &nl_colm_forcing
-   
-  ! ----- forcing -----
-   DEF_dir_forcing  = '/share/home/dq013/zhwei/colm/data/CoLM_Forcing/MPI-ESM1-2-HR/ssp585/' 
 
-   DEF_forcing%dataset           = 'CMIP6' 
-   DEF_forcing%solarin_all_band  = .true.  
-   DEF_forcing%HEIGHT_V          = 50.0    
+  ! ----- forcing -----
+   DEF_dir_forcing  = '/share/home/dq013/zhwei/colm/data/CoLM_Forcing/MPI-ESM1-2-HR/ssp585/'
+
+   DEF_forcing%dataset           = 'CMIP6'
+   DEF_forcing%solarin_all_band  = .true.
+   DEF_forcing%HEIGHT_V          = 50.0
    DEF_forcing%HEIGHT_T          = 40.0
    DEF_forcing%HEIGHT_Q          = 40.0
-   
-   DEF_forcing%NVAR              = 8        ! variable number of forcing data
-   DEF_forcing%startyr           = 2016     ! start year of forcing data  
-   DEF_forcing%startmo           = 1        ! start month of forcing data
-   DEF_forcing%endyr             = 2100     ! end year of forcing data
-   DEF_forcing%endmo             = 12       ! end month of forcing data
+
+   DEF_forcing%NVAR              = 8       ! variable number of forcing data
+   DEF_forcing%startyr           = 2016    ! start year of forcing data
+   DEF_forcing%startmo           = 1       ! start month of forcing data
+   DEF_forcing%endyr             = 2100    ! end year of forcing data
+   DEF_forcing%endmo             = 12      ! end month of forcing data
    DEF_forcing%dtime             = 10800 10800 10800 10800 10800 10800 10800 10800
    DEF_forcing%offset            = 10800 10800 10800 10800 10800 10800 10800 10800
-   DEF_forcing%nlands            = 1        ! land grid number in 1d
-   
-   DEF_forcing%leapyear          = .true.   ! leapyear calendar
-   DEF_forcing%data2d            = .true.   ! data in 2 dimension (lon, lat)
-   DEF_forcing%hightdim          = .false.  ! have "z" dimension
-   DEF_forcing%dim2d             = .false.  ! lat/lon value in 2 dimension (lon, lat)
-   
-   DEF_forcing%latname           = 'lat'  ! dimension name of latitude
-   DEF_forcing%lonname           = 'lon' ! dimension name of longitude
-   
+   DEF_forcing%nlands            = 1       ! land grid number in 1d
+
+   DEF_forcing%leapyear          = .true.  ! leapyear calendar
+   DEF_forcing%data2d            = .true.  ! data in 2 dimension (lon, lat)
+   DEF_forcing%hightdim          = .false. ! have "z" dimension
+   DEF_forcing%dim2d             = .false. ! lat/lon value in 2 dimension (lon, lat)
+
+   DEF_forcing%latname           = 'lat'   ! dimension name of latitude
+   DEF_forcing%lonname           = 'lon'   ! dimension name of longitude
+
    DEF_forcing%groupby           = 'year'  ! file grouped by year/month
-   
+
    DEF_forcing%fprefix(1) = 'tas/tas_1d'
    DEF_forcing%fprefix(2) = 'huss/huss_1d'
    DEF_forcing%fprefix(3) = 'ps/ps_1d'
@@ -39,6 +39,7 @@
 
 
    DEF_forcing%vname    = 'tas' 'huss' 'ps' 'pr' 'uas' 'vas' 'rsds' 'rlds'
+   DEF_forcing%timelog  = 'instant' 'instant' 'instant' 'foreward' 'instant' 'instant' 'foreward' 'foreward'
    DEF_forcing%tintalgo = 'linear' 'linear' 'linear' 'nearest' 'linear' 'linear' 'coszen' 'linear'
 
 /

--- a/run/forcing/MSWX.nml
+++ b/run/forcing/MSWX.nml
@@ -1,33 +1,33 @@
 &nl_colm_forcing
-   
-  ! ----- forcing -----
-   DEF_dir_forcing  = '/tera06/zhwei/CoLM_Forcing/MSWX_V100/' 
 
-   DEF_forcing%dataset           = 'MSWX' 
-   DEF_forcing%solarin_all_band  = .true.  
-   DEF_forcing%HEIGHT_V          = 50.0    
+  ! ----- forcing -----
+   DEF_dir_forcing  = '/shr03/CoLM_Forcing/MSWX_V100/'
+
+   DEF_forcing%dataset           = 'MSWX'
+   DEF_forcing%solarin_all_band  = .true.
+   DEF_forcing%HEIGHT_V          = 50.0
    DEF_forcing%HEIGHT_T          = 40.
    DEF_forcing%HEIGHT_Q          = 40.
-   
-   DEF_forcing%NVAR              = 8        ! variable number of forcing data
-   DEF_forcing%startyr           = 1979     ! start year of forcing data  
-   DEF_forcing%startmo           = 1        ! start month of forcing data
-   DEF_forcing%endyr             = 2021     ! end year of forcing data
-   DEF_forcing%endmo             = 12       ! end month of forcing data
+
+   DEF_forcing%NVAR              = 8       ! variable number of forcing data
+   DEF_forcing%startyr           = 1979    ! start year of forcing data
+   DEF_forcing%startmo           = 1       ! start month of forcing data
+   DEF_forcing%endyr             = 2021    ! end year of forcing data
+   DEF_forcing%endmo             = 12      ! end month of forcing data
    DEF_forcing%dtime             = 10800 10800 10800 10800 10800 10800 10800 10800
    DEF_forcing%offset            = 10800 10800 10800 10800 10800 10800 0 10800
-   DEF_forcing%nlands            = 1        ! land grid number in 1d
-   
-   DEF_forcing%leapyear          = .true.   ! leapyear calendar
-   DEF_forcing%data2d            = .true.   ! data in 2 dimension (lon, lat)
-   DEF_forcing%hightdim          = .false.  ! have "z" dimension
-   DEF_forcing%dim2d             = .false.  ! lat/lon value in 2 dimension (lon, lat)
-   
-   DEF_forcing%latname           = 'lat'  ! dimension name of latitude
-   DEF_forcing%lonname           = 'lon' ! dimension name of longitude
-   
-   DEF_forcing%groupby           = 'month'  ! file grouped by year/month
-   
+   DEF_forcing%nlands            = 1       ! land grid number in 1d
+
+   DEF_forcing%leapyear          = .true.  ! leapyear calendar
+   DEF_forcing%data2d            = .true.  ! data in 2 dimension (lon, lat)
+   DEF_forcing%hightdim          = .false. ! have "z" dimension
+   DEF_forcing%dim2d             = .false. ! lat/lon value in 2 dimension (lon, lat)
+
+   DEF_forcing%latname           = 'lat'   ! dimension name of latitude
+   DEF_forcing%lonname           = 'lon'   ! dimension name of longitude
+
+   DEF_forcing%groupby           = 'month' ! file grouped by year/month
+
    DEF_forcing%fprefix(1) = 'Temp'
    DEF_forcing%fprefix(2) = 'SpecHum'
    DEF_forcing%fprefix(3) = 'Pres'
@@ -37,8 +37,9 @@
    DEF_forcing%fprefix(7) = 'SWd'
    DEF_forcing%fprefix(8) = 'LWd'
 
-   
-   DEF_forcing%vname    = 'air_temperature' 'specific_humidity' 'surface_pressure' 'precipitation' 'NULL' 'wind_speed' 'downward_shortwave_radiation' 'downward_longwave_radiation' 
+
+   DEF_forcing%vname    = 'air_temperature' 'specific_humidity' 'surface_pressure' 'precipitation' 'NULL' 'wind_speed' 'downward_shortwave_radiation' 'downward_longwave_radiation'
+   DEF_forcing%timelog  = 'instant' 'instant' 'instant' 'foreward' 'instant' 'instant' 'foreward' 'foreward'
    DEF_forcing%tintalgo = 'linear' 'linear' 'linear' 'nearest' 'NULL' 'linear' 'coszen' 'linear'
 
 /

--- a/run/forcing/POINT.nml
+++ b/run/forcing/POINT.nml
@@ -1,20 +1,20 @@
 &nl_colm_forcing
 
    ! ----- forcing -----
-   DEF_dir_forcing  = '/tera06/zhwei/CoLM_Forcing/PLUMBER2/Forcing/'
+   DEF_dir_forcing  = '/shr03/CoLM_Forcing/PLUMBER2/Forcing/'
 
-   DEF_forcing%dataset           = 'POINT' 
-   DEF_forcing%solarin_all_band  = .true.  
-   DEF_forcing%HEIGHT_V          = 100.0    
+   DEF_forcing%dataset           = 'POINT'
+   DEF_forcing%solarin_all_band  = .true.
+   DEF_forcing%HEIGHT_V          = 100.0
    DEF_forcing%HEIGHT_T          = 50.
    DEF_forcing%HEIGHT_Q          = 50.
-   
+
    DEF_forcing%NVAR              = 8        ! variable number of forcing data
-   DEF_forcing%startyr           = 2013     ! start year of forcing data  
+   DEF_forcing%startyr           = 2013     ! start year of forcing data
    DEF_forcing%startmo           = 1        ! start month of forcing data
    DEF_forcing%endyr             = 2020     ! end year of forcing data
    DEF_forcing%endmo             = 12       ! end month of forcing data
-   
+
    DEF_forcing%fprefix(1) = 'CN-Dan_2004-2005_FLUXNET2015_Met.nc'
    DEF_forcing%fprefix(2) = 'CN-Dan_2004-2005_FLUXNET2015_Met.nc'
    DEF_forcing%fprefix(3) = 'CN-Dan_2004-2005_FLUXNET2015_Met.nc'
@@ -23,8 +23,9 @@
    DEF_forcing%fprefix(6) = 'CN-Dan_2004-2005_FLUXNET2015_Met.nc'
    DEF_forcing%fprefix(7) = 'CN-Dan_2004-2005_FLUXNET2015_Met.nc'
    DEF_forcing%fprefix(8) = 'CN-Dan_2004-2005_FLUXNET2015_Met.nc'
-   
-   DEF_forcing%vname    = 'Tair' 'Qair' 'Psurf' 'Precip' 'NULL' 'Wind' 'SWdown' 'LWdown' 
+
+   DEF_forcing%vname    = 'Tair' 'Qair' 'Psurf' 'Precip' 'NULL' 'Wind' 'SWdown' 'LWdown'
+   DEF_forcing%timelog  = 'instant' 'instant' 'instant' 'foreward' 'instant' 'instant' 'foreward' 'foreward'
    DEF_forcing%tintalgo = 'linear' 'linear' 'linear' 'nearest' 'NULL' 'linear' 'coszen' 'linear'
 
 /

--- a/run/forcing/PRINCETON.nml
+++ b/run/forcing/PRINCETON.nml
@@ -1,33 +1,33 @@
 &nl_colm_forcing
-  
-  ! ----- forcing -----
-   DEF_dir_forcing  = '/tera06/zhwei/CoLM_Forcing/princeton-r/' 
 
-   DEF_forcing%dataset           = 'PRINCETON' 
-   DEF_forcing%solarin_all_band  = .true.  
-   DEF_forcing%HEIGHT_V          = 50.0    
+  ! ----- forcing -----
+   DEF_dir_forcing  = '/shr03/CoLM_Forcing/princeton-r/'
+
+   DEF_forcing%dataset           = 'PRINCETON'
+   DEF_forcing%solarin_all_band  = .true.
+   DEF_forcing%HEIGHT_V          = 50.0
    DEF_forcing%HEIGHT_T          = 40.
    DEF_forcing%HEIGHT_Q          = 40.
-   
-   DEF_forcing%NVAR              = 8        ! variable number of forcing data
-   DEF_forcing%startyr           = 1948     ! start year of forcing data  
-   DEF_forcing%startmo           = 1        ! start month of forcing data
-   DEF_forcing%endyr             = 2006     ! end year of forcing data
-   DEF_forcing%endmo             = 12       ! end month of forcing data
+
+   DEF_forcing%NVAR              = 8           ! variable number of forcing data
+   DEF_forcing%startyr           = 1948        ! start year of forcing data
+   DEF_forcing%startmo           = 1           ! start month of forcing data
+   DEF_forcing%endyr             = 2006        ! end year of forcing data
+   DEF_forcing%endmo             = 12          ! end month of forcing data
    DEF_forcing%dtime             = 10800 10800 10800 10800 10800 10800 10800 10800
    DEF_forcing%offset            = 0 0 0 0 0 0 0 0
-   DEF_forcing%nlands            = 1        ! land grid number in 1d
-   
-   DEF_forcing%leapyear          = .true.   ! leapyear calendar
-   DEF_forcing%data2d            = .true.   ! data in 2 dimension (lon, lat)
-   DEF_forcing%hightdim          = .false.  ! have "z" dimension
-   DEF_forcing%dim2d             = .false.  ! lat/lon value in 2 dimension (lon, lat)
-   
+   DEF_forcing%nlands            = 1           ! land grid number in 1d
+
+   DEF_forcing%leapyear          = .true.      ! leapyear calendar
+   DEF_forcing%data2d            = .true.      ! data in 2 dimension (lon, lat)
+   DEF_forcing%hightdim          = .false.     ! have "z" dimension
+   DEF_forcing%dim2d             = .false.     ! lat/lon value in 2 dimension (lon, lat)
+
    DEF_forcing%latname           = 'latitude'  ! dimension name of latitude
    DEF_forcing%lonname           = 'longitude' ! dimension name of longitude
-   
-   DEF_forcing%groupby           = 'year'  ! file grouped by year/month
-   
+
+   DEF_forcing%groupby           = 'year'      ! file grouped by year/month
+
    DEF_forcing%fprefix(1) = 'tas/tas_3hourly_'
    DEF_forcing%fprefix(2) = 'shum/shum_3hourly_'
    DEF_forcing%fprefix(3) = 'pres/pres_3hourly_'
@@ -37,8 +37,9 @@
    DEF_forcing%fprefix(7) = 'dswrf/dswrf_3hourly_'
    DEF_forcing%fprefix(8) = 'dlwrf/dlwrf_3hourly_'
 
-   
-   DEF_forcing%vname    = 'tas' 'shum' 'pres' 'prcp' 'NULL' 'wind' 'dswrf' 'dlwrf' 
+
+   DEF_forcing%vname    = 'tas' 'shum' 'pres' 'prcp' 'NULL' 'wind' 'dswrf' 'dlwrf'
+   DEF_forcing%timelog  = 'instant' 'instant' 'instant' 'foreward' 'instant' 'instant' 'foreward' 'foreward'
    DEF_forcing%tintalgo = 'linear' 'linear' 'linear' 'nearest' 'NULL' 'linear' 'coszen' 'linear'
 
 /

--- a/run/forcing/QIAN.nml
+++ b/run/forcing/QIAN.nml
@@ -1,7 +1,7 @@
 &nl_colm_forcing
-   
+
    ! ----- forcing -----
-   DEF_dir_forcing  = '/tera06/zhwei/CoLM_Forcing/qian/' 
+   DEF_dir_forcing  = '/shr03/CoLM_Forcing/qian/'
 
    DEF_forcing%dataset           = 'QIAN'
    DEF_forcing%solarin_all_band  = .true.
@@ -18,12 +18,12 @@
    DEF_forcing%offset            = 5400  5400  5400  10800  0  5400  0 0
    DEF_forcing%nlands            = 1        ! land grid number in 1d
 
-   DEF_forcing%leapyear          = .false.   ! leapyear calendar
+   DEF_forcing%leapyear          = .false.  ! leapyear calendar
    DEF_forcing%data2d            = .true.   ! data in 2 dimension (lon, lat)
    DEF_forcing%hightdim          = .false.  ! have "z" dimension
-   DEF_forcing%dim2d             = .true.  ! lat/lon value in 2 dimension (lon, lat)
+   DEF_forcing%dim2d             = .true.   ! lat/lon value in 2 dimension (lon, lat)
 
-   DEF_forcing%latname           = 'LATIXY'  ! dimension name of latitude
+   DEF_forcing%latname           = 'LATIXY' ! dimension name of latitude
    DEF_forcing%lonname           = 'LONGXY' ! dimension name of longitude
 
    DEF_forcing%groupby           = 'month'  ! file grouped by year/month
@@ -39,6 +39,7 @@
 
 
    DEF_forcing%vname    = 'TBOT' 'QBOT' 'PSRF' 'PRECTmms' 'NULL' 'WIND' 'FSDS' 'NULL'
+   DEF_forcing%timelog  = 'instant' 'instant' 'instant' 'foreward' 'instant' 'instant' 'foreward' 'foreward'
    DEF_forcing%tintalgo = 'linear' 'linear' 'linear' 'nearest' 'NULL' 'linear' 'coszen' 'NULL'
 
 /

--- a/run/forcing/TPMFD.nml
+++ b/run/forcing/TPMFD.nml
@@ -1,37 +1,37 @@
 &nl_colm_forcing
 
   ! ----- forcing -----
-   DEF_dir_forcing  = '/tera06/zhwei/CoLM_Forcing/TPMFD/' 
+   DEF_dir_forcing  = '/shr03/CoLM_Forcing/TPMFD/'
 
-   DEF_forcing%dataset           = 'TPMFD' 
-   DEF_forcing%solarin_all_band  = .true.  
-   DEF_forcing%HEIGHT_V          = 50.0    
-   DEF_forcing%HEIGHT_T          = 40.0
-   DEF_forcing%HEIGHT_Q          = 40.0
+   DEF_forcing%dataset            = 'TPMFD'
+   DEF_forcing%solarin_all_band   = .true.
+   DEF_forcing%HEIGHT_V           = 50.0
+   DEF_forcing%HEIGHT_T           = 40.0
+   DEF_forcing%HEIGHT_Q           = 40.0
 
-   DEF_forcing%regional          = .true.
-   DEF_forcing%regbnd            = 25.4166 41.3818 61.0 105.678
-   DEF_forcing%has_missing_value = .true.
-   DEF_forcing%missing_value_name= 'missing_value'
+   DEF_forcing%regional           = .true.
+   DEF_forcing%regbnd             = 25.4166 41.3818 61.0 105.678
+   DEF_forcing%has_missing_value  = .true.
+   DEF_forcing%missing_value_name = 'missing_value'
 
-   DEF_forcing%NVAR              = 8        ! variable number of forcing data
-   DEF_forcing%startyr           = 1979     ! start year of forcing data  
-   DEF_forcing%startmo           = 1        ! start month of forcing data
-   DEF_forcing%endyr             = 2021     ! end year of forcing data
-   DEF_forcing%endmo             = 12       ! end month of forcing data
-   DEF_forcing%dtime             = 3600 3600 3600 3600 3600 3600 3600 3600
-   DEF_forcing%offset            = 0 0 0 0 0 0 0 0
-   DEF_forcing%nlands            = 1        ! land grid number in 1d
+   DEF_forcing%NVAR               = 8           ! variable number of forcing data
+   DEF_forcing%startyr            = 1979        ! start year of forcing data
+   DEF_forcing%startmo            = 1           ! start month of forcing data
+   DEF_forcing%endyr              = 2021        ! end year of forcing data
+   DEF_forcing%endmo              = 12          ! end month of forcing data
+   DEF_forcing%dtime              = 3600 3600 3600 3600 3600 3600 3600 3600
+   DEF_forcing%offset             = 0 0 0 0 0 0 0 0
+   DEF_forcing%nlands             = 1           ! land grid number in 1d
 
-   DEF_forcing%leapyear          = .true.   ! leapyear calendar
-   DEF_forcing%data2d            = .true.   ! data in 2 dimension (lon, lat)
-   DEF_forcing%hightdim          = .false.  ! have "z" dimension
-   DEF_forcing%dim2d             = .false.  ! lat/lon value in 2 dimension (lon, lat)
+   DEF_forcing%leapyear           = .true.      ! leapyear calendar
+   DEF_forcing%data2d             = .true.      ! data in 2 dimension (lon, lat)
+   DEF_forcing%hightdim           = .false.     ! have "z" dimension
+   DEF_forcing%dim2d              = .false.     ! lat/lon value in 2 dimension (lon, lat)
 
-   DEF_forcing%latname           = 'latitude'  ! dimension name of latitude
-   DEF_forcing%lonname           = 'longitude' ! dimension name of longitude
+   DEF_forcing%latname            = 'latitude'  ! dimension name of latitude
+   DEF_forcing%lonname            = 'longitude' ! dimension name of longitude
 
-   DEF_forcing%groupby           = 'month'  ! file grouped by year/month
+   DEF_forcing%groupby            = 'month'     ! file grouped by year/month
 
    DEF_forcing%fprefix(1) = 'temp/temp_'
    DEF_forcing%fprefix(2) = 'shum/shum_'
@@ -44,6 +44,7 @@
 
 
    DEF_forcing%vname    = 'temp' 'shum' 'pres' 'prcp' 'NULL' 'wind' 'srad' 'lrad'
+   DEF_forcing%timelog  = 'instant' 'instant' 'instant' 'foreward' 'instant' 'instant' 'foreward' 'foreward'
    DEF_forcing%tintalgo = 'linear' 'linear' 'linear' 'nearest' 'NULL' 'linear' 'coszen' 'linear'
 
 /

--- a/run/forcing/WFDE5.nml
+++ b/run/forcing/WFDE5.nml
@@ -1,35 +1,35 @@
 &nl_colm_forcing
-   
+
    ! ----- forcing -----
-   DEF_dir_forcing  = '/tera06/zhwei/CoLM_Forcing/WFDE5/'
+   DEF_dir_forcing  = '/shr03/CoLM_Forcing/WFDE5/'
 
-   DEF_forcing%dataset           = 'WFDE5'
-   DEF_forcing%solarin_all_band  = .true.
-   DEF_forcing%HEIGHT_V          = 50.0
-   DEF_forcing%HEIGHT_T          = 40.
-   DEF_forcing%HEIGHT_Q          = 40.
+   DEF_forcing%dataset            = 'WFDE5'
+   DEF_forcing%solarin_all_band   = .true.
+   DEF_forcing%HEIGHT_V           = 50.0
+   DEF_forcing%HEIGHT_T           = 40.
+   DEF_forcing%HEIGHT_Q           = 40.
 
-   DEF_forcing%has_missing_value = .true.
-   DEF_forcing%missing_value_name            = '_FillValue'
+   DEF_forcing%has_missing_value  = .true.
+   DEF_forcing%missing_value_name = '_FillValue'
 
-   DEF_forcing%NVAR              = 8        ! variable number of forcing data
-   DEF_forcing%startyr           = 1979     ! start year of forcing data
-   DEF_forcing%startmo           = 1        ! start month of forcing data
-   DEF_forcing%endyr             = 2019     ! end year of forcing data
-   DEF_forcing%endmo             = 12       ! end month of forcing data
-   DEF_forcing%dtime             = 3600 3600 3600 3600 3600 3600 3600 3600
-   DEF_forcing%offset            = 0 0 0 0 0 0 0 0
-   DEF_forcing%nlands            = 1        ! land grid number in 1d
+   DEF_forcing%NVAR               = 8       ! variable number of forcing data
+   DEF_forcing%startyr            = 1979    ! start year of forcing data
+   DEF_forcing%startmo            = 1       ! start month of forcing data
+   DEF_forcing%endyr              = 2019    ! end year of forcing data
+   DEF_forcing%endmo              = 12      ! end month of forcing data
+   DEF_forcing%dtime              = 3600 3600 3600 3600 3600 3600 3600 3600
+   DEF_forcing%offset             = 0 0 0 0 0 0 0 0
+   DEF_forcing%nlands             = 1       ! land grid number in 1d
 
-   DEF_forcing%leapyear          = .true.   ! leapyear calendar
-   DEF_forcing%data2d            = .true.   ! data in 2 dimension (lon, lat)
-   DEF_forcing%hightdim          = .false.  ! have "z" dimension
-   DEF_forcing%dim2d             = .false.  ! lat/lon value in 2 dimension (lon, lat)
+   DEF_forcing%leapyear           = .true.  ! leapyear calendar
+   DEF_forcing%data2d             = .true.  ! data in 2 dimension (lon, lat)
+   DEF_forcing%hightdim           = .false. ! have "z" dimension
+   DEF_forcing%dim2d              = .false. ! lat/lon value in 2 dimension (lon, lat)
 
-   DEF_forcing%latname           = 'lat'  ! dimension name of latitude
-   DEF_forcing%lonname           = 'lon' ! dimension name of longitude
+   DEF_forcing%latname            = 'lat'   ! dimension name of latitude
+   DEF_forcing%lonname            = 'lon'   ! dimension name of longitude
 
-   DEF_forcing%groupby           = 'month'  ! file grouped by year/month
+   DEF_forcing%groupby            = 'month' ! file grouped by year/month
 
    DEF_forcing%fprefix(1)     = 'near_surface_air_temperature/Tair_WFDE5_CRU_'
    DEF_forcing%fprefix(2)     = 'near_surface_specific_humidity/Qair_WFDE5_CRU_'
@@ -42,6 +42,7 @@
 
 
    DEF_forcing%vname          = 'Tair' 'Qair' 'PSurf' 'precipitation' 'NULL' 'Wind' 'SWdown' 'LWdown'
+   DEF_forcing%timelog        = 'instant' 'instant' 'instant' 'foreward' 'instant' 'instant' 'foreward' 'foreward'
    DEF_forcing%tintalgo       = 'linear' 'linear' 'linear' 'nearest' 'NULL' 'linear' 'coszen' 'linear'
 
 /

--- a/run/forcing/WFDEI.nml
+++ b/run/forcing/WFDEI.nml
@@ -1,36 +1,36 @@
 &nl_colm_forcing
-   
+
   ! ----- forcing -----
-   DEF_dir_forcing  = '/tera06/zhwei/CoLM_Forcing/WFDEI/'
+   DEF_dir_forcing  = '/shr03/CoLM_Forcing/WFDEI/'
 
-   DEF_forcing%dataset           = 'WFDEI'
-   DEF_forcing%solarin_all_band  = .true.
-   DEF_forcing%HEIGHT_V          = 50.0
-   DEF_forcing%HEIGHT_T          = 40.
-   DEF_forcing%HEIGHT_Q          = 40.
+   DEF_forcing%dataset            = 'WFDEI'
+   DEF_forcing%solarin_all_band   = .true.
+   DEF_forcing%HEIGHT_V           = 50.0
+   DEF_forcing%HEIGHT_T           = 40.
+   DEF_forcing%HEIGHT_Q           = 40.
 
-   DEF_forcing%has_missing_value = .true.
-   DEF_forcing%missing_value_name            = '_FillValue'
+   DEF_forcing%has_missing_value  = .true.
+   DEF_forcing%missing_value_name = '_FillValue'
 
 
-   DEF_forcing%NVAR              = 8        ! variable number of forcing data
-   DEF_forcing%startyr           = 1979     ! start year of forcing data
-   DEF_forcing%startmo           = 1        ! start month of forcing data
-   DEF_forcing%endyr             = 2016     ! end year of forcing data
-   DEF_forcing%endmo             = 12       ! end month of forcing data
-   DEF_forcing%dtime             = 10800 10800 10800 10800 0 10800 10800 10800
-   DEF_forcing%offset            = 5400 5400 5400 5400 0 5400 0 5400
-   DEF_forcing%nlands            = 1        ! land grid number in 1d
+   DEF_forcing%NVAR               = 8        ! variable number of forcing data
+   DEF_forcing%startyr            = 1979     ! start year of forcing data
+   DEF_forcing%startmo            = 1        ! start month of forcing data
+   DEF_forcing%endyr              = 2016     ! end year of forcing data
+   DEF_forcing%endmo              = 12       ! end month of forcing data
+   DEF_forcing%dtime              = 10800 10800 10800 10800 0 10800 10800 10800
+   DEF_forcing%offset             = 5400 5400 5400 5400 0 5400 0 5400
+   DEF_forcing%nlands             = 1        ! land grid number in 1d
 
-   DEF_forcing%leapyear          = .false.   ! leapyear calendar
-   DEF_forcing%data2d            = .true.   ! data in 2 dimension (lon, lat)
-   DEF_forcing%hightdim          = .false.  ! have "z" dimension
-   DEF_forcing%dim2d             = .true.  ! lat/lon value in 2 dimension (lon, lat)
+   DEF_forcing%leapyear           = .false.  ! leapyear calendar
+   DEF_forcing%data2d             = .true.   ! data in 2 dimension (lon, lat)
+   DEF_forcing%hightdim           = .false.  ! have "z" dimension
+   DEF_forcing%dim2d              = .true.   ! lat/lon value in 2 dimension (lon, lat)
 
-   DEF_forcing%latname           = 'LATIXY'  ! dimension name of latitude
-   DEF_forcing%lonname           = 'LONGXY' ! dimension name of longitude
+   DEF_forcing%latname            = 'LATIXY' ! dimension name of latitude
+   DEF_forcing%lonname            = 'LONGXY' ! dimension name of longitude
 
-   DEF_forcing%groupby           = 'month'  ! file grouped by year/month
+   DEF_forcing%groupby            = 'month'  ! file grouped by year/month
 
    DEF_forcing%fprefix(1)     = 'clmforc.WFDEI.c2017.0.5x0.5.TPQWL.'
    DEF_forcing%fprefix(2)     = 'clmforc.WFDEI.c2017.0.5x0.5.TPQWL.'
@@ -43,6 +43,7 @@
 
 
    DEF_forcing%vname          = 'TBOT' 'QBOT' 'PSRF' 'PRECTmms' 'NULL' 'WIND' 'FSDS' 'FLDS'
+   DEF_forcing%timelog        = 'instant' 'instant' 'instant' 'foreward' 'instant' 'instant' 'foreward' 'foreward'
    DEF_forcing%tintalgo       = 'linear' 'linear' 'linear' 'nearest' 'NULL' 'linear' 'coszen' 'linear'
 
 /

--- a/share/MOD_Namelist.F90
+++ b/share/MOD_Namelist.F90
@@ -228,6 +228,7 @@ MODULE MOD_Namelist
    logical :: DEF_URBAN_TREE        = .true.
    logical :: DEF_URBAN_WATER       = .true.
    logical :: DEF_URBAN_LUCY        = .true.
+   logical :: DEF_USE_CANYON_HWR    = .true.
 
 ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ! ----- Part 11: parameteration schemes -----
@@ -877,6 +878,7 @@ CONTAINS
       DEF_URBAN_TREE,                         & !add by hua yuan, modeling urban tree or not
       DEF_URBAN_WATER,                        & !add by hua yuan, modeling urban water or not
       DEF_URBAN_LUCY,                         &
+      DEF_USE_CANYON_HWR,                     &
 
       DEF_USE_SOILPAR_UPS_FIT,                &
       DEF_THERMAL_CONDUCTIVITY_SCHEME,        &
@@ -1349,6 +1351,7 @@ CONTAINS
       CALL mpi_bcast (DEF_URBAN_TREE                         ,1   ,mpi_logical   ,p_address_master ,p_comm_glb ,p_err)
       CALL mpi_bcast (DEF_URBAN_WATER                        ,1   ,mpi_logical   ,p_address_master ,p_comm_glb ,p_err)
       CALL mpi_bcast (DEF_URBAN_LUCY                         ,1   ,mpi_logical   ,p_address_master ,p_comm_glb ,p_err)
+      CALL mpi_bcast (DEF_USE_CANYON_HWR                     ,1   ,mpi_logical   ,p_address_master ,p_comm_glb ,p_err)
 
       ! 06/2023, added by weinan
       CALL mpi_bcast (DEF_USE_SOILPAR_UPS_FIT                ,1   ,mpi_logical   ,p_address_master ,p_comm_glb ,p_err)

--- a/share/MOD_Namelist.F90
+++ b/share/MOD_Namelist.F90
@@ -396,6 +396,9 @@ MODULE MOD_Namelist
       character(len=256) :: vname(8)           = (/ &
          'TBOT    ','QBOT    ','PSRF    ','PRECTmms', &
          'NULL    ','WIND    ','FSDS    ','FLDS    ' /)
+      character(len=256) :: timelog(8)         = (/ &
+         'instant ','instant ','instant ','foreward', &
+         'NULL    ','instant ','forward ','foreward' /)
       character(len=256) :: tintalgo(8)        = (/ &
          'linear ','linear ','linear ','nearest', &
          'NULL   ','linear ','coszen ','linear ' /)
@@ -1466,6 +1469,7 @@ CONTAINS
       DO ivar = 1, 8
          CALL mpi_bcast (DEF_forcing%fprefix(ivar)           ,256 ,mpi_character ,p_address_master ,p_comm_glb ,p_err)
          CALL mpi_bcast (DEF_forcing%vname(ivar)             ,256 ,mpi_character ,p_address_master ,p_comm_glb ,p_err)
+         CALL mpi_bcast (DEF_forcing%timelog(ivar)           ,256 ,mpi_character ,p_address_master ,p_comm_glb ,p_err)
          CALL mpi_bcast (DEF_forcing%tintalgo(ivar)          ,256 ,mpi_character ,p_address_master ,p_comm_glb ,p_err)
       ENDDO
       CALL mpi_bcast (DEF_forcing%CBL_fprefix                ,256 ,mpi_character ,p_address_master ,p_comm_glb ,p_err)

--- a/share/MOD_Namelist.F90
+++ b/share/MOD_Namelist.F90
@@ -58,7 +58,7 @@ MODULE MOD_Namelist
 ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
    character(len=256) :: SITE_fsrfdata   = 'null'
-   
+
    real(r8) :: SITE_lon_location = 113.5897
    real(r8) :: SITE_lat_location = 22.3507
 
@@ -141,6 +141,7 @@ MODULE MOD_Namelist
    logical :: USE_srfdata_from_3D_gridded_data = .false.
 
    ! ----- land cover data year (for static land cover, i.e. non-LULCC) -----
+   ! NOTE: Please check the LC data year range available
    integer :: DEF_LC_YEAR  = 2005
 
    ! ----- Subgrid scheme -----
@@ -174,6 +175,10 @@ MODULE MOD_Namelist
 ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ! ----- Part 7: Leaf Area Index -----
 ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+   ! NOTE: Please check the LAI data year range available
+   integer :: DEF_LAI_START_YEAR = 2000
+   integer :: DEF_LAI_END_YEAR   = 2020
 
    ! add by zhongwang wei @ sysu 2021/12/23
    ! To allow read satellite observed LAI
@@ -856,6 +861,8 @@ CONTAINS
       DEF_Interception_scheme,                & !add by zhongwang wei @ sysu 2022/05/23
       DEF_SSP,                                & !add by zhongwang wei @ sysu 2023/02/07
 
+      DEF_LAI_START_YEAR,                     &
+      DEF_LAI_END_YEAR,                       &
       DEF_LAI_CHANGE_YEARLY,                  &
       DEF_USE_LAIFEEDBACK,                    & !add by Xingjie Lu, use for updating LAI with leaf carbon
       DEF_USE_IRRIGATION,                     & !use irrigation
@@ -1169,6 +1176,10 @@ CONTAINS
 
 #ifdef LULCC
 
+         write(*,*) '                  *****                  '
+         write(*,*) 'Warning: The LULCC data is provided for years 2000 to 2020 right now! '
+         write(*,*) 'Please make sure the year range you set is suitable. '
+
 #if (defined LULC_USGS || defined BGC)
          write(*,*) '                  *****                  '
          write(*,*) 'Fatal ERROR: LULCC is not supported for LULC_USGS/BGC at present. STOP! '
@@ -1192,8 +1203,8 @@ CONTAINS
          !write(*,*) '                  *****                  '
          !write(*,*) 'Fatal ERROR: LULCC is not supported for LULC_IGBP_PC/URBAN at present. STOP! '
          !write(*,*) 'It is coming soon. '
-         ![update] 24/10/2023: right now IGBP/PFT/PC and Urban are all supported.
          !CALL CoLM_stop ()
+         ![update] 24/10/2023: right now IGBP/PFT/PC and Urban are all supported.
 #endif
 
 #if (defined SinglePoint)
@@ -1203,6 +1214,12 @@ CONTAINS
          CALL CoLM_stop ()
 #endif
 
+#endif
+
+#if (defined DEF_LAI_CHANGE_YEARLY)
+         write(*,*) '                  *****                  '
+         write(*,*) 'Warning: The LAI data is provided for years 2000 to 2020 right now! '
+         write(*,*) 'Any year before 2000 or after 2020 will be treated as 2000 or 2020. '
 #endif
 
 
@@ -1312,6 +1329,8 @@ CONTAINS
       CALL mpi_bcast (DEF_SOLO_PFT                           ,1   ,mpi_logical   ,p_address_master ,p_comm_glb ,p_err)
       CALL mpi_bcast (DEF_SUBGRID_SCHEME                     ,256 ,mpi_character ,p_address_master ,p_comm_glb ,p_err)
 
+      CALL mpi_bcast (DEF_LAI_START_YEAR                     ,1   ,mpi_integer   ,p_address_master ,p_comm_glb ,p_err)
+      CALL mpi_bcast (DEF_LAI_END_YEAR                       ,1   ,mpi_integer   ,p_address_master ,p_comm_glb ,p_err)
       CALL mpi_bcast (DEF_LAI_CHANGE_YEARLY                  ,1   ,mpi_logical   ,p_address_master ,p_comm_glb ,p_err)
 
       ! 05/2023, added by Xingjie lu
@@ -1804,7 +1823,7 @@ CONTAINS
       CALL sync_hist_vars_one (DEF_hist_vars%discharge   , set_defaults)
       CALL sync_hist_vars_one (DEF_hist_vars%wdsrf_hru   , set_defaults)
       CALL sync_hist_vars_one (DEF_hist_vars%veloc_hru   , set_defaults)
-      
+
       CALL sync_hist_vars_one (DEF_hist_vars%sensors     , set_defaults)
 
    END SUBROUTINE sync_hist_vars


### PR DESCRIPTION
    -add(MOD_Namelist.F90,MOD_UserSpecifiedForcing.F90):
        add time log flag for forcing: instant, forward, and backward.

    -mod(MOD_Forcing.F90):
        add corresponding code to deal with backward/foreward flag,
        especially for solar radiation.

    -add(run/forcing/*.nml):
        add timelog flag to manifest the time log for each variable.
          Flags available: instant, forward, backward    

    -add(Aggregation_LAI.F90,Aggregation_Urban.F90):
        only generate the available years' data.

    -add(MOD_LAIReadin.F90,MOD_Urban_LAIReadin.F90):
        only read the available years' data.

    -add(MOD_Namelist.F90):
        add the LAI year range namelist and give some warning info.

    -mod(mksrfdata/MOD_SingleSrfdata.F90,MOD_LandUrban.F90,Aggregation_Urban.F90):
        make surface data to output building H/L data.

    -mod(mkinidata/MOD_Initialize.F90,MOD_UrbanIniTimeVariable.F90,MOD_UrbanReadin.F90):
        corresponding modification in making initial data.

    -mod(URBAN/*.F90):
        change H/W to H/R in related files.

    -add(MOD_Namelist.F90):
        add namelist DEF_USE_CANYON_HWR. 'true' is for needing a transfer
        from H/W to H/L.
   
    -fix(MOD_LeafTemperature.F90,MOD_LeafTemperaturePC.F90,MOD_Urban_Flux.F90):
        add 'hvap' in the Eq. to calculate the change in heat fluxes from leaf (dele).

    The below by @Wenzong Dong:
    -fix(MOD_Urban_LAIReadin.F90): fix bug of missing right parenthesis
    -fix(MOD_Urban_Vars_TimeInvariants.F90): change HWR to HLR
    -fix(MOD_SingleSrfdata.F90): fix bug of 'elvstd', it is only used if DEF_USE_Forcing_Downscaling is true
    -add(MOD_SingleSrfdata.F90): add hlr calculating use lambda_w

    -fix(MOD_Thermal.F90):
        A bug fix for soil resistance calculation for the 1st step.
        Initialize rss for LP92, set rss = 1.0. [Report by @Zhuo Liu]

    -mod(MOD_CanopyLayerProfile.F90):
        remove 'abort', change to return. This case hardly happens.
        Basically, it will not affect the simulation so much.
