### PR TITLE
1) restore soil resistance for CB soil; 2) skip snow optical process if SNICAR is not defined; 3) optimazition for output info; 4) for single point case, reading soil texture from global dataset.

### DIFF
--- a/main/CoLM.F90
+++ b/main/CoLM.F90
@@ -278,8 +278,10 @@ PROGRAM CoLM
       CALL READ_TimeVariables (jdate, lc_year, casename, dir_restart)
 
       ! Read in SNICAR optical and aging parameters
-      CALL SnowOptics_init( DEF_file_snowoptics ) ! SNICAR optical parameters
-      CALL SnowAge_init( DEF_file_snowaging )     ! SNICAR aging   parameters
+      IF (DEF_USE_SNICAR) THEN
+         CALL SnowOptics_init( DEF_file_snowoptics ) ! SNICAR optical parameters
+         CALL SnowAge_init( DEF_file_snowaging )     ! SNICAR aging   parameters
+      ENDIF
 
       ! ----------------------------------------------------------------------
       doalb = .true.
@@ -443,7 +445,7 @@ PROGRAM CoLM
          ! Write out the model variables for restart run and the histroy file
          ! ----------------------------------------------------------------------
          CALL hist_out (idate, deltim, itstamp, etstamp, ptstamp, dir_hist, casename)
-         
+
          CALL CheckEquilibrium (idate, deltim, itstamp, dir_hist, casename)
 
          ! DO land USE and land cover change simulation
@@ -535,7 +537,9 @@ PROGRAM CoLM
 #endif
 
 #ifdef CoLMDEBUG
-         CALL print_VSF_iteration_stat_info ()
+         IF (DEF_USE_VariablySaturatedFlow) THEN
+            CALL print_VSF_iteration_stat_info ()
+         ENDIF
 #endif
 
 

--- a/main/MOD_Albedo.F90
+++ b/main/MOD_Albedo.F90
@@ -267,7 +267,7 @@ ENDIF
 !  (based on new snow level state, after SnowFilter is rebuilt.
 !  NEEDS TO BE AFTER SnowFiler is rebuilt, otherwise there
 !  can be zero snow layers but an active column in filter)
-
+IF (DEF_USE_SNICAR) THEN
       snwcp_ice  = 0.0     !excess precipitation due to snow capping [kg m-2 s-1]
       do_capsnow = .false. !true => DO snow capping
 
@@ -292,7 +292,7 @@ ENDIF
            wliq_soisno (:0),wice_soisno(:0),&
            t_soisno    (:1),t_grnd         ,&
            forc_t          ,snw_rds         )
-
+ENDIF
 ! ----------------------------------------------------------------------
 
       lsai = lai + sai

--- a/main/MOD_LeafInterception.F90
+++ b/main/MOD_LeafInterception.F90
@@ -282,7 +282,7 @@ CONTAINS
             ENDIF
 
 #if(defined CoLMDEBUG)
-            IF (tex_rain+tex_snow+tti_rain+tti_snow-p0 > 1.e-10) THEN
+            IF (tex_rain+tex_snow+tti_rain+tti_snow-p0 > 1.e-10 .and. .not.DEF_VEG_SNOW) THEN
                write(6,*) 'tex_ + tti_ > p0 in interception code : '
             ENDIF
 #endif

--- a/mksrfdata/Aggregation_SoilTexture.F90
+++ b/mksrfdata/Aggregation_SoilTexture.F90
@@ -5,10 +5,10 @@ SUBROUTINE Aggregation_SoilTexture ( &
 
 ! ----------------------------------------------------------------------
 ! DESCRIPTION:
-! Aggregate soil texture class within a patch. 
+! Aggregate soil texture class within a patch.
 !
-! Use the USDA soil texture triangle (using the amount of sand, clay, and 
-! silt contents) to identify the soil texture in fine grid resolution and 
+! Use the USDA soil texture triangle (using the amount of sand, clay, and
+! silt contents) to identify the soil texture in fine grid resolution and
 ! then finding the major soil type in a patch by counting number of fine
 ! grids with each type of soil and adopting the major one.
 !
@@ -72,7 +72,9 @@ SUBROUTINE Aggregation_SoilTexture ( &
 
 #ifdef SinglePoint
       IF (USE_SITE_soilparameters) THEN
-         RETURN
+         ! Since the site soil texture is not available now, temporally
+         !RETURN
+         write(*,'(/, A)') 'Reading from global dataset ...'
       ENDIF
 #endif
 
@@ -86,7 +88,7 @@ SUBROUTINE Aggregation_SoilTexture ( &
          CALL aggregation_data_daemon (gland, data_i4_2d_in1 = soiltext)
 #endif
       ENDIF
-            
+
       IF (p_is_worker) THEN
 
          IF (numpatch > 0) allocate (soiltext_patches (numpatch))

--- a/mksrfdata/MOD_SingleSrfdata.F90
+++ b/mksrfdata/MOD_SingleSrfdata.F90
@@ -281,7 +281,8 @@ CONTAINS
          CALL ncio_read_serial (fsrfdata, 'soil_BA_beta          ', SITE_soil_BA_beta          )
 
          IF (DEF_Runoff_SCHEME == 3) THEN ! for Simple VIC
-            CALL ncio_read_serial (fsrfdata, 'soil_texture       ', SITE_soil_texture          )
+            ! reading from global dataset currently
+            !CALL ncio_read_serial (fsrfdata, 'soil_texture       ', SITE_soil_texture          )
          ENDIF
       ENDIF
 
@@ -464,7 +465,7 @@ ENDIF
 #endif
          CALL ncio_read_serial (fsrfdata, 'soil_BA_alpha         ', SITE_soil_BA_alpha         )
          CALL ncio_read_serial (fsrfdata, 'soil_BA_beta          ', SITE_soil_BA_beta          )
-         
+
          IF (DEF_Runoff_SCHEME == 3) THEN ! for Simple VIC
             CALL ncio_read_serial (fsrfdata, 'soil_texture       ', SITE_soil_texture          )
          ENDIF
@@ -647,7 +648,7 @@ ENDIF
       CALL ncio_write_serial (fsrfdata, 'soil_BA_beta ', SITE_soil_BA_beta , 'soil')
       CALL ncio_put_attr     (fsrfdata, 'soil_BA_alpha', 'source', source)
       CALL ncio_put_attr     (fsrfdata, 'soil_BA_beta ', 'source', source)
-      
+
       IF (DEF_Runoff_SCHEME == 3) THEN ! for Simple VIC
          CALL ncio_write_serial (fsrfdata, 'soil_texture ', SITE_soil_texture)
          CALL ncio_put_attr     (fsrfdata, 'soil_texture ', 'source', source)

--- a/share/MOD_Namelist.F90
+++ b/share/MOD_Namelist.F90
@@ -1103,10 +1103,11 @@ CONTAINS
          DEF_USE_PC   = .false.
          DEF_FAST_PC  = .false.
          DEF_SOLO_PFT = .false.
-
+#ifdef vanGenuchten_Mualem_SOIL_MODEL
          write(*,*) '                  *****                  '
-         write(*,*) 'Note: Soil resistance is automaticlly turned off for USGS|IGBP scheme.'
+         write(*,*) 'Note: Soil resistance is automaticlly turned off for VG soil + USGS|IGBP scheme.'
          DEF_RSS_SCHEME = 0
+#endif
 #endif
 
 #ifdef LULC_IGBP_PFT


### PR DESCRIPTION
    -mod(MOD_Namelist.F90):
        restore soil resistance setting for CB soil, only set no RSS for VG.

    -mod(MOD_Albedo.F90):
        skip snow optical process when SNICAR is not defined.

    -mod(CoLM.F90,MOD_LeafInterception.F90):
        optimazition for output info.

    -mod(Aggregation_SoilTexture.F90):
        read soil texture from global dataset for single point case.