### PR TITLE
1) Add soil wf_clay and wf_om for single poing run for urban model; 2) Optimize urban single point code to be consistent with natural single point [by @Wenzong Dong].

### DIFF
--- a/main/CoLM.F90
+++ b/main/CoLM.F90
@@ -54,7 +54,7 @@ PROGRAM CoLM
 #ifdef CATCHMENT
    USE MOD_HRUVector
 #endif
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
    USE MOD_CaMa_colmCaMa ! whether cama-flood is used
 #endif
 #ifdef SinglePoint
@@ -314,7 +314,7 @@ PROGRAM CoLM
 
       CALL CheckEqb_init ()
 
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
       CALL colm_CaMa_init !initialize CaMa-Flood
 #endif
 
@@ -452,7 +452,7 @@ PROGRAM CoLM
          CALL lateral_flow (deltim)
 #endif
 
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
          CALL colm_CaMa_drv(idate(3)) ! run CaMa-Flood
 #endif
 
@@ -491,7 +491,7 @@ PROGRAM CoLM
 
          ! Get leaf area index
          ! ----------------------------------------------------------------------
-#if(defined DYN_PHENOLOGY)
+#if (defined DYN_PHENOLOGY)
          ! Update once a day
          dolai = .false.
          Julian_1day = int(calendarday(jdate)-1)/1*1 + 1
@@ -540,7 +540,7 @@ PROGRAM CoLM
 #else
             CALL WRITE_TimeVariables (jdate, lc_year,  casename, dir_restart)
 #endif
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
             IF (p_is_master) THEN
                CALL colm_cama_write_restart (jdate, lc_year,  casename, dir_restart)
             ENDIF
@@ -607,7 +607,7 @@ PROGRAM CoLM
       CALL mpi_barrier (p_comm_glb, p_err)
 #endif
 
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
       CALL colm_cama_exit ! finalize CaMa-Flood
 #endif
 

--- a/main/CoLMDRIVER.F90
+++ b/main/CoLMDRIVER.F90
@@ -96,7 +96,7 @@ SUBROUTINE CoLMDRIVER (idate,deltim,dolai,doalb,dosst,oro)
                dksatf(1:,i),    dkdry(1:,i),     BA_alpha(1:,i),  BA_beta(1:,i),   &
                rootfr(1:,m),    lakedepth(i),    dz_lake(1:,i),   topostd(i),      &
                BVIC(i),                                                            &
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
              ! flood variables [mm, m2/m2, mm/s, mm/s]
                flddepth_cama(i),fldfrc_cama(i),  fevpg_fld(i),    finfg_fld(i),    &
 #endif
@@ -184,7 +184,7 @@ SUBROUTINE CoLMDRIVER (idate,deltim,dolai,doalb,dosst,oro)
          ENDIF
 
 
-#if(defined BGC)
+#if (defined BGC)
          IF(patchtype(i) .eq. 0)THEN
             !
             !               ***** Call CoLM BGC model *****
@@ -292,7 +292,7 @@ SUBROUTINE CoLMDRIVER (idate,deltim,dolai,doalb,dosst,oro)
             mss_bcpho(:,i)  ,mss_bcphi(:,i)  ,mss_ocpho(:,i)  ,mss_ocphi(:,i)  ,&
             mss_dst1(:,i)   ,mss_dst2(:,i)   ,mss_dst3(:,i)   ,mss_dst4(:,i)   ,&
 
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
           ! flood variables [mm, m2/m2, mm/s, mm/s]
             flddepth_cama(i),fldfrc_cama(i)  ,fevpg_fld(i)    ,finfg_fld(i)    ,&
 #endif

--- a/main/CoLMMAIN.F90
+++ b/main/CoLMMAIN.F90
@@ -19,7 +19,7 @@ SUBROUTINE CoLMMAIN ( &
            hksati,       csol,         k_solids,     dksatu,       &
            dksatf,       dkdry,        BA_alpha,     BA_beta,      &
            rootfr,       lakedepth,    dz_lake,      topostd, BVIC,&
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
            ! add flood depth, flood fraction, flood evaporation and
            ! flood re-infiltration
            flddepth,     fldfrc,       fevpg_fld,    qinfl_fld,    &
@@ -165,7 +165,7 @@ SUBROUTINE CoLMMAIN ( &
    USE MOD_Namelist, only: DEF_Interception_scheme, DEF_USE_VariablySaturatedFlow, &
                            DEF_USE_PLANTHYDRAULICS, DEF_USE_IRRIGATION
    USE MOD_LeafInterception
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
    ! get flood depth [mm], flood fraction[0-1], flood evaporation [mm/s], flood inflow [mm/s]
    USE MOD_CaMa_colmCaMa, only: get_fldevp
    USE YOS_CMF_INPUT, only: LWINFILT,LWEVAP
@@ -310,7 +310,7 @@ SUBROUTINE CoLMMAIN ( &
         forc_hpbl   ,&! atmospheric boundary layer height [m]
         forc_aerdep(14)!atmospheric aerosol deposition data [kg/m/s]
 
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
    real(r8), intent(in)    :: fldfrc    !inundation fraction--> allow re-evaporation and infiltration![0-1]
    real(r8), intent(inout) :: flddepth  !inundation depth--> allow re-evaporation and infiltration![mm]
    real(r8), intent(out)   :: fevpg_fld !effective evaporation from inundation [mm/s]
@@ -547,7 +547,7 @@ SUBROUTINE CoLMMAIN ( &
    real(r8) :: wextra, t_rain, t_snow
    integer ps, pe, pc
 
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
    !add variables for flood evaporation [mm/s] and re-infiltration [mm/s] calculation.
    real(r8) :: kk
    real(r8) :: taux_fld    ! wind stress: E-W [kg/m/s**2]
@@ -660,7 +660,7 @@ SUBROUTINE CoLMMAIN ( &
 
          IF (patchtype == 0) THEN
 
-#if(defined LULC_USGS || defined LULC_IGBP)
+#if (defined LULC_USGS || defined LULC_IGBP)
             CALL LEAF_interception_wrap (deltim,dewmx,forc_us,forc_vs,chil,sigf,lai,sai,forc_t, tleaf,&
                       prc_rain,prc_snow,prl_rain,prl_snow,bifall,&
                       ldew,ldew_rain,ldew_snow,z0m,forc_hgt_u,pg_rain,pg_snow,qintr,qintr_rain,qintr_snow)
@@ -768,7 +768,7 @@ SUBROUTINE CoLMMAIN ( &
                  ssi               ,wimp              ,smpmin            ,zwt               ,&
                  wa                ,qcharge           ,&
 
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
              !add variables for flood depth [mm], flood fraction [0-1] and re-infiltration [mm/s] calculation.
                  flddepth          ,fldfrc            ,qinfl_fld         ,&
 #endif
@@ -796,7 +796,7 @@ SUBROUTINE CoLMMAIN ( &
                  rsur_ie           ,rnof              ,qinfl             ,ssi               ,&
                  pondmx            ,wimp              ,zwt               ,wdsrf             ,&
                  wa                ,wetwat            ,&
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
              !add variables for flood depth [mm], flood fraction [0-1] and re-infiltration [mm/s] calculation.
                  flddepth          ,fldfrc            ,qinfl_fld         ,&
 #endif
@@ -877,7 +877,7 @@ SUBROUTINE CoLMMAIN ( &
          ! energy balance
          ! ----------------------------------------
          zerr=errore
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
          IF (abs(errore) > .5) THEN
             write(6,*) 'Warning: energy balance violation ',errore,patchclass
          ENDIF
@@ -894,7 +894,7 @@ SUBROUTINE CoLMMAIN ( &
                endwb = endwb + wetwat
             ENDIF
          ENDIF
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
          IF (LWINFILT) THEN
             IF (patchtype == 0) THEN
                endwb=endwb - qinfl_fld*deltim
@@ -919,7 +919,7 @@ SUBROUTINE CoLMMAIN ( &
 
          xerr=errorw/deltim
 
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
          IF (abs(errorw) > 1.e-3) THEN
             IF     (patchtype == 0) THEN
                write(6,*) 'Warning: water balance violation in CoLMMAIN (soil) ', errorw
@@ -1094,7 +1094,7 @@ SUBROUTINE CoLMMAIN ( &
          errorw=(endwb-totwb)-(pg_rain+pg_snow-fevpa)*deltim
 #endif
 
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
          IF (DEF_USE_VariablySaturatedFlow) THEN
             IF (abs(errorw) > 1.e-3) THEN
                write(6,*) 'Warning: water balance violation in CoLMMAIN (land ice) ', errorw
@@ -1221,12 +1221,12 @@ SUBROUTINE CoLMMAIN ( &
 
 #else
          CALL external_lake( &
-               ! "in" arguments    
+               ! "in" arguments
                ! -------------------
-               deltim      ,patchlatr     ,patchlonr      ,bifall        ,& 
+               deltim      ,patchlatr     ,patchlonr      ,bifall        ,&
                forc_hgt_u  ,forc_hgt_t    ,forc_hgt_q     ,forc_us       ,&
                forc_vs     ,forc_t        ,forc_q         ,forc_rhoair   ,&
-               forc_psrf   ,forc_frl      ,sabg           ,forc_hpbl     ,& 
+               forc_psrf   ,forc_frl      ,sabg           ,forc_hpbl     ,&
                forc_sols   ,forc_soll     ,forc_solsd     ,forc_solld    ,&
                prc_rain    ,prl_rain      ,prc_snow       ,prl_snow      ,&
                t_precip    ,ipatch        ,&
@@ -1289,7 +1289,7 @@ SUBROUTINE CoLMMAIN ( &
          errorw = errorw + rnof * deltim
 #endif
 
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
          IF (DEF_USE_Dynamic_Lake) THEN
             IF (abs(errorw) > 1.e-3) THEN
                write(*,*) 'Warning: water balance violation in CoLMMAIN (lake) ', errorw
@@ -1349,7 +1349,7 @@ SUBROUTINE CoLMMAIN ( &
 !======================================================================
       ENDIF
 
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
       IF (LWEVAP) THEN
          IF ((flddepth .gt. 1.e-6).and.(fldfrc .gt. 0.05).and.patchtype == 0)THEN
             CALL get_fldevp (forc_hgt_u,forc_hgt_t,forc_hgt_q,&
@@ -1392,7 +1392,7 @@ SUBROUTINE CoLMMAIN ( &
       coszen = orb_coszen(calday,patchlonr,patchlatr)
 
       IF (patchtype <= 5) THEN   !LAND
-#if(defined DYN_PHENOLOGY)
+#if (defined DYN_PHENOLOGY)
          ! need to update lai and sai, fveg, green, they are done once in a day only
          IF (dolai) THEN
             CALL LAI_empirical(patchclass,nl_soil,rootfr,t_soisno(1:),lai,sai,fveg,green)
@@ -1407,7 +1407,7 @@ SUBROUTINE CoLMMAIN ( &
 
          IF (patchtype == 0) THEN
 
-#if(defined LULC_USGS || defined LULC_IGBP)
+#if (defined LULC_USGS || defined LULC_IGBP)
             CALL snowfraction (tlai(ipatch),tsai(ipatch),z0m,zlnd,scv,snowdp,wt,sigf,fsno)
             lai = tlai(ipatch)
             sai = tsai(ipatch) * sigf

--- a/main/HYDRO/MOD_Catch_SubsurfaceFlow.F90
+++ b/main/HYDRO/MOD_Catch_SubsurfaceFlow.F90
@@ -4,13 +4,13 @@
 MODULE MOD_Catch_SubsurfaceFlow
 !-------------------------------------------------------------------------------------
 ! DESCRIPTION:
-!   
+!
 !   Ground water lateral flow.
 !
 !   Ground water fluxes are calculated
 !   1. between elements
 !   2. between hydrological response units
-!   3. between patches inside one HRU  
+!   3. between patches inside one HRU
 !
 ! Created by Shupeng Zhang, May 2023
 !-------------------------------------------------------------------------------------
@@ -27,17 +27,17 @@ MODULE MOD_Catch_SubsurfaceFlow
    real(r8), allocatable :: lakedepth_elm(:)
    real(r8), allocatable :: riverdpth_elm(:)
    real(r8), allocatable :: wdsrf_elm    (:)
-    
+
    real(r8), parameter :: e_ice  = 6.0   ! soil ice impedance factor
-   
+
    ! anisotropy ratio of lateral/vertical hydraulic conductivity (unitless)
    ! for USDA soil texture class:
    ! 0: undefined
-   ! 1: clay;  2: silty clay;  3: sandy clay;   4: clay loam;   5: silty clay loam;   6: sandy clay loam; &    
+   ! 1: clay;  2: silty clay;  3: sandy clay;   4: clay loam;   5: silty clay loam;   6: sandy clay loam; &
    ! 7: loam;  8: silty loam;  9: sandy loam;  10: silt;       11: loamy sand;       12: sand
    real(r8), parameter :: raniso(0:12) = (/ 1., &
                                             48., 40., 28., 24., 20., 14., 12., 10., 4., 2., 3., 2. /)
-   
+
    ! -- neighbour variables --
    type(pointer_real8_1d), allocatable :: agwt_nb    (:)  ! ground water area (for patchtype <= 2) of neighbours [m^2]
    type(pointer_real8_1d), allocatable :: theta_a_nb (:)  ! saturated volume content [-]
@@ -48,7 +48,7 @@ MODULE MOD_Catch_SubsurfaceFlow
    type(pointer_real8_1d), allocatable :: lakedp_nb  (:)  ! lake depth of neighbour [m]
 
 CONTAINS
-   
+
    ! ----------
    SUBROUTINE subsurface_network_init ()
 
@@ -63,12 +63,12 @@ CONTAINS
    USE MOD_Catch_RiverLakeNetwork, only: lake_id, riverdpth
    USE MOD_Vars_TimeInvariants,    only: patchtype, lakedepth
    IMPLICIT NONE
-   
+
    integer :: ielm, inb, i, ihru, ps, pe, ipatch, ipxl
-   
+
    real(r8), allocatable :: agwt_b(:)
    real(r8), allocatable :: islake(:)
-   type(pointer_real8_1d), allocatable :: iswat_nb (:)  
+   type(pointer_real8_1d), allocatable :: iswat_nb (:)
 
    integer, allocatable :: eindex(:)
 
@@ -88,7 +88,7 @@ CONTAINS
       IF (allocated(eindex)) deallocate (eindex)
 
       IF (p_is_worker) THEN
-         
+
          IF (numelm > 0) allocate (lake_id_elm  (numelm))
          IF (numelm > 0) allocate (riverdpth_elm(numelm))
          IF (numelm > 0) allocate (lakedepth_elm(numelm))
@@ -129,7 +129,7 @@ CONTAINS
                lakedepth_elm(ielm) = sum(lakedepth(ps:pe) * elm_patch%subfrc(ps:pe))
             ENDIF
          ENDDO
-         
+
          CALL allocate_neighbour_data (agwt_nb   )
          CALL allocate_neighbour_data (theta_a_nb)
          CALL allocate_neighbour_data (zwt_nb    )
@@ -152,12 +152,12 @@ CONTAINS
                ENDIF
             ENDDO
          ENDIF
-         
+
          CALL retrieve_neighbour_data (lakedepth_elm, lakedp_nb)
-         
+
          CALL retrieve_neighbour_data (agwt_b, agwt_nb )
          CALL retrieve_neighbour_data (islake, iswat_nb)
-         
+
          DO ielm = 1, numelm
             DO inb = 1, elementneighbour(ielm)%nnb
                IF (elementneighbour(ielm)%glbindex(inb) > 0) THEN ! skip ocean neighbour
@@ -165,18 +165,18 @@ CONTAINS
                ENDIF
             ENDDO
          ENDDO
-         
+
          IF (allocated(agwt_b  )) deallocate(agwt_b  )
          IF (allocated(islake  )) deallocate(islake  )
          IF (allocated(iswat_nb)) deallocate(iswat_nb)
-         
+
       ENDIF
 
    END SUBROUTINE subsurface_network_init
 
    ! ---------
    SUBROUTINE subsurface_flow (deltime)
-      
+
    USE MOD_SPMD_Task
    USE MOD_UserDefFun
    USE MOD_Mesh
@@ -193,7 +193,7 @@ CONTAINS
    USE MOD_Hydro_SoilWater, only: soilwater_aquifer_exchange
 
    IMPLICIT NONE
-   
+
    real(r8), intent(in) :: deltime
 
    ! Local Variables
@@ -201,8 +201,8 @@ CONTAINS
 
    type(hillslope_network_type), pointer :: hrus
 
-   real(r8), allocatable :: theta_a_h (:) 
-   real(r8), allocatable :: zwt_h     (:) 
+   real(r8), allocatable :: theta_a_h (:)
+   real(r8), allocatable :: zwt_h     (:)
    real(r8), allocatable :: Kl_h      (:) ! [m/s]
    real(r8), allocatable :: xsubs_h   (:) ! [m/s]
    real(r8), allocatable :: xsubs_fc  (:) ! [m/s]
@@ -215,8 +215,8 @@ CONTAINS
    real(r8) :: ca, cb
    real(r8) :: alp
 
-   real(r8), allocatable :: theta_a_elm (:) 
-   real(r8), allocatable :: zwt_elm     (:) 
+   real(r8), allocatable :: theta_a_elm (:)
+   real(r8), allocatable :: zwt_elm     (:)
    real(r8), allocatable :: Kl_elm      (:) ! [m/s]
 
    integer  :: jnb
@@ -250,7 +250,7 @@ CONTAINS
 
          xsubs_elm(:) = 0.  ! subsurface lateral flow between element basins
          xsubs_hru(:) = 0.  ! subsurface lateral flow between hydrological response units
-         xsubs_pch(:) = 0.  ! subsurface lateral flow between patches inside one HRU     
+         xsubs_pch(:) = 0.  ! subsurface lateral flow between patches inside one HRU
 
          xwsub(:) = 0. ! total recharge/discharge from subsurface lateral flow
 
@@ -268,13 +268,13 @@ CONTAINS
 
             IF (lake_id_elm(ielm) > 0) CYCLE  ! lake
             IF (sum(hrus%agwt) <= 0)   CYCLE  ! no area of soil, urban or wetland
-            
+
             allocate (theta_a_h (nhru));  theta_a_h = 0.
             allocate (zwt_h     (nhru));  zwt_h     = 0.
             allocate (Kl_h      (nhru));  Kl_h      = 0.
 
             DO i = 1, nhru
-               
+
                IF (hrus%indx(i) == 0) CYCLE ! river
                IF (hrus%agwt(i) == 0) CYCLE ! no area of soil, urban or wetland
 
@@ -287,14 +287,14 @@ CONTAINS
                   IF (patchtype(ipatch) <= 2) THEN
                      theta_s_h = theta_s_h + hru_patch%subfrc(ipatch) &
                         * sum(porsl(1:nl_soil,ipatch) * dz_soi(1:nl_soil) &
-                        - wice_soisno(1:nl_soil,ipatch)/denice) / sum(dz_soi(1:nl_soil)) 
+                        - wice_soisno(1:nl_soil,ipatch)/denice) / sum(dz_soi(1:nl_soil))
                      sumwt = sumwt + hru_patch%subfrc(ipatch)
-                  ENDIF 
+                  ENDIF
                ENDDO
                IF (sumwt > 0) theta_s_h = theta_s_h / sumwt
 
                IF (theta_s_h > 0.) THEN
-                  
+
                   air_h    = 0.
                   zwt_h(i) = 0.
                   sumwt    = 0.
@@ -305,9 +305,9 @@ CONTAINS
                            - wliq_soisno(1:nl_soil,ipatch)/denh2o &
                            - wice_soisno(1:nl_soil,ipatch)/denice ) - wa(ipatch)/1.0e3)
                         air_h = max(0., air_h)
-                        
+
                         zwt_h(i) = zwt_h(i) + zwt(ipatch) * hru_patch%subfrc(ipatch)
-                        
+
                         sumwt = sumwt + hru_patch%subfrc(ipatch)
                      ENDIF
                   ENDDO
@@ -333,7 +333,7 @@ CONTAINS
                            icefrac = min(1., wice_soisno(ilev,ipatch)/denice/dz_soi(ilev)/porsl(ilev,ipatch))
                            imped   = 10.**(-e_ice*icefrac)
                            Kl_h(i) = Kl_h(i) + hru_patch%subfrc(ipatch) * raniso(soiltext(ipatch)) &
-                              * hksati(ilev,ipatch)/1.0e3 * imped * dz_soi(ilev)/zi_soi(nl_soil) 
+                              * hksati(ilev,ipatch)/1.0e3 * imped * dz_soi(ilev)/zi_soi(nl_soil)
                         ENDDO
                         sumwt = sumwt + hru_patch%subfrc(ipatch)
                      ENDIF
@@ -345,7 +345,7 @@ CONTAINS
                ENDIF
 
             ENDDO
-            
+
             allocate (xsubs_h  (nhru))
             allocate (xsubs_fc (nhru))
 
@@ -353,22 +353,22 @@ CONTAINS
             xsubs_fc(:) = 0.
 
             DO i = 1, nhru
-                  
+
                j = hrus%inext(i)
 
                IF (j <= 0)        CYCLE ! downstream is out of catchment
                IF (Kl_h(i) == 0.) CYCLE ! this HRU is frozen
-               
+
                j_is_river = (hrus%indx(j) == 0)
 
                IF ((.not. j_is_river) .and. (Kl_h(j) == 0.)) CYCLE ! non-river downstream HRU is frozen
-                  
+
                zsubs_h_up = hrus%elva(i) - zwt_h(i)
 
                IF (.not. j_is_river) THEN
                   zsubs_h_dn = hrus%elva(j) - zwt_h(j)
                ELSE
-                  zsubs_h_dn = hrus%elva(1) - riverdpth_elm(ielm) + wdsrf_hru(hrus%ihru(1)) 
+                  zsubs_h_dn = hrus%elva(1) - riverdpth_elm(ielm) + wdsrf_hru(hrus%ihru(1))
                ENDIF
 
                IF (.not. j_is_river) THEN
@@ -408,7 +408,7 @@ CONTAINS
                ELSE
                   cb = hrus%flen(i) * Kl_fc / delp / hrus%area(j) * deltime
                ENDIF
-               
+
                xsubs_fc(i) = (zsubs_h_up - zsubs_h_dn) * hrus%flen(i) * Kl_fc / (1+ca+cb) / delp
 
                xsubs_h(i) = xsubs_h(i) + xsubs_fc(i) / hrus%agwt(i)
@@ -418,12 +418,12 @@ CONTAINS
                ELSE
                   xsubs_h(j) = xsubs_h(j) - xsubs_fc(i) / hrus%agwt(j)
                ENDIF
-               
+
             ENDDO
-            
+
             IF (hrus%indx(1) == 0) THEN
                ! xsubs_h(1) is positive = out of soil column
-               IF (xsubs_h(1)*deltime > wdsrf_hru(hrus%ihru(1))) THEN 
+               IF (xsubs_h(1)*deltime > wdsrf_hru(hrus%ihru(1))) THEN
                   alp = wdsrf_hru(hrus%ihru(1)) / (xsubs_h(1)*deltime)
                   xsubs_h(1) = xsubs_h(1) * alp
                   DO i = 2, nhru
@@ -433,33 +433,33 @@ CONTAINS
                   ENDDO
                ENDIF
             ENDIF
-               
+
             ! Update total subsurface lateral flow (1): Between hydrological units
             ! for soil, urban, wetland or river patches
             DO i = 1, nhru
                xsubs_hru(hrus%ihru(i)) = xsubs_h(i)
-               
+
                ps = hru_patch%substt(hrus%ihru(i))
                pe = hru_patch%subend(hrus%ihru(i))
                DO ipatch = ps, pe
-                  IF ((patchtype(ipatch) <= 2) .or. (hrus%indx(i) == 0)) THEN 
-                     xwsub(ipatch) = xwsub(ipatch) + xsubs_h(i) * 1.e3 ! (positive = out of soil column) 
+                  IF ((patchtype(ipatch) <= 2) .or. (hrus%indx(i) == 0)) THEN
+                     xwsub(ipatch) = xwsub(ipatch) + xsubs_h(i) * 1.e3 ! (positive = out of soil column)
                   ENDIF
                ENDDO
 
                IF (hrus%indx(1) == 0) THEN
                   DO ipatch = ps, pe
-                     IF (patchtype(ipatch) <= 2) THEN 
+                     IF (patchtype(ipatch) <= 2) THEN
                         rsub(ipatch) = - xsubs_h(1) * hrus%area(1) / sum(hrus%agwt) * 1.0e3 ! m/s to mm/s
                      ENDIF
                   ENDDO
                ENDIF
             ENDDO
-            
+
             DO i = 1, nhru
                ! Inside hydrological units
                IF (hrus%agwt(i) > 0) THEN
-               
+
                   bdamp = 4.8
 
                   IF (zwt_h(i) > 1.5) THEN
@@ -513,11 +513,11 @@ CONTAINS
          CALL retrieve_neighbour_data (wdsrf_elm  , wdsrf_nb  )
 
          DO ielm = 1, numelm
-            
+
             hrus => hillslope_element(ielm)
-               
+
             iam_lake = (lake_id_elm(ielm) > 0)
-            
+
             DO jnb = 1, elementneighbour(ielm)%nnb
 
                IF (elementneighbour(ielm)%glbindex(jnb) == -9) CYCLE ! skip ocean neighbour
@@ -527,16 +527,16 @@ CONTAINS
                IF (iam_lake .and. nb_is_lake) THEN
                   CYCLE
                ENDIF
-               
+
                IF (.not. iam_lake) THEN
                   Kl_up      = Kl_elm    (ielm)
                   zwt_up     = zwt_elm    (ielm)
                   theta_a_up = theta_a_elm(ielm)
-                  zsubs_up   = elementneighbour(ielm)%myelva - zwt_up 
+                  zsubs_up   = elementneighbour(ielm)%myelva - zwt_up
                   area_up    = sum(hrus%agwt)
                ELSE
                   theta_a_up = 1.
-                  zsubs_up   = elementneighbour(ielm)%myelva - lakedepth_elm(ielm) + wdsrf_elm(ielm) 
+                  zsubs_up   = elementneighbour(ielm)%myelva - lakedepth_elm(ielm) + wdsrf_elm(ielm)
                   area_up    = elementneighbour(ielm)%myarea
                ENDIF
 
@@ -554,7 +554,7 @@ CONTAINS
 
                IF ((.not. iam_lake)   .and. (area_up <= 0)) CYCLE
                IF ((.not. nb_is_lake) .and. (area_dn <= 0)) CYCLE
-               IF ((.not. iam_lake)   .and. (Kl_up == 0. )) CYCLE 
+               IF ((.not. iam_lake)   .and. (Kl_up == 0. )) CYCLE
                IF ((.not. nb_is_lake) .and. (Kl_dn == 0. )) CYCLE
 
                ! water body is dry.
@@ -564,7 +564,7 @@ CONTAINS
                IF (nb_is_lake .and. (zsubs_up < zsubs_dn) .and. (wdsrf_nb(ielm)%val(jnb) == 0.)) THEN
                   CYCLE
                ENDIF
-               
+
                lenbdr = elementneighbour(ielm)%lenbdr(jnb)
 
                delp = elementneighbour(ielm)%dist(jnb)
@@ -609,7 +609,7 @@ CONTAINS
                ELSE
                   xsubs_nb = xsubs_nb / elementneighbour(ielm)%myarea
                ENDIF
-               
+
                xsubs_elm(ielm) = xsubs_elm(ielm) + xsubs_nb
 
             ENDDO
@@ -633,14 +633,14 @@ CONTAINS
 
       ! Exchange between soil water and aquifer.
       IF (p_is_worker) THEN
-      
+
          sp_zi(0) = 0.
          sp_zi(1:nl_soil) = zi_soi(1:nl_soil) * 1000.0   ! from meter to mm
          sp_dz(1:nl_soil) = sp_zi(1:nl_soil) - sp_zi(0:nl_soil-1)
-         
+
          DO ipatch = 1, numpatch
 
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
             ! For water balance check, the sum of water in soil column before the calcultion
             w_sum_before = sum(wliq_soisno(1:nl_soil,ipatch)) + sum(wice_soisno(1:nl_soil,ipatch)) &
                + wa(ipatch) + wdsrf(ipatch) + wetwat(ipatch)
@@ -652,7 +652,7 @@ CONTAINS
                is_dry_lake = .false.
             ENDIF
 
-            IF ((patchtype(ipatch) <= 1) .or. is_dry_lake) THEN 
+            IF ((patchtype(ipatch) <= 1) .or. is_dry_lake) THEN
 
                exwater = xwsub(ipatch) * deltime
 
@@ -684,7 +684,7 @@ CONTAINS
                      wresi(ilev) = 0.
                   ENDIF
                ENDDO
-      
+
                zwtmm = zwt(ipatch) * 1000. ! m -> mm
 
                ! check consistancy between water table location and liquid water content
@@ -716,7 +716,7 @@ CONTAINS
                   nl_soil, exwater, sp_zi, is_permeable, eff_porosity, vl_r, psi0(:,ipatch), &
                   hksati(:,ipatch), nprms, prms, porsl(nl_soil,ipatch), wdsrf(ipatch), &
                   vol_liq, zwtmm, wa(ipatch), izwt)
-               
+
                ! update the mass of liquid water
                DO ilev = nl_soil, 1, -1
                   IF (is_permeable(ilev)) THEN
@@ -755,11 +755,11 @@ CONTAINS
                ENDIF
 
             ELSEIF (patchtype(ipatch) == 4) THEN ! land water bodies
-                  
+
                wdsrf(ipatch) = wa(ipatch) + wdsrf(ipatch) - xwsub(ipatch)*deltime
 
                IF (wdsrf(ipatch) < 0) THEN
-                  wa   (ipatch) = wdsrf(ipatch) 
+                  wa   (ipatch) = wdsrf(ipatch)
                   wdsrf(ipatch) = 0
                ELSE
                   wa(ipatch) = 0
@@ -767,7 +767,7 @@ CONTAINS
 
             ENDIF
 
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
             ! For water balance check, the sum of water in soil column after the calcultion
             w_sum_after = sum(wliq_soisno(1:nl_soil,ipatch)) + sum(wice_soisno(1:nl_soil,ipatch)) &
                + wa(ipatch) + wdsrf(ipatch) + wetwat(ipatch)
@@ -802,9 +802,9 @@ CONTAINS
       IF (allocated(agwt_nb   )) deallocate(agwt_nb   )
       IF (allocated(islake_nb )) deallocate(islake_nb )
       IF (allocated(lakedp_nb )) deallocate(lakedp_nb )
-      
+
       IF (associated(hillslope_element)) deallocate(hillslope_element)
-      
+
    END SUBROUTINE subsurface_network_final
 
 END MODULE MOD_Catch_SubsurfaceFlow

--- a/main/MOD_Albedo.F90
+++ b/main/MOD_Albedo.F90
@@ -595,7 +595,7 @@ ENDIF
       ENDIF
       zmu2 = zmu * zmu
 
-#if(defined LULC_USGS)
+#if (defined LULC_USGS)
       ! yuan: to be consistent with CoLM2014, no stem considered
       ! for twostream and leaf optical property calculations
       sai_ = 0.

--- a/main/MOD_Const_PFT.F90
+++ b/main/MOD_Const_PFT.F90
@@ -247,7 +247,7 @@ MODULE MOD_Const_PFT
          /)
 
    ! reflectance of green leaf in visible band
-#if(defined LULC_IGBP_PC)
+#if (defined LULC_IGBP_PC)
    ! Leaf optical properties adapted from measured data (Dong et al., 2021)
    real(r8), parameter :: rhol_vis_p(0:N_PFT+N_CFT-1) &
       = (/0.110,  0.070,  0.070,  0.070,  0.100,  0.110,  0.100,  0.100&
@@ -286,7 +286,7 @@ MODULE MOD_Const_PFT
          /)
 
    ! reflectance of green leaf in near infrared band
-#if(defined LULC_IGBP_PC)
+#if (defined LULC_IGBP_PC)
    ! Leaf optical properties adapted from measured data (Dong et al., 2021)
    real(r8), parameter :: rhol_nir_p(0:N_PFT+N_CFT-1) &
       = (/0.350,  0.360,  0.370,  0.360,  0.450,  0.460,  0.450,  0.420&
@@ -325,7 +325,7 @@ MODULE MOD_Const_PFT
          /)
 
    ! transmittance of green leaf in visible band
-#if(defined LULC_IGBP_PC)
+#if (defined LULC_IGBP_PC)
    ! Leaf optical properties adapted from measured data (Dong et al., 2021)
    real(r8), parameter :: taul_vis_p(0:N_PFT+N_CFT-1) &
       = (/0.050,  0.050,  0.050,  0.050,  0.050,  0.060,  0.050,  0.060&
@@ -364,7 +364,7 @@ MODULE MOD_Const_PFT
          /)
 
    ! transmittance of green leaf in near infrared band
-#if(defined LULC_IGBP_PC)
+#if (defined LULC_IGBP_PC)
    ! Leaf optical properties adapted from measured data (Dong et al., 2021)
    real(r8), parameter :: taul_nir_p(0:N_PFT+N_CFT-1) &
       = (/0.340,  0.280,  0.290,  0.380,  0.250,  0.330,  0.250,  0.430&

--- a/main/MOD_Forcing.F90
+++ b/main/MOD_Forcing.F90
@@ -180,7 +180,7 @@ CONTAINS
          ! allocate memory for forcing data
          CALL allocate_block_data (gforc, metdata)  ! forcing data
          CALL allocate_block_data (gforc, avgcos )  ! time-average of cos(zenith)
-#if(defined URBAN_MODEL && defined SinglePoint)
+#if (defined URBAN_MODEL && defined SinglePoint)
          CALL allocate_block_data (gforc, rainf)
          CALL allocate_block_data (gforc, snowf)
 #endif

--- a/main/MOD_Hist.F90
+++ b/main/MOD_Hist.F90
@@ -126,7 +126,7 @@ CONTAINS
    USE MOD_Vars_PFTimeInvariants, only: pftclass
    USE MOD_LandPFT, only: patch_pft_s
 #endif
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
    USE MOD_CaMa_Vars !definition of CaMa variables
 #endif
    USE MOD_Forcing, only: forcmask_pch
@@ -149,7 +149,7 @@ CONTAINS
    logical :: lwrite
    character(len=256) :: file_hist
    integer :: itime_in_file
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
    character(len=256) :: file_hist_cama
    integer :: itime_in_file_cama
 #endif
@@ -223,7 +223,7 @@ CONTAINS
             write(*,*) 'Warning : Please USE one of DAY/MONTH/YEAR for history group.'
          ENDIF
 
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
          ! add variables to write cama-flood output.
          ! file name of cama-flood output
          file_hist_cama = trim(dir_hist) // '/' // trim(site) //'_hist_cama_'//trim(cdate)//'.nc'
@@ -3935,7 +3935,7 @@ CONTAINS
             a_sensors, file_hist, 'sensors', itime_in_file, 'sensor', 1, nsensor, &
             sumarea, filter, 'variable sensors','user defined')
 
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
 #ifdef USEMPI
          CALL mpi_barrier (p_comm_glb, p_err)
 #endif

--- a/main/MOD_LAIEmpirical.F90
+++ b/main/MOD_LAIEmpirical.F90
@@ -46,7 +46,7 @@ CONTAINS
    integer j       !number of soil layers
 
 !-----------------------------------------------------------------------
-#if(defined LULC_USGS)
+#if (defined LULC_USGS)
 ! Maximum fractional cover of vegetation [-]
    real(r8), dimension(24), parameter :: &
    vegc=(/1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, &

--- a/main/MOD_Lake.F90
+++ b/main/MOD_Lake.F90
@@ -1304,7 +1304,7 @@ CONTAINS
       ENDIF
 
 
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
       ! sum energy content and total energy into lake for energy check. any errors will be from the
       !     tridiagonal solution.
       esum1 = 0.0

--- a/main/MOD_LeafInterception.F90
+++ b/main/MOD_LeafInterception.F90
@@ -288,7 +288,7 @@ CONTAINS
                tex_snow = tex_snow * deltim
             ENDIF
 
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
             IF (tex_rain+tex_snow+tti_rain+tti_snow-p0 > 1.e-10 .and. .not.DEF_VEG_SNOW) THEN
                write(6,*) 'tex_ + tti_ > p0 in interception code : '
             ENDIF
@@ -325,7 +325,7 @@ CONTAINS
          qintr_rain = prc_rain + prl_rain + qflx_irrig_sprinkler - thru_rain / deltim
          qintr_snow = prc_snow + prl_snow - thru_snow / deltim
 
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
          w = w - ldew - (pg_rain+pg_snow)*deltim
          IF (abs(w) > 1.e-6) THEN
             write(6,*) 'something wrong in interception code: '
@@ -484,7 +484,7 @@ CONTAINS
             tex_rain = max( tex_rain, 0. )
             tex_snow = 0.
 
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
             IF (tex_rain+tex_snow+tti_rain+tti_snow-p0 > 1.e-10) THEN
                write(6,*) 'tex_ + tti_ > p0 in interception code : '
             ENDIF
@@ -515,7 +515,7 @@ CONTAINS
          qintr_snow = prc_snow + prl_snow - thru_snow / deltim
 
 
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
          w = w - ldew - (pg_rain+pg_snow)*deltim
          IF (abs(w) > 1.e-6) THEN
             write(6,*) 'something wrong in interception code : '
@@ -641,7 +641,7 @@ CONTAINS
             tex_rain = max(tex_rain, 0. )
             tex_snow = 0.
 
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
             IF (tex_rain+tex_snow+tti_rain+tti_snow-p0 > 1.e-10) THEN
                write(6,*) 'tex_ + tti_ > p0 in interception code : '
             ENDIF
@@ -671,7 +671,7 @@ CONTAINS
          qintr_snow = prc_snow + prl_snow - thru_snow / deltim
 
 
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
          w = w - ldew - (pg_rain+pg_snow)*deltim
          IF (abs(w) > 1.e-6) THEN
             write(6,*) 'something wrong in interception code : '
@@ -815,7 +815,7 @@ CONTAINS
             tex_rain   = max( tex_rain, 0. )
             tex_snow   = max( tex_snow, 0. )
 
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
             IF (tex_rain+tex_snow+tti_rain+tti_snow-p0 > 1.e-10) THEN
                write(6,*) 'tex_ + tti_ > p0 in interception code : '
             ENDIF
@@ -846,7 +846,7 @@ CONTAINS
          qintr_rain = prc_rain + prl_rain + qflx_irrig_sprinkler - thru_rain / deltim
          qintr_snow = prc_snow + prl_snow - thru_snow / deltim
 
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
          w = w - ldew - (pg_rain+pg_snow)*deltim
          IF (abs(w) > 1.e-6) THEN
             write(6,*) 'something wrong in interception code : '
@@ -1011,7 +1011,7 @@ CONTAINS
 
             tex_rain = (prc_rain+prl_rain+qflx_irrig_sprinkler)*fvegc*deltim  - int_rain
             tex_snow = (prc_snow+prl_snow)*fvegc*deltim - int_snow
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
             IF (tex_rain+tex_snow+tti_rain+tti_snow-p0 > 1.e-10) THEN
                write(6,*) 'tex_ + tti_ > p0 in interception code : '
             ENDIF
@@ -1044,7 +1044,7 @@ CONTAINS
          qintr_snow = prc_snow + prl_snow - thru_snow / deltim
 
 
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
          w = w - ldew - (pg_rain+pg_snow)*deltim
          IF (abs(w) > 1.e-6) THEN
             write(6,*) 'something wrong in interception code : '
@@ -1253,7 +1253,7 @@ CONTAINS
             !-------------------------------------------------------------------------
 
 
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
             IF (tex_rain+tex_snow+tti_rain+tti_snow-p0 > 1.e-10) THEN
                write(6,*) 'tex_ + tti_ > p0 in interception code : '
             ENDIF
@@ -1286,7 +1286,7 @@ CONTAINS
 
          qintr_rain = prc_rain + prl_rain + qflx_irrig_sprinkler - thru_rain / deltim
          qintr_snow = prc_snow + prl_snow - thru_snow / deltim
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
          w = w - ldew - (pg_rain+pg_snow)*deltim
          IF (abs(w) > 1.e-6) THEN
             write(6,*) 'something wrong in interception code : '
@@ -1494,7 +1494,7 @@ CONTAINS
                tex_snow  = tex_snow  + Overload*IntSnowFract
             ENDIF
 
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
             IF (tex_rain+tex_snow+tti_rain+tti_snow-p0 > 1.e-10) THEN
                write(6,*) 'tex_ + tti_ > p0 in interception code : '
             ENDIF
@@ -1525,7 +1525,7 @@ CONTAINS
 
          qintr_rain = prc_rain + prl_rain - thru_rain / deltim
          qintr_snow = prc_snow + prl_snow - thru_snow / deltim
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
          w = w - ldew - (pg_rain+pg_snow)*deltim
          IF (abs(w) > 1.e-6) THEN
             write(6,*) 'something wrong in interception code : '
@@ -1690,7 +1690,7 @@ CONTAINS
 
             tex_rain = (prc_rain+prl_rain+qflx_irrig_sprinkler)*fvegc*deltim  - int_rain
             tex_snow = (prc_snow+prl_snow)*fvegc*deltim - int_snow
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
             IF (tex_rain+tex_snow+tti_rain+tti_snow-p0 > 1.e-10) THEN
                write(6,*) 'tex_ + tti_ > p0 in interception code : '
             ENDIF
@@ -1717,7 +1717,7 @@ CONTAINS
 
          qintr_rain = prc_rain + prl_rain + qflx_irrig_sprinkler - thru_rain / deltim
          qintr_snow = prc_snow + prl_snow - thru_snow / deltim
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
          w = w - ldew - (pg_rain+pg_snow)*deltim
          IF (abs(w) > 1.e-6) THEN
             write(6,*) 'something wrong in interception code : '

--- a/main/MOD_LeafTemperature.F90
+++ b/main/MOD_LeafTemperature.F90
@@ -1121,7 +1121,7 @@ ENDIF
           ! account for vegetation heat change
           - dheatl
 
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
       IF(abs(err) .gt. .2) &
       write(6,*) 'energy imbalance in LeafTemperature.F90',it-1,err,sabv,irab,fsenl,hvap*fevpl,hprl,dheatl
 #endif

--- a/main/MOD_LeafTemperaturePC.F90
+++ b/main/MOD_LeafTemperaturePC.F90
@@ -1936,7 +1936,7 @@ ENDIF
                 ! account for vegetation heat change
                 - dheatl(i)
 
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
             IF(abs(err) .gt. .2) &
                write(6,*) 'energy imbalance in LeafTemperaturePC.F90', &
                           i,it-1,err,sabv(i),irab(i),fsenl(i),hvap*fevpl(i),hprl(i),dheatl(i)

--- a/main/MOD_SoilSnowHydrology.F90
+++ b/main/MOD_SoilSnowHydrology.F90
@@ -7,7 +7,7 @@ MODULE MOD_SoilSnowHydrology
    USE MOD_Namelist, only: DEF_USE_PLANTHYDRAULICS, DEF_USE_SNICAR,     &
                            DEF_URBAN_RUN,           DEF_USE_IRRIGATION, &
                            DEF_SPLIT_SOILSNOW,      DEF_Runoff_SCHEME
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
    USE YOS_CMF_INPUT,      only: LWINFILT
 #endif
 #ifdef CROP
@@ -51,7 +51,7 @@ CONTAINS
               qseva_snow  ,qsdew_snow  ,qsubl_snow  ,qfros_snow  ,fsno        ,&
               rsur        ,rnof        ,qinfl       ,pondmx      ,ssi         ,&
               wimp        ,smpmin      ,zwt         ,wa          ,qcharge     ,&
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
               flddepth    ,fldfrc      ,qinfl_fld                             ,&
 #endif
 ! SNICAR model variables
@@ -133,7 +133,7 @@ CONTAINS
         qfros_snow              ,&! surface dew added to snow pack (mm h2o /s) [+]
         fsno                      ! snow fractional cover
 
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
    real(r8), intent(inout) :: flddepth  ! inundation water depth [mm]
    real(r8), intent(in)    :: fldfrc    ! inundation water depth   [0-1]
    real(r8), intent(out)   :: qinfl_fld ! grid averaged inundation water input from top (mm/s)
@@ -189,7 +189,7 @@ CONTAINS
        zimm(0:nl_soil)            ! interface level below a "z" level (mm)
 
    real(r8) :: err_solver, w_sum
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
    real(r8) ::gfld ,rsur_fld, qinfl_fld_subgrid ! inundation water input from top (mm/s)
 #endif
 
@@ -325,7 +325,7 @@ IF(patchtype<=1)THEN   ! soil ground only
       ! infiltration into surface soil layer
       qinfl = gwat - rsur
 
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
       IF (LWINFILT) THEN
          !  re-infiltration [mm/s] calculation.
          ! IF surface runoff is occurred (rsur != 0.), flood depth <1.e-6  and flood fraction <0.05,
@@ -429,14 +429,14 @@ ELSE
       err_solver = err_solver-(qsdew_soil+qfros_soil-qsubl_soil)*deltim
 ENDIF
 
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
       IF (LWINFILT) THEN
          err_solver = err_solver-(gfld-rsur_fld)*fldfrc*deltim
       ENDIF
 #endif
 
 
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
       IF(abs(err_solver) > 1.e-3)THEN
          write(6,*) 'Warning: water balance violation after all soilwater calculation', err_solver
       ENDIF
@@ -496,7 +496,7 @@ ENDIF
               fsno        ,rsur        ,rsur_se     ,rsur_ie     ,rnof        ,&
               qinfl       ,ssi         ,pondmx      ,wimp        ,zwt         ,&
               wdsrf       ,wa          ,wetwat      ,&
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
               flddepth    ,fldfrc      ,qinfl_fld                             ,&
 #endif
 ! SNICAR model variables
@@ -586,7 +586,7 @@ ENDIF
         qsubl_snow       , &! sublimation rate from snow pack (mm h2o /s) [+]
         qfros_snow       , &! surface dew added to snow pack (mm h2o /s) [+]
         fsno                ! snow fractional cover
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
    real(r8), intent(inout) :: flddepth  ! inundation water input from top (mm/s)
    real(r8), intent(in)    :: fldfrc    ! inundation water input from top (mm/s)
    real(r8), intent(out)   :: qinfl_fld ! inundation water input from top (mm/s)
@@ -669,7 +669,7 @@ ENDIF
    integer, parameter :: nprms = 5
 #endif
    real(r8) :: prms(nprms, 1:nl_soil)
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
    real(r8) :: gfld,qinfl_all,rsur_fld, qinfl_fld_subgrid! inundation water input from top (mm/s)
 #endif
 
@@ -843,7 +843,7 @@ IF((patchtype<=1) .or. is_dry_lake)THEN   ! soil ground only
       rsubst = 0
 #endif
 
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
       IF (LWINFILT) THEN
          !  re-infiltration [mm/s] calculation.
          ! IF surface runoff is occurred (rsur != 0.), flood depth <1.e-6  and flood fraction <0.05,
@@ -1057,13 +1057,13 @@ ELSE
       err_solver = err_solver-(qsdew_soil+qfros_soil-qsubl_soil)*deltim
 ENDIF
 
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
       IF (LWINFILT) THEN
          err_solver = err_solver-(gfld-rsur_fld)*fldfrc*deltim
       ENDIF
 #endif
 
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
       IF(abs(err_solver) > 1.e-3)THEN
          write(6,'(A,E20.5,A,I0)') 'Warning (WATER_VSF): water balance violation', err_solver, &
             ' in element ', landpatch%eindex(ipatch)
@@ -2033,7 +2033,7 @@ ENDIF
 
       CALL tridia (nl_soil, amx, bmx, cmx, rmx, dwat )
 
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
   ! The mass balance error (mm) for this time step is
       errorw = -deltim*(qin(1)-qout(nl_soil)-dqodw1(nl_soil)*dwat(nl_soil))
       DO j = 1, nl_soil

--- a/main/URBAN/CoLMMAIN_Urban.F90
+++ b/main/URBAN/CoLMMAIN_Urban.F90
@@ -138,7 +138,7 @@
            mss_bcpho    ,mss_bcphi    ,mss_ocpho    ,mss_ocphi    ,&
            mss_dst1     ,mss_dst2     ,mss_dst3     ,mss_dst4     ,&
 
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
            ! flood depth [mm], flood fraction[0-1],
            ! flood evaporation [mm/s], flood re-infiltration [mm/s]
            flddepth     ,fldfrc       ,fevpg_fld    ,qinfl_fld    ,&
@@ -345,7 +345,7 @@
         forc_hgt_q            ,&! observational height of humidity [m]
         forc_rhoair             ! density air [kg/m3]
 
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
    real(r8), intent(in)    :: fldfrc    !inundation fraction--> allow re-evaporation and infiltration![0-1]
    real(r8), intent(inout) :: flddepth  !inundation depth--> allow re-evaporation and infiltration![mm]
    real(r8), intent(out)   :: fevpg_fld !effective evaporation from inundation [mm/s]
@@ -1073,7 +1073,7 @@
          sm_roof            ,sm_gimp            ,sm_gper            ,sm_lake            ,&
          lake_icefrac       ,scv_lake           ,snowdp_lake        ,imeltl             ,&
          fioldl             ,w_old                                                      ,&
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
          flddepth           ,fldfrc             ,qinfl_fld                              ,&
 #endif
          forc_us            ,forc_vs                                                    ,&
@@ -1214,7 +1214,7 @@
       ! energy balance check
       ! ----------------------------------------
       zerr=errore
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
       IF(abs(errore)>.5)THEN
          write(6,*) 'Warning: energy balance violation ',errore,patchclass
       ENDIF
@@ -1244,7 +1244,7 @@
       errorw = (endwb - totwb) - (forc_prc + forc_prl + urb_irrig - fevpa - rnof)*deltim
       xerr   = errorw/deltim
 
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
       IF(abs(errorw)>1.e-3) THEN
          write(6,*) 'Warning: water balance violation', errorw, ipatch, patchclass
          !STOP

--- a/main/URBAN/MOD_Urban_Flux.F90
+++ b/main/URBAN/MOD_Urban_Flux.F90
@@ -44,6 +44,7 @@ MODULE MOD_Urban_Flux
 !
 !-----------------------------------------------------------------------
    USE MOD_Precision
+   USE MOD_SPMD_Task
    USE MOD_Namelist, only: DEF_RSS_SCHEME, DEF_VEG_SNOW
    USE MOD_Vars_Global
    USE MOD_Qsadv, only: qsadv
@@ -808,7 +809,7 @@ CONTAINS
       croof  = croofs + croofl*htvp_roof
 
 
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
 #endif
 
       tafu = taf(2)
@@ -2341,7 +2342,7 @@ ENDIF
       err = sabv + irab + dirab_dtl*dtl(it-1) &
           - fsenl - hvap*fevpl - dheatl
 
-#if(defined CLMDEBUG)
+#if (defined CoLMDEBUG)
       IF (abs(err) .gt. .2) THEN
          write(6,*) 'energy imbalance in UrbanVegFlux.F90', &
          i,it-1,err,sabv,irab,fsenl,hvap*fevpl,dheatl

--- a/main/URBAN/MOD_Urban_Hydrology.F90
+++ b/main/URBAN/MOD_Urban_Hydrology.F90
@@ -62,7 +62,7 @@ CONTAINS
         sm_roof        ,sm_gimp        ,sm_gper        ,sm_lake        ,&
         lake_icefrac   ,scv_lake       ,snowdp_lake    ,imelt_lake     ,&
         fioldl         ,w_old                                          ,&
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
         flddepth       ,fldfrc         ,qinfl_fld                      ,&
 #endif
         forc_us        ,forc_vs                                        ,&
@@ -156,7 +156,7 @@ CONTAINS
 
    real(r8), intent(inout) :: rootflux(1:nl_soil)
 
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
    real(r8), intent(inout) :: flddepth  ! inundation water depth [mm]
    real(r8), intent(in)    :: fldfrc    ! inundation water depth [0-1]
    real(r8), intent(out)   :: qinfl_fld ! grid averaged inundation water input from top (mm/s)
@@ -272,7 +272,7 @@ CONTAINS
              0.          ,& ! fsno, not active
              rsur_gper   ,rnof_gper   ,qinfl       ,pondmx      ,ssi         ,&
              wimp        ,smpmin      ,zwt         ,wa          ,qcharge     ,&
-#if(defined CaMa_Flood)
+#if (defined CaMa_Flood)
              flddepth    ,fldfrc      ,qinfl_fld                             ,&
 #endif
 ! SNICAR model variables

--- a/main/URBAN/MOD_Urban_Thermal.F90
+++ b/main/URBAN/MOD_Urban_Thermal.F90
@@ -1080,46 +1080,19 @@ CONTAINS
 ! during the timestep.  this energy is later added to the sensible heat flux.
 
       ! --- for pervious ground ---
-      ! update of snow
-      IF (lbp < 1) THEN
-         egsmax = (wice_gpersno(lbp)+wliq_gpersno(lbp)) / deltim
-         egidif = max( 0., fevpgper - egsmax )
-         fevpgper = min ( fevpgper, egsmax )
-         fsengper = fsengper + htvp_gper*egidif
-      ENDIF
-
-      ! update of soil
-      egsmax = (wice_gpersno(1)+wliq_gpersno(1)) / deltim
+      egsmax = (wice_gpersno(lbp)+wliq_gpersno(lbp)) / deltim
       egidif = max( 0., fevpgper - egsmax )
       fevpgper = min ( fevpgper, egsmax )
       fsengper = fsengper + htvp_gper*egidif
 
       ! --- for impervious ground ---
-      ! update of snow
-      IF (lbi < 1) THEN
-         egsmax = (wice_gimpsno(lbi)+wliq_gimpsno(lbi)) / deltim
-         egidif = max( 0., fevpgimp - egsmax )
-         fevpgimp = min ( fevpgimp, egsmax )
-         fsengimp = fsengimp + htvp_gimp*egidif
-      ENDIF
-
-      ! update of soil
-      egsmax = (wice_gimpsno(1)+wliq_gimpsno(1)) / deltim
+      egsmax = (wice_gimpsno(lbi)+wliq_gimpsno(lbi)) / deltim
       egidif = max( 0., fevpgimp - egsmax )
       fevpgimp = min ( fevpgimp, egsmax )
       fsengimp = fsengimp + htvp_gimp*egidif
 
       ! --- for roof ---
-      ! update of snow
-      IF (lbr < 1) THEN
-         egsmax = (wice_roofsno(lbr)+wliq_roofsno(lbr)) / deltim
-         egidif = max( 0., fevproof - egsmax )
-         fevproof = min ( fevproof, egsmax )
-         fsenroof = fsenroof + htvp_roof*egidif
-      ENDIF
-
-      ! update of soil
-      egsmax = (wice_roofsno(1)+wliq_roofsno(1)) / deltim
+      egsmax = (wice_roofsno(lbr)+wliq_roofsno(lbr)) / deltim
       egidif = max( 0., fevproof - egsmax )
       fevproof = min ( fevproof, egsmax )
       fsenroof = fsenroof + htvp_roof*egidif

--- a/mkinidata/MOD_IniTimeVariable.F90
+++ b/mkinidata/MOD_IniTimeVariable.F90
@@ -30,7 +30,7 @@ CONTAINS
                      ,alb,ssun,ssha,ssoi,ssno,ssno_lyr,thermk,extkb,extkd&
                      ,trad,tref,qref,rst,emis,zol,rib&
                      ,ustar,qstar,tstar,fm,fh,fq&
-#if(defined BGC)
+#if (defined BGC)
                      ,use_cnini, totlitc, totsomc, totcwdc, decomp_cpools, decomp_cpools_vr, ctrunc_veg, ctrunc_soil, ctrunc_vr &
                      ,totlitn, totsomn, totcwdn, decomp_npools, decomp_npools_vr, ntrunc_veg, ntrunc_soil, ntrunc_vr &
                      ,totvegc, totvegn, totcolc, totcoln, col_endcb, col_begcb, col_endnb, col_begnb &

--- a/mkinidata/MOD_Initialize.F90
+++ b/mkinidata/MOD_Initialize.F90
@@ -295,8 +295,8 @@ CONTAINS
 #ifndef SinglePoint
          CALL landpatch%get_lonlat_radian (patchlonr, patchlatr)
 #else
-         patchlonr(:) = SITE_lon_location * pi/180. 
-         patchlatr(:) = SITE_lat_location * pi/180. 
+         patchlonr(:) = SITE_lon_location * pi/180.
+         patchlatr(:) = SITE_lat_location * pi/180.
 #endif
 
 #if (defined LULC_IGBP_PFT || defined LULC_IGBP_PC)
@@ -1125,7 +1125,7 @@ CONTAINS
 ! ...................
 ! 2.4 LEAF area index
 ! ...................
-#if(defined DYN_PHENOLOGY)
+#if (defined DYN_PHENOLOGY)
       ! CREATE fraction of vegetation cover, greenness, leaf area index, stem index
       IF (p_is_worker) THEN
 
@@ -1318,7 +1318,7 @@ CONTAINS
                ,use_soilini, nl_soil_ini, soil_z, soil_t(1:,i), soil_w(1:,i), use_snowini, snow_d(i) &
                ! for SOIL Water INIT by using water table depth
                ,use_wtd, zwtmm, zc_soimm, zi_soimm, vliq_r, nprms, prms)
-               
+
 #ifdef EXTERNAL_LAKE
             IF(patchtype(i) == 4) THEN
                z0m(i) = DEF_External_Lake%DEF_LAKE_Z0M

--- a/mkinidata/MOD_SoilColorRefl.F90
+++ b/mkinidata/MOD_SoilColorRefl.F90
@@ -54,7 +54,7 @@ CONTAINS
                          0.37, 0.35, 0.33, 0.31, 0.29, 0.27, 0.25, 0.23, 0.21, 0.19 /)
 
       ! Guessed soil color of the Lawrence's classification
-#if(defined LULC_USGS)
+#if (defined LULC_USGS)
       IF(L.eq. 0) isc = 1  ! 0  Ocean (not used)
       IF(L.eq. 1) isc = 16 ! 1  Urban and Built-Up Land
       IF(L.eq. 2) isc = 3  ! 2  Dryland Cropland and Pasture
@@ -82,7 +82,7 @@ CONTAINS
       IF(L.eq.24) isc = 1  !24  Snow or Ice (not used)
 #endif
 
-#if(defined LULC_IGBP)
+#if (defined LULC_IGBP)
       IF(L.eq. 0) isc = 1  !0   Ocean (not used)
       IF(L.eq. 1) isc = 17 !1   Evergreen Needleleaf Forest
       IF(L.eq. 2) isc = 18 !2   Evergreen Broadleaf Forest

--- a/mksrfdata/MOD_SingleSrfdata.F90
+++ b/mksrfdata/MOD_SingleSrfdata.F90
@@ -2112,6 +2112,32 @@ ENDIF
             ENDDO
          ENDIF
 
+         u_site_wf_clay = (USE_SITE_soilparameters) .and. ncio_var_exist(fsrfdata,'soil_wf_clay',USE_SITE_soilparameters)
+         IF (u_site_wf_clay) THEN
+            CALL ncio_read_serial (fsrfdata, 'soil_wf_clay', SITE_soil_wf_clay)
+         ELSE
+            allocate (SITE_soil_wf_clay (8))
+            DO nsl = 1, 8
+               write(c,'(i1)') nsl
+               filename = trim(DEF_dir_rawdata)//'/soil/wf_clay_s.nc'
+               CALL read_point_var_2d_real8 (gridsoil, filename, 'wf_clay_s_l'//trim(c), &
+                  SITE_lon_location, SITE_lat_location, SITE_soil_wf_clay(nsl))
+            ENDDO
+         ENDIF
+
+         u_site_wf_om = (USE_SITE_soilparameters) .and. ncio_var_exist(fsrfdata,'soil_wf_om',USE_SITE_soilparameters)
+         IF (u_site_wf_om) THEN
+            CALL ncio_read_serial (fsrfdata, 'soil_wf_om', SITE_soil_wf_om)
+         ELSE
+            allocate (SITE_soil_wf_om (8))
+            DO nsl = 1, 8
+               write(c,'(i1)') nsl
+               filename = trim(DEF_dir_rawdata)//'/soil/wf_om_s.nc'
+               CALL read_point_var_2d_real8 (gridsoil, filename, 'wf_om_s_l'//trim(c), &
+                  SITE_lon_location, SITE_lat_location, SITE_soil_wf_om(nsl))
+            ENDDO
+         ENDIF
+
          u_site_OM_density = (USE_SITE_soilparameters) .and. ncio_var_exist(fsrfdata,'soil_OM_density',USE_SITE_soilparameters)
          IF (u_site_OM_density) THEN
             CALL ncio_read_serial (fsrfdata, 'soil_OM_density', SITE_soil_OM_density)
@@ -2344,6 +2370,8 @@ ENDIF
          write(*,'(A,8ES10.2,3A)') 'soil_vf_om             : ', SITE_soil_vf_om            (1:8), ' (from ',trim(datasource(u_site_vf_om            )),')'
          write(*,'(A,8ES10.2,3A)') 'soil_wf_gravels        : ', SITE_soil_wf_gravels       (1:8), ' (from ',trim(datasource(u_site_wf_gravels       )),')'
          write(*,'(A,8ES10.2,3A)') 'soil_wf_sand           : ', SITE_soil_wf_sand          (1:8), ' (from ',trim(datasource(u_site_wf_sand          )),')'
+         write(*,'(A,8ES10.2,3A)') 'soil_wf_clay           : ', SITE_soil_wf_clay          (1:8), ' (from ',trim(datasource(u_site_wf_clay          )),')'
+         write(*,'(A,8ES10.2,3A)') 'soil_wf_om             : ', SITE_soil_wf_om            (1:8), ' (from ',trim(datasource(u_site_wf_om            )),')'
          write(*,'(A,8ES10.2,3A)') 'soil_OM_density        : ', SITE_soil_OM_density       (1:8), ' (from ',trim(datasource(u_site_OM_density       )),')'
          write(*,'(A,8ES10.2,3A)') 'soil_BD_all            : ', SITE_soil_BD_all           (1:8), ' (from ',trim(datasource(u_site_BD_all           )),')'
          write(*,'(A,8ES10.2,3A)') 'soil_theta_s           : ', SITE_soil_theta_s          (1:8), ' (from ',trim(datasource(u_site_theta_s          )),')'
@@ -2575,6 +2603,8 @@ ENDIF
          CALL ncio_read_serial (fsrfdata, 'soil_vf_om'            , SITE_soil_vf_om            )
          CALL ncio_read_serial (fsrfdata, 'soil_wf_gravels'       , SITE_soil_wf_gravels       )
          CALL ncio_read_serial (fsrfdata, 'soil_wf_sand'          , SITE_soil_wf_sand          )
+         CALL ncio_read_serial (fsrfdata, 'soil_wf_clay'          , SITE_soil_wf_clay          )
+         CALL ncio_read_serial (fsrfdata, 'soil_wf_om'            , SITE_soil_wf_om            )
 
          CALL ncio_read_serial (fsrfdata, 'soil_OM_density'       , SITE_soil_OM_density)
          CALL ncio_read_serial (fsrfdata, 'soil_BD_all'           , SITE_soil_BD_all    )
@@ -3129,6 +3159,14 @@ ENDIF
       CALL ncio_write_serial (fsrfdata, 'soil_wf_sand', SITE_soil_wf_sand(1:8), 'soil')
       CALL ncio_put_attr     (fsrfdata, 'soil_wf_sand', 'source', trim(datasource(u_site_wf_sand)))
       CALL ncio_put_attr     (fsrfdata, 'soil_wf_sand', 'long_name', 'gravimetric fraction of sand')
+
+      CALL ncio_write_serial (fsrfdata, 'soil_wf_clay', SITE_soil_wf_clay(1:8), 'soil')
+      CALL ncio_put_attr     (fsrfdata, 'soil_wf_clay', 'source', trim(datasource(u_site_wf_clay)))
+      CALL ncio_put_attr     (fsrfdata, 'soil_wf_clay', 'long_name', 'gravimetric fraction of clay')
+
+      CALL ncio_write_serial (fsrfdata, 'soil_wf_om', SITE_soil_wf_om(1:8), 'soil')
+      CALL ncio_put_attr     (fsrfdata, 'soil_wf_om', 'source', trim(datasource(u_site_wf_om)))
+      CALL ncio_put_attr     (fsrfdata, 'soil_wf_om', 'long_name', 'gravimetric fraction of om')
 
       CALL ncio_write_serial (fsrfdata, 'soil_OM_density', SITE_soil_OM_density(1:8), 'soil')
       CALL ncio_put_attr     (fsrfdata, 'soil_OM_density', 'source', trim(datasource(u_site_OM_density)))

--- a/preprocess/aggregation_landtypes.F90
+++ b/preprocess/aggregation_landtypes.F90
@@ -25,10 +25,10 @@ use MOD_SPMD_Task
 IMPLICIT NONE
 
 ! arguments:
-#if(defined LULC_USGS)
+#if (defined LULC_USGS)
       integer, parameter :: N_land_classification = 24 ! GLCC USGS number of land cover category
 #endif
-#if(defined LULC_IGBP)
+#if (defined LULC_IGBP)
       integer, parameter :: N_land_classification = 17 ! MODIS IGBP number of land cover category
 #endif
       integer, parameter :: nlat = 21600  ! 180*(60*2)
@@ -102,12 +102,12 @@ IMPLICIT NONE
       integer(kind=MPI_OFFSET_KIND) :: fdlast
 #endif
 
-#if(defined USE_POINT_DATA)
+#if (defined USE_POINT_DATA)
 
    allocate (fraction_patches(0:N_land_classification,1:lon_points,1:lat_points))
    fraction_patches(:,:,:) = 0.0
 
-#if(defined LULC_USGS)
+#if (defined LULC_USGS)
    fraction_patches(LULC_USGS,:,:) = 1.0
 #else
    fraction_patches(LULC_IGBP,:,:) = 1.0
@@ -120,11 +120,11 @@ IMPLICIT NONE
 
       allocate (landtypes(nlon,nrow_start:nrow_end))
 
-#if(defined LULC_USGS)
+#if (defined LULC_USGS)
      ! GLCC USGS classification
       lndname = trim(dir_rawdata)//'RAW_DATA_updated/landtypes_usgs_update.bin'
 #endif
-#if(defined LULC_IGBP)
+#if (defined LULC_IGBP)
      ! MODIS IGBP classification
       lndname = trim(dir_rawdata)//'RAW_DATA_updated/landtypes_igbp_update.bin'
 #endif
@@ -197,7 +197,7 @@ print *, 'OPENMP enabled, threads num = ', OPENMP
 #endif
       do j = 1, lat_points
 !----------------------modified by zsg--------------------------------------
-#if(defined USER_GRID)
+#if (defined USER_GRID)
          j1 = READ_row_UB(j)   ! read upper boundary of latitude
          j2 = READ_row_LB(j)   ! read lower boundary of latitude
 #else
@@ -206,7 +206,7 @@ print *, 'OPENMP enabled, threads num = ', OPENMP
 #endif
          do i = 1, lon_points
 
-#if(defined USER_GRID)
+#if (defined USER_GRID)
             i1 = READ_col_UB(i)   ! read upper boundary of longitude
             i2 = READ_col_LB(i)   ! read lower boundary of longitude
 #else
@@ -223,7 +223,7 @@ print *, 'OPENMP enabled, threads num = ', OPENMP
                   ncol_mod = mod(ncol,nlon)
                   if(ncol_mod == 0) ncol_mod = nlon
 
-#if(defined USER_GRID)
+#if (defined USER_GRID)
                   !-------find out the minimum distance for area weighting--------
                   area_for_sum = find_min_area(lone_rad(i),lonw_rad(i),lone_rad_i(ncol_mod),&
                                  lonw_rad_i(ncol_mod),sinn(j),sins(j),sinn_i(nrow),sins_i(nrow))
@@ -235,10 +235,10 @@ print *, 'OPENMP enabled, threads num = ', OPENMP
                   area_patches(L) = area_patches(L) + area_for_sum
                   area_grids = area_grids + area_for_sum
 
-#if(defined LULC_USGS)
+#if (defined LULC_USGS)
                   if(L==24)then  ! GLACIER/ICE SHEET (24)
 #endif
-#if(defined LULC_IGBP)
+#if (defined LULC_IGBP)
                   if(L==15)then  ! GLACIER/ICE SHEET (15)
 #endif
                      g_patches = 100.
@@ -256,11 +256,11 @@ print *, 'OPENMP enabled, threads num = ', OPENMP
 
             f_glacier_patches = a_glacier_patches / area_grids
             if(f_glacier_patches > 0.001)then     ! 0.1/100
-#if(defined LULC_USGS)
+#if (defined LULC_USGS)
                err_f_glacier = fraction_patches(24,i,j) - f_glacier_patches
                fraction_patches(24,i,j) = f_glacier_patches  ! GLCC USGS GLACIER/ICE SHEET (24)
 #endif
-#if(defined LULC_IGBP)
+#if (defined LULC_IGBP)
                err_f_glacier = fraction_patches(15,i,j) - f_glacier_patches
                fraction_patches(15,i,j) = f_glacier_patches  ! MODIS IGBP GLACIER/ICE SHEET (15)
 #endif

--- a/preprocess/rd_land_types.F90
+++ b/preprocess/rd_land_types.F90
@@ -124,10 +124,10 @@ IMPLICIT NONE
 
       ! (2) global land cover characteristics
       ! ---------------------------------
-#if(defined LULC_USGS)
+#if (defined LULC_USGS)
       integer, allocatable :: landtypes_usgs(:,:)  ! GLCC USGS land cover types
 #endif
-#if(defined LULC_IGBP)
+#if (defined LULC_IGBP)
       integer, allocatable :: landtypes_igbp(:,:)  ! MODIS IGBP land cover types
 #endif
 
@@ -198,10 +198,10 @@ IMPLICIT NONE
 !   ---------------------------------------------------------------
 !
       allocate ( elevation      (nlon,buff_lb:buff_ub) ,&
-#if(defined LULC_USGS)
+#if (defined LULC_USGS)
                  landtypes_usgs (nlon,buff_lb:buff_ub) ,&
 #endif
-#if(defined LULC_IGBP)
+#if (defined LULC_IGBP)
                  landtypes_igbp (nlon,buff_lb:buff_ub) ,&
 #endif
 
@@ -270,7 +270,7 @@ IMPLICIT NONE
 ! ........................................
 !     (2.1) global land cover type (version 2.0) (USGS)
 
-#if(defined LULC_USGS)
+#if (defined LULC_USGS)
      ! GLCC USGS classification
      ! -------------------
 
@@ -347,7 +347,7 @@ IMPLICIT NONE
       IF (p_master) print*,'land water points =', ii, 'wetland points=', iii, 'glacier points=', iiii, 'urban points=', jjj
 #endif
 
-#if(defined LULC_IGBP)
+#if (defined LULC_IGBP)
      ! MODIS IGBP classification
      ! -------------------
 
@@ -457,10 +457,10 @@ IMPLICIT NONE
             IF(elevation(ncol,nrow)>-9990) THEN
                ! Replace GLCC_USGS and MODIS_IGBP water bodies with GLWD classification
                IF(lakewetland(ncol,nrow) <= 3) THEN
-#if(defined LULC_USGS)
+#if (defined LULC_USGS)
                   landtypes_usgs(ncol,nrow) = 16
 #endif
-#if(defined LULC_IGBP)
+#if (defined LULC_IGBP)
                   landtypes_igbp(ncol,nrow) = 17
 #endif
                   ii = ii + 1
@@ -470,10 +470,10 @@ IMPLICIT NONE
                !IF(lakewetland(ncol,nrow) > 3 .and. lakewetland(ncol,nrow) < 13)THEN
 ! deleted by dai, 08/15/2016
 !               IF(lakewetland(ncol,nrow) > 3 .and. lakewetland(ncol,nrow) < 11)THEN
-!#if(defined LULC_USGS)
+!#if (defined LULC_USGS)
 !                  landtypes_usgs(ncol,nrow) = 17
 !#endif
-!#if(defined LULC_IGBP)
+!#if (defined LULC_IGBP)
 !                  landtypes_igbp(ncol,nrow) = 11
 !#endif
 !                  iii = iii + 1
@@ -536,23 +536,23 @@ IMPLICIT NONE
             IF(elevation(ncol,nrow)>-9990) THEN
                ! Replace GLCC and MODIS glacier/ice sheet with glacier specific dataset
                IF(glacier(ncol,nrow) > 0.5 .and. glacier(ncol,nrow) < 101.)THEN
-#if(defined LULC_USGS)
+#if (defined LULC_USGS)
                   landtypes_usgs(ncol,nrow) = 24
 #endif
-#if(defined LULC_IGBP)
+#if (defined LULC_IGBP)
                   landtypes_igbp(ncol,nrow) = 15
 #endif
                   ii = ii + 1
                ENDIF
                ! Antarctic (ice sheet / barren ONLY)
                IF(nrow > 18000)THEN  ! (90N + 60S) * 120
-#if(defined LULC_USGS)
+#if (defined LULC_USGS)
                   IF(landtypes_usgs(ncol,nrow)/=23)THEN
                      landtypes_usgs(ncol,nrow) = 24
                      glacier(ncol,nrow) = 100.
                   ENDIF
 #endif
-#if(defined LULC_IGBP)
+#if (defined LULC_IGBP)
                   IF(landtypes_igbp(ncol,nrow)/=16)THEN
                      landtypes_igbp(ncol,nrow) = 15
                      glacier(ncol,nrow) = 100.
@@ -563,13 +563,13 @@ IMPLICIT NONE
 !               ! Greenland  (ice sheet / barren / built-up ONLY)
 !               ! BETWEEN (59-83N, 74-11W) =>| 0<nrow<(90-31)*120, (180-74)*120<ncol<(180-11)*120
 !               IF(nrow<3720 .and. (ncol>12720 .and. ncol<20280))THEN
-!#if(defined LULC_USGS)
+!#if (defined LULC_USGS)
 !                  IF(landtypes_usgs(ncol,nrow)/=23 .or. landtypes_usgs(ncol,nrow)/=1)THEN
 !                     landtypes_usgs(ncol,nrow) = 24
 !                     glacier(ncol,nrow) = 100.
 !                  ENDIF
 !#endif
-!#if(defined LULC_IGBP)
+!#if (defined LULC_IGBP)
 !                  IF(landtypes_igbp(ncol,nrow)/=16 .or. landtypes_igbp(ncol,nrow)/=13)THEN
 !                     landtypes_igbp(ncol,nrow) = 15
 !                     glacier(ncol,nrow) = 100.
@@ -631,10 +631,10 @@ IMPLICIT NONE
             IF(elevation(ncol,nrow)>-9990) THEN
                ! Replace GLCC and MODIS urban/built-up with urban specific dataset
                IF(urban(ncol,nrow) == 1)THEN
-#if(defined LULC_USGS)
+#if (defined LULC_USGS)
                   landtypes_usgs(ncol,nrow) = 1
 #endif
-#if(defined LULC_IGBP)
+#if (defined LULC_IGBP)
                   landtypes_igbp(ncol,nrow) = 13
 #endif
                   ii = ii + 1
@@ -664,8 +664,8 @@ IMPLICIT NONE
       IF (p_master) print*,'URBAN'
       IF (p_master) print*,'Urban and Built-up Land Points =', ii
 
-#if(defined CoLMDEBUG)
-#if(defined LULC_USGS)
+#if (defined CoLMDEBUG)
+#if (defined LULC_USGS)
       ii = 0
       iii = 0
       iiii = 0
@@ -706,7 +706,7 @@ IMPLICIT NONE
       IF (p_master) print*,'land water points =', ii, 'wetland points=', iii, 'glacier points=', iiii, 'urban points=', jjj
 #endif
 
-#if(defined LULC_IGBP)
+#if (defined LULC_IGBP)
       ii = 0
       iii = 0
       iiii = 0
@@ -749,10 +749,10 @@ IMPLICIT NONE
 #endif
 
 #if (defined usempi)
-#if(defined LULC_USGS)
+#if (defined LULC_USGS)
       CALL update_buff (landtypes_usgs, nlon, nlat, buff_lb, nrow_start, nrow_end, buff_ub)
 #endif
-#if(defined LULC_IGBP)
+#if (defined LULC_IGBP)
       CALL update_buff (landtypes_igbp, nlon, nlat, buff_lb, nrow_start, nrow_end, buff_ub)
 #endif
 #endif
@@ -763,7 +763,7 @@ IMPLICIT NONE
       allocate (ntmp(nlon,buff_lb:buff_ub))
 !      ! WATER BODIES
 !      ! ------------
-!#if(defined LULC_USGS)
+!#if (defined LULC_USGS)
 !      iii = 0
 !
 !      ! GLCC USGS land cover classification (WATER BODIES)
@@ -799,7 +799,7 @@ IMPLICIT NONE
 !      IF (p_master) print*, 'GLCC WATER BODIES','iii=',iii
 !#endif
 !
-!#if(defined LULC_IGBP)
+!#if (defined LULC_IGBP)
 !      iii = 0
 !
 !      ! MODIS IGBP land cover classification (WATER BODIES)
@@ -835,8 +835,8 @@ IMPLICIT NONE
 !      IF (p_master) print*, 'MODIS IGBP WATER BODIES','iii=',iii
 !#endif
 !
-!#if(defined CoLMDEBUG)
-!#if(defined LULC_USGS)
+!#if (defined CoLMDEBUG)
+!#if (defined LULC_USGS)
 !      iiii = 0
 !
 !      DO j = nrow_start, nrow_end
@@ -857,7 +857,7 @@ IMPLICIT NONE
 !#endif
 !      IF (p_master) print*, 'GLCC WATER BODIES','iiii=',iiii
 !#endif
-!#if(defined LULC_IGBP)
+!#if (defined LULC_IGBP)
 !      iiii = 0
 !
 !      DO j = nrow_start, nrow_end
@@ -886,7 +886,7 @@ IMPLICIT NONE
 !
 !      ! WETLAND
 !      ! -------
-!#if(defined LULC_USGS)
+!#if (defined LULC_USGS)
 !      iii = 0
 !
 !      ! GLCC USGS land cover classification (WETLAND)
@@ -919,7 +919,7 @@ IMPLICIT NONE
 !      IF (p_master) print*, 'GLCC WETLAND','iii=',iii
 !#endif
 !
-!#if(defined LULC_IGBP)
+!#if (defined LULC_IGBP)
 !      iii = 0
 !
 !      ! MODIS land cover classification (WETLAND)
@@ -952,8 +952,8 @@ IMPLICIT NONE
 !      IF (p_master) print*, 'MODIS IGBP WETLAND','iii=',iii
 !#endif
 !
-!#if(defined CoLMDEBUG)
-!#if(defined LULC_USGS)
+!#if (defined CoLMDEBUG)
+!#if (defined LULC_USGS)
 !      iiii = 0
 !
 !      DO j = nrow_start, nrow_end
@@ -974,7 +974,7 @@ IMPLICIT NONE
 !#endif
 !      IF (p_master) print*, 'GLCC WETLAND', 'iiii=',iiii
 !#endif
-!#if(defined LULC_IGBP)
+!#if (defined LULC_IGBP)
 !      iiii = 0
 !
 !      DO j = nrow_start, nrow_end
@@ -999,7 +999,7 @@ IMPLICIT NONE
 
       ! GLACIER/ICESHEET
       ! ------------------
-#if(defined LULC_USGS)
+#if (defined LULC_USGS)
       iii = 0
 
       ! GLCC USGS land cover classification (GLACIER/ICESHEET)
@@ -1034,7 +1034,7 @@ IMPLICIT NONE
 #endif
       IF (p_master) print*, 'GLCC GLACIER/ICESHEET','iii=',iii
 #endif
-#if(defined LULC_IGBP)
+#if (defined LULC_IGBP)
       iii = 0
 
       ! MODIS IGBP land cover classification (GLACIER/ICESHEET)
@@ -1070,8 +1070,8 @@ IMPLICIT NONE
       IF (p_master) print*, 'MODIS IGBP GLACIER/ICESHEET','iii=',iii
 #endif
 
-#if(defined CoLMDEBUG)
-#if(defined LULC_USGS)
+#if (defined CoLMDEBUG)
+#if (defined LULC_USGS)
       iiii = 0
 
       DO j = nrow_start, nrow_end
@@ -1092,7 +1092,7 @@ IMPLICIT NONE
 #endif
       IF (p_master) print*, 'GLCC GLACIER/ICESHEET', 'iiii=',iiii
 #endif
-#if(defined LULC_IGBP)
+#if (defined LULC_IGBP)
       iiii = 0
 
       DO j = nrow_start, nrow_end
@@ -1117,7 +1117,7 @@ IMPLICIT NONE
 
       ! URBAN and BUILT-UP LAND
       ! ------------------
-#if(defined LULC_USGS)
+#if (defined LULC_USGS)
       iii = 0
 
       ! GLCC USGS land cover classification (URBAN and BUILT-UP LAND)
@@ -1153,7 +1153,7 @@ IMPLICIT NONE
       IF (p_master) print*, 'GLCC URBAN and BUILT-UP LAND','iii=',iii
 #endif
 
-#if(defined LULC_IGBP)
+#if (defined LULC_IGBP)
       iii = 0
 
       ! MODIS IGBP land cover classification (URBAN and BUILT-UP LAND)
@@ -1189,8 +1189,8 @@ IMPLICIT NONE
       IF (p_master) print*, 'MODIS IGBP URBAN and BUILT-UP LAND','iii=',iii
 #endif
 
-#if(defined CoLMDEBUG)
-#if(defined LULC_USGS)
+#if (defined CoLMDEBUG)
+#if (defined LULC_USGS)
       iiii = 0
 
       DO j = nrow_start, nrow_end
@@ -1212,7 +1212,7 @@ IMPLICIT NONE
       IF (p_master) print*, 'GLCC URBAN and BUILT-UP LAND', 'iiii=',iiii
 #endif
 
-#if(defined LULC_IGBP)
+#if (defined LULC_IGBP)
       iiii = 0
       DO j = nrow_start, nrow_end
          DO i = 1, nlon
@@ -1235,8 +1235,8 @@ IMPLICIT NONE
 #endif
 
       !--------------------------------------------------------------------
-#if(defined CoLMDEBUG)
-#if(defined LULC_USGS)
+#if (defined CoLMDEBUG)
+#if (defined LULC_USGS)
       ii = 0
       iii = 0
       iiii = 0
@@ -1279,7 +1279,7 @@ IMPLICIT NONE
       IF (p_master) print*,'land water points =', ii, 'wetland points=', iii, 'glacier points=', iiii, 'urban points=', jjj
 #endif
 
-#if(defined LULC_IGBP)
+#if (defined LULC_IGBP)
       ii = 0
       iii = 0
       iiii = 0
@@ -1323,7 +1323,7 @@ IMPLICIT NONE
 #endif
 #endif
 
-!#if(defined ongoing)
+!#if (defined ongoing)
 ! ..............................................
 ! ... (6) global cultural characteristics (crops)
 ! ..............................................
@@ -1331,7 +1331,7 @@ IMPLICIT NONE
 !#endif
 
 ! Write out the land cover types
-#if(defined LULC_USGS)
+#if (defined LULC_USGS)
      ! GLCC USGS classification
      ! -------------------
       lndname = trim(dir_rawdata)//'RAW_DATA_updated/landtypes_usgs_update.bin'
@@ -1357,7 +1357,7 @@ IMPLICIT NONE
       close (iunit)
 #endif
 #endif
-#if(defined LULC_IGBP)
+#if (defined LULC_IGBP)
      ! MODIS IGBP classification
      ! -------------------
       lndname = trim(dir_rawdata)//'RAW_DATA_updated/landtypes_igbp_update.bin'
@@ -1393,10 +1393,10 @@ IMPLICIT NONE
 
       deallocate ( ntmp )
       deallocate ( elevation      ,&
-#if(defined LULC_USGS)
+#if (defined LULC_USGS)
                    landtypes_usgs ,&
 #endif
-#if(defined LULC_IGBP)
+#if (defined LULC_IGBP)
                    landtypes_igbp ,&
 #endif
                    lakewetland    ,&

--- a/preprocess/rd_soil_properties.F90
+++ b/preprocess/rd_soil_properties.F90
@@ -175,7 +175,7 @@ IMPLICIT NONE
       inquire(iolength=length) land_chr1
       allocate ( landtypes(nlon,nlat) )
 
-#if(defined LULC_USGS)
+#if (defined LULC_USGS)
      ! GLCC USGS classification
      ! -------------------
       lndname = trim(dir_rawdata)//'RAW_DATA_updated/landtypes_usgs_update.bin'
@@ -189,7 +189,7 @@ IMPLICIT NONE
       close (iunit)
 #endif
 
-#if(defined LULC_IGBP)
+#if (defined LULC_IGBP)
      ! MODIS IGBP classification
      ! -------------------
       lndname = trim(dir_rawdata)//'RAW_DATA_updated/landtypes_igbp_update.bin'
@@ -415,10 +415,10 @@ print *, 'OPENMP enabled, threads num = ', OPENMP, "soil parameters..."
 
                if(soil_grav_l < 0.0) soil_grav_l = 0.0  ! missing value = -1
 
-#if(defined LULC_USGS)
+#if (defined LULC_USGS)
                if(landtypes(i,j)==16)then   !WATER BODIES(16)
 #endif
-#if(defined LULC_IGBP)
+#if (defined LULC_IGBP)
                if(landtypes(i,j)==17)then   !WATER BODIES(17)
 #endif
                   soil_grav_l = 0.
@@ -428,10 +428,10 @@ print *, 'OPENMP enabled, threads num = ', OPENMP, "soil parameters..."
                   soil_bd_l   = 1.2
                endif
 
-#if(defined LULC_USGS)
+#if (defined LULC_USGS)
                if(landtypes(i,j)==24)then   !GLACIER and ICESHEET(24)
 #endif
-#if(defined LULC_IGBP)
+#if (defined LULC_IGBP)
                if(landtypes(i,j)==15)then   !GLACIER and ICE SHEET(15)
 #endif
                   soil_grav_l = 90.
@@ -441,7 +441,7 @@ print *, 'OPENMP enabled, threads num = ', OPENMP, "soil parameters..."
                   soil_bd_l   = 2.0
                endif
 
-#if(defined Gravels0)
+#if (defined Gravels0)
                   soil_grav_l = 0.0
 #endif
 

--- a/share/MOD_RangeCheck.F90
+++ b/share/MOD_RangeCheck.F90
@@ -166,7 +166,7 @@ CONTAINS
 
          write(*,'(A)') trim(str_print)
 
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
          IF (len_trim(exception) > 0) THEN
             CALL CoLM_stop ()
          ENDIF
@@ -290,7 +290,7 @@ CONTAINS
 
          write(*,'(A)') trim(str_print)
 
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
          IF (len_trim(exception) > 0) THEN
             CALL CoLM_stop ()
          ENDIF
@@ -415,7 +415,7 @@ CONTAINS
 
          write(*,'(A)') trim(str_print)
 
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
          IF (len_trim(exception) > 0) THEN
             CALL CoLM_stop ()
          ENDIF
@@ -532,7 +532,7 @@ CONTAINS
 #endif
          ENDIF
       ENDIF
-      
+
       IF (p_is_master) THEN
 #ifdef USEMPI
          CALL mpi_recv (exception, 256, MPI_CHARACTER, p_address_worker(p_root), &
@@ -543,7 +543,7 @@ CONTAINS
 
          write(*,'(A)') trim(str_print)
 
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
          IF (len_trim(exception) > 0) THEN
             CALL CoLM_stop ()
          ENDIF
@@ -662,7 +662,7 @@ CONTAINS
 #endif
          ENDIF
       ENDIF
-      
+
       IF (p_is_master) THEN
 #ifdef USEMPI
          CALL mpi_recv (exception, 256, MPI_CHARACTER, p_address_worker(p_root), &
@@ -673,7 +673,7 @@ CONTAINS
 
          write(*,'(A)') trim(str_print)
 
-#if(defined CoLMDEBUG)
+#if (defined CoLMDEBUG)
          IF (len_trim(exception) > 0) THEN
             CALL CoLM_stop ()
          ENDIF
@@ -757,7 +757,7 @@ CONTAINS
 #endif
          ENDIF
       ENDIF
-      
+
       IF (p_is_master) THEN
 #ifdef USEMPI
          CALL mpi_recv (str_print, 256, MPI_CHARACTER, p_address_worker(p_root), &


### PR DESCRIPTION
    -add(MOD_SingleSrfdata.F90):
        read soil wf_clay and wf_om for single point urban.

    -mod(mksrfdata/MOD_SingleSrfdata.F90): 
        Optimize urban single point code to be consistent with natural single point.
    
    -fix(mksrfdata/MOD_SingleSrfdata.F90): 
        fix a bug when use lake and tree coverage from CoLM2024 raw data.

    -adj(*.F90):
        add a space after #if for printing code with bold fonts.

    -fix(MOD_Urban_Flux.F90):
        correct a macro name CLMDEBUG to CoLMDEBUG.