### PR TITLE
Add options for reference height setting: absolute or relative. Note: Changes may be needed for forcing nml files @Zhongwang Wei.

### DIFF
--- a/main/MOD_Forcing.F90
+++ b/main/MOD_Forcing.F90
@@ -487,7 +487,7 @@ CONTAINS
                         cosz = orb_coszen(calday, gforc%rlon(ilon), gforc%rlat(ilat))
                         cosz = max(0.001, cosz)
                         ! 10/24/2024, yuan: deal with time log with backward or foreward
-                        IF (timelog(ivar) == 'foreward') THEN
+                        IF (trim(timelog(ivar)) == 'foreward') THEN
                            forcn(ivar)%blk(ib,jb)%val(i,j) = &
                               cosz / avgcos%blk(ib,jb)%val(i,j) * forcn_LB(ivar)%blk(ib,jb)%val(i,j)
                         ELSE

--- a/main/MOD_GroundFluxes.F90
+++ b/main/MOD_GroundFluxes.F90
@@ -32,11 +32,12 @@ CONTAINS
 ! Original author : Yongjiu Dai, 09/15/1999; 08/30/2002
 !
 ! REVISIONS:
-! Hua Yuan, 09/2019: removed sigf to be consistant with PFT runs, removed fsena,
-!                    fevpa, renamed z0ma to z0m
-! Shaofeng Liu, 05/2023: add option to call moninobuk_leddy, the LargeEddy
-!                        surface turbulence scheme (LZD2022);
-!                        make a proper update of um.
+! 09/2019, Hua Yuan: removed sigf to be consistant with PFT runs, removed
+!          fsena, fevpa, renamed z0ma to z0m.
+!
+! 05/2023, Shaofeng Liu: add option to call moninobuk_leddy, the LargeEddy
+!          surface turbulence scheme (LZD2022); make a proper update of um.
+!
 !=======================================================================
 
    USE MOD_Precision
@@ -44,6 +45,7 @@ CONTAINS
    USE MOD_FrictionVelocity
    USE mod_namelist, only: DEF_USE_CBL_HEIGHT,DEF_RSS_SCHEME
    USE MOD_TurbulenceLEddy
+
    IMPLICIT NONE
 
 !----------------------- Dummy argument --------------------------------

--- a/main/MOD_LeafTemperature.F90
+++ b/main/MOD_LeafTemperature.F90
@@ -105,6 +105,7 @@ CONTAINS
    USE MOD_CanopyLayerProfile
    USE MOD_TurbulenceLEddy
    USE MOD_AssimStomataConductance
+   USE MOD_UserSpecifiedForcing, only: HEIGHT_mode
    USE MOD_Vars_TimeInvariants, only: patchclass
    USE MOD_Const_LC, only: z0mr, displar
    USE MOD_PlantHydraulic, only :PlantHydraulicStress_twoleaf, getvegwp_twoleaf
@@ -304,6 +305,9 @@ CONTAINS
 
    real(r8) :: &
         displa,     &! displacement height [m]
+        hu_,        &! adjusted observational height of wind [m]
+        ht_,        &! adjusted observational height of temperature [m]
+        hq_,        &! adjusted observational height of humidity [m]
         zldis,      &! reference height "minus" zero displacement heght [m]
         zii,        &! convective boundary layer height [m]
         z0mv,       &! roughness length, momentum [m]
@@ -518,7 +522,23 @@ CONTAINS
       dth = thm - taf
       dqh = qm  - qaf
       dthv  = dth*(1.+0.61*qm) + 0.61*th*dqh
-      zldis = hu - displa
+
+      hu_ = hu; ht_ = ht; hq_ = hq;
+
+      IF (trim(HEIGHT_mode) == 'absolute') THEN
+#ifndef SingPoint
+         ! to ensure the obs height >= htop+10.
+         hu_ = max(htop+10., hu)
+         ht_ = max(htop+10., ht)
+         hq_ = max(htop+10., hq)
+#endif
+      ELSE ! relative height
+         hu_ = htop + hu
+         ht_ = htop + ht
+         hq_ = htop + hq
+      ENDIF
+
+      zldis = hu_ - displa
 
       IF(zldis <= 0.0) THEN
          write(6,*) 'the obs height of u less than the zero displacement heght'
@@ -550,11 +570,11 @@ CONTAINS
 ! Evaluate stability-dependent variables using moz from prior iteration
          IF (rd_opt == 3) THEN
             IF (DEF_USE_CBL_HEIGHT) THEN
-              CALL moninobukm_leddy(hu,ht,hq,displa,z0mv,z0hv,z0qv,obu,um, &
+              CALL moninobukm_leddy(hu_,ht_,hq_,displa,z0mv,z0hv,z0qv,obu,um, &
                                     displasink,z0mv,hpbl,ustar,fh2m,fq2m, &
                                     htop,fmtop,fm,fh,fq,fht,fqt,phih)
             ELSE
-              CALL moninobukm(hu,ht,hq,displa,z0mv,z0hv,z0qv,obu,um, &
+              CALL moninobukm(hu_,ht_,hq_,displa,z0mv,z0hv,z0qv,obu,um, &
                               displasink,z0mv,ustar,fh2m,fq2m, &
                               htop,fmtop,fm,fh,fq,fht,fqt,phih)
             ENDIF
@@ -564,10 +584,10 @@ CONTAINS
             raw = 1./(vonkar/(fq-fqt)*ustar)
          ELSE
             IF (DEF_USE_CBL_HEIGHT) THEN
-               CALL moninobuk_leddy(hu,ht,hq,displa,z0mv,z0hv,z0qv,obu,um,hpbl, &
+               CALL moninobuk_leddy(hu_,ht_,hq_,displa,z0mv,z0hv,z0qv,obu,um,hpbl, &
                                     ustar,fh2m,fq2m,fm10m,fm,fh,fq)
             ELSE
-               CALL moninobuk(hu,ht,hq,displa,z0mv,z0hv,z0qv,obu,um,&
+               CALL moninobuk(hu_,ht_,hq_,displa,z0mv,z0hv,z0qv,obu,um,&
                               ustar,fh2m,fq2m,fm10m,fm,fh,fq)
             ENDIF
             ! Aerodynamic resistance
@@ -918,7 +938,7 @@ ENDIF
            um = max(ur,.1)
          ELSE
            IF (DEF_USE_CBL_HEIGHT) THEN !//TODO: Shaofeng, 2023.05.18
-             zii = max(5.*hu,hpbl)
+             zii = max(5.*hu_,hpbl)
            ENDIF !//TODO: Shaofeng, 2023.05.18
            wc = (-grav*ustar*thvstar*zii/thv)**(1./3.)
           wc2 = beta*beta*(wc*wc)

--- a/main/MOD_UserSpecifiedForcing.F90
+++ b/main/MOD_UserSpecifiedForcing.F90
@@ -45,6 +45,8 @@ MODULE MOD_UserSpecifiedForcing
    character(len=256) :: dataset
 
    logical  :: solarin_all_band   ! whether solar radiation in all bands is available
+
+   character(len=256) :: HEIGHT_mode ! observation height mode
    real(r8) :: HEIGHT_V           ! observation height of wind speed
    real(r8) :: HEIGHT_T           ! observation height of air temperature
    real(r8) :: HEIGHT_Q           ! observation height of specific humidity
@@ -110,6 +112,7 @@ CONTAINS
       allocate (tintalgo (NVAR))
 
       solarin_all_band = DEF_forcing%solarin_all_band ! whether solar radiation in all bands is available
+      HEIGHT_mode      = DEF_forcing%HEIGHT_mode      ! observation height mode
       HEIGHT_V         = DEF_forcing%HEIGHT_V         ! observation height of wind speed
       HEIGHT_T         = DEF_forcing%HEIGHT_T         ! observation height of air temperature
       HEIGHT_Q         = DEF_forcing%HEIGHT_Q         ! observation height of specific humidity

--- a/main/URBAN/MOD_Urban_Flux.F90
+++ b/main/URBAN/MOD_Urban_Flux.F90
@@ -111,6 +111,7 @@ CONTAINS
    USE MOD_Const_Physical, only: cpair,vonkar,grav,hvap
    USE MOD_FrictionVelocity
    USE MOD_CanopyLayerProfile
+   USE MOD_UserSpecifiedForcing, only: HEIGHT_mode
    IMPLICIT NONE
 
 !----------------------- Dummy argument --------------------------------
@@ -262,9 +263,9 @@ CONTAINS
         numlay         ! available layer number
 
    real(r8) :: &
-        huu,          &! observational height of wind [m]
-        htu,          &! observational height of temperature [m]
-        hqu,          &! observational height of humidity [m]
+        hu_,          &! adjusted observational height of wind [m]
+        ht_,          &! adjusted observational height of temperature [m]
+        hq_,          &! adjusted observational height of humidity [m]
         ktop,         &! K value at a specific height
         utop,         &! u value at a specific height
         fht,          &! integral of profile function for heat at the top layer
@@ -509,12 +510,22 @@ CONTAINS
       dqh  =  qm - qaf(2)
       dthv = dth*(1.+0.61*qm) + 0.61*th*dqh
 
-      ! to ensure the obs height >= hroof+10.
-      huu = max(hroof+10., hu)
-      htu = max(hroof+10., ht)
-      hqu = max(hroof+10., hq)
+      hu_ = hu; ht_ = ht; hq_ = hq;
 
-      zldis = huu - displa
+      IF (trim(HEIGHT_mode) == 'absolute') THEN
+#ifndef SingPoint
+         ! to ensure the obs height >= hroof+10.
+         hu_ = max(hroof+10., hu)
+         ht_ = max(hroof+10., ht)
+         hq_ = max(hroof+10., hq)
+#endif
+      ELSE ! relative height
+         hu_ = hroof + hu
+         ht_ = hroof + ht
+         hq_ = hroof + hq
+      ENDIF
+
+      zldis = hu_ - displa
 
       IF (zldis <= 0.0) THEN
          write(6,*) 'the obs height of u less than the zero displacement heght'
@@ -538,7 +549,7 @@ CONTAINS
 
          !NOTE: displat=hroof, z0mt=0, are set for roof
          ! fmtop is calculated at the same height of fht, fqt
-         CALL moninobukm(huu,htu,hqu,displa,z0m,z0h,z0q,obu,um, &
+         CALL moninobukm(hu_,ht_,hq_,displa,z0m,z0h,z0q,obu,um, &
               hroof,0.,ustar,fh2m,fq2m,hroof,fmtop,fm,fh,fq,fht,fqt,phih)
 
 ! Aerodynamic resistance
@@ -885,6 +896,7 @@ CONTAINS
    USE MOD_FrictionVelocity
    USE MOD_CanopyLayerProfile
    USE MOD_AssimStomataConductance
+   USE MOD_UserSpecifiedForcing, only: HEIGHT_mode
    IMPLICIT NONE
 
 !-----------------------Arguments---------------------------------------
@@ -1150,9 +1162,9 @@ CONTAINS
         numlay         ! available layer number
 
    real(r8) :: &
-        huu,          &! observational height of wind [m]
-        htu,          &! observational height of temperature [m]
-        hqu,          &! observational height of humidity [m]
+        hu_,          &! adjusted observational height of wind [m]
+        ht_,          &! adjusted observational height of temperature [m]
+        hq_,          &! adjusted observational height of humidity [m]
         ktop,         &! K value at a specific height
         utop,         &! u value at a specific height
         fht,          &! integral of profile function for heat at the top layer
@@ -1487,12 +1499,22 @@ CONTAINS
       dqh =  qm - qaf(2)
       dthv = dth*(1.+0.61*qm) + 0.61*th*dqh
 
-      ! To ensure the obs height >= hroof+10.
-      huu = max(hroof+10., hu)
-      htu = max(hroof+10., ht)
-      hqu = max(hroof+10., hq)
+      hu_ = hu; ht_ = ht; hq_ = hq;
 
-      zldis = huu - displa
+      IF (trim(HEIGHT_mode) == 'absolute') THEN
+#ifndef SingPoint
+         ! to ensure the obs height >= hroof+10.
+         hu_ = max(hroof+10., hu)
+         ht_ = max(hroof+10., ht)
+         hq_ = max(hroof+10., hq)
+#endif
+      ELSE ! relative height
+         hu_ = hroof + hu
+         ht_ = hroof + ht
+         hq_ = hroof + hq
+      ENDIF
+
+      zldis = hu_ - displa
 
       IF (zldis <= 0.0) THEN
          write(6,*) 'the obs height of u less than the zero displacement heght'
@@ -1517,7 +1539,7 @@ CONTAINS
 !-----------------------------------------------------------------------
 ! Evaluate stability-dependent variables using moz from prior iteration
 
-         CALL moninobukm(huu,htu,hqu,displa,z0m,z0h,z0q,obu,um, &
+         CALL moninobukm(hu_,ht_,hq_,displa,z0m,z0h,z0q,obu,um, &
               hroof,0.,ustar,fh2m,fq2m,hroof,fmtop,fm,fh,fq,fht,fqt,phih)
 
 ! Aerodynamic resistance

--- a/run/forcing/ERA5.nml
+++ b/run/forcing/ERA5.nml
@@ -5,8 +5,8 @@
 
    DEF_forcing%dataset           = 'ERA5'
    DEF_forcing%solarin_all_band  = .true.
-   DEF_forcing%HEIGHT_mode       = 'absolute'  ! 'absolute' height to tree/building or
-                                               ! 'relative' height to ground surface
+   DEF_forcing%HEIGHT_mode       = 'absolute'  ! 'absolute' height to ground surface or
+                                               ! 'relative' height to tree/building
                                                ! if not speficied, default is absolute
    DEF_forcing%HEIGHT_V          = 50.0
    DEF_forcing%HEIGHT_T          = 40.0

--- a/run/forcing/ERA5.nml
+++ b/run/forcing/ERA5.nml
@@ -5,6 +5,9 @@
 
    DEF_forcing%dataset           = 'ERA5'
    DEF_forcing%solarin_all_band  = .true.
+   DEF_forcing%HEIGHT_mode       = 'absolute'  ! 'absolute' height to tree/building or
+                                               ! 'relative' height to ground surface
+                                               ! if not speficied, default is absolute
    DEF_forcing%HEIGHT_V          = 50.0
    DEF_forcing%HEIGHT_T          = 40.0
    DEF_forcing%HEIGHT_Q          = 40.0

--- a/run/forcing/ERA5.nml
+++ b/run/forcing/ERA5.nml
@@ -6,7 +6,7 @@
    DEF_forcing%dataset           = 'ERA5'
    DEF_forcing%solarin_all_band  = .true.
    DEF_forcing%HEIGHT_mode       = 'absolute'  ! 'absolute' height to ground surface or
-                                               ! 'relative' height to tree/building
+                                               ! 'relative' height to tree/building top
                                                ! if not speficied, default is absolute
    DEF_forcing%HEIGHT_V          = 50.0
    DEF_forcing%HEIGHT_T          = 40.0

--- a/run/forcing/ERA5LAND.nml
+++ b/run/forcing/ERA5LAND.nml
@@ -5,9 +5,12 @@
 
    DEF_forcing%dataset            = 'ERA5LAND'
    DEF_forcing%solarin_all_band   = .true.
-   DEF_forcing%HEIGHT_V           = 50.0
-   DEF_forcing%HEIGHT_T           = 40.
-   DEF_forcing%HEIGHT_Q           = 40.
+   DEF_forcing%HEIGHT_mode        = 'relative'  ! 'absolute' height to tree/building or
+                                                ! 'relative' height to ground surface
+                                                ! if not speficied, default is absolute
+   DEF_forcing%HEIGHT_V           = 10.0
+   DEF_forcing%HEIGHT_T           = 10.0
+   DEF_forcing%HEIGHT_Q           = 10.0
 
    DEF_forcing%has_missing_value  = .true.
    DEF_forcing%missing_value_name = 'missing_value'

--- a/run/forcing/ERA5LAND.nml
+++ b/run/forcing/ERA5LAND.nml
@@ -6,7 +6,7 @@
    DEF_forcing%dataset            = 'ERA5LAND'
    DEF_forcing%solarin_all_band   = .true.
    DEF_forcing%HEIGHT_mode        = 'relative'  ! 'absolute' height to ground surface or
-                                                ! 'relative' height to tree/building
+                                                ! 'relative' height to tree/building top
                                                 ! if not speficied, default is absolute
    DEF_forcing%HEIGHT_V           = 10.0
    DEF_forcing%HEIGHT_T           = 10.0

--- a/run/forcing/ERA5LAND.nml
+++ b/run/forcing/ERA5LAND.nml
@@ -5,8 +5,8 @@
 
    DEF_forcing%dataset            = 'ERA5LAND'
    DEF_forcing%solarin_all_band   = .true.
-   DEF_forcing%HEIGHT_mode        = 'relative'  ! 'absolute' height to tree/building or
-                                                ! 'relative' height to ground surface
+   DEF_forcing%HEIGHT_mode        = 'relative'  ! 'absolute' height to ground surface or
+                                                ! 'relative' height to tree/building
                                                 ! if not speficied, default is absolute
    DEF_forcing%HEIGHT_V           = 10.0
    DEF_forcing%HEIGHT_T           = 10.0

--- a/share/MOD_Namelist.F90
+++ b/share/MOD_Namelist.F90
@@ -356,6 +356,7 @@ MODULE MOD_Namelist
 
       character(len=256) :: dataset            = 'CRUNCEP'
       logical            :: solarin_all_band   = .true.
+      character(len=256) :: HEIGHT_mode        = 'absolute'
       real(r8)           :: HEIGHT_V           = 100.0
       real(r8)           :: HEIGHT_T           = 50.
       real(r8)           :: HEIGHT_Q           = 50.
@@ -1443,6 +1444,7 @@ CONTAINS
 
       CALL mpi_bcast (DEF_forcing%dataset                    ,256 ,mpi_character ,p_address_master ,p_comm_glb ,p_err)
       CALL mpi_bcast (DEF_forcing%solarin_all_band           ,1   ,mpi_logical   ,p_address_master ,p_comm_glb ,p_err)
+      CALL mpi_bcast (DEF_forcing%HEIGHT_mode                ,256 ,mpi_character ,p_address_master ,p_comm_glb ,p_err)
       CALL mpi_bcast (DEF_forcing%HEIGHT_V                   ,1   ,mpi_real8     ,p_address_master ,p_comm_glb ,p_err)
       CALL mpi_bcast (DEF_forcing%HEIGHT_T                   ,1   ,mpi_real8     ,p_address_master ,p_comm_glb ,p_err)
       CALL mpi_bcast (DEF_forcing%HEIGHT_Q                   ,1   ,mpi_real8     ,p_address_master ,p_comm_glb ,p_err)


### PR DESCRIPTION
    -add(MOD_Namelist.F90,MOD_UserSpecifiedForcing.F90):
        add namelist HEIGHT_mode. 'absolute' height to tree/building or
        'relative' height to ground surface

    -add(ERA5.nml,ERA5LAND.nml):
        examples for setting HEIGHT_mode. 'absolute' height to tree/building
        or 'relative' height to ground surface.
        NOTE: If not speficied, default is absolute.

    -mod(MOD_LeafTemperature.F90,MOD_LeafTemperaturePC.F90,MOD_Urban_Flux.F90):
        read the namelist HEIGHT_mode, and add corresponding codes to adjust
        the reference height according to user's option.