### PR TITLE
1) bug fix for lulcc surface diag memory allocation [by @Wanyi Lin and @Wenzong Dong]; 2) modify for forcing read when reaching the end time by difined; 3) code annotation and format adjustment.

### DIFF
--- a/main/CoLM.F90
+++ b/main/CoLM.F90
@@ -460,7 +460,7 @@ PROGRAM CoLM
          CALL do_DataAssimilation (idate, deltim)
 #endif
 
-         ! Write out the model variables for restart run and the histroy file
+         ! Write out the model histroy file
          ! ----------------------------------------------------------------------
          CALL hist_out (idate, deltim, itstamp, etstamp, ptstamp, dir_hist, casename)
 
@@ -526,6 +526,8 @@ PROGRAM CoLM
          ENDIF
 #endif
 
+         ! Write out the model state variables for restart run
+         ! ----------------------------------------------------------------------
          IF (save_to_restart (idate, deltim, itstamp, ptstamp)) THEN
 #ifdef LULCC
             CALL WRITE_TimeVariables (jdate, jdate(1), casename, dir_restart)

--- a/main/CoLM.F90
+++ b/main/CoLM.F90
@@ -478,7 +478,7 @@ PROGRAM CoLM
             CALL hist_final    ()
 
             ! Call LULCC driver
-            CALL LulccDriver (casename,dir_landdata,dir_restart,idate,greenwich)
+            CALL LulccDriver (casename, dir_landdata, dir_restart, idate, greenwich)
 
             ! Allocate Forcing and Fluxes variable of next year
             CALL allocate_1D_Forcing

--- a/main/CoLMMAIN.F90
+++ b/main/CoLMMAIN.F90
@@ -123,7 +123,9 @@ SUBROUTINE CoLMMAIN ( &
 !                  snowcompaction           |]           = 3 (land ice)
 !                  snowlayerscombine        |]           = 4 (lake)
 !                  snowlayersdivide         |]
-!                  snowage                  |]
+!
+!                  GLACIER_TEMP             |] glacier model
+!                  GLACIER_WATER            |]
 !
 !                  newsnow_lake             |]
 !                  laketem                  |] lake scheme
@@ -132,7 +134,7 @@ SUBROUTINE CoLMMAIN ( &
 !                  SOCEAN                   |> ocean and sea ice
 !
 !                  orb_coszen               |> all surface
-!                  EcoModel (LAI_empirical) |> land
+!                  EcoModel (LAI_empirical) |> land - not actived
 !                  snowfraction             |> land
 !                  albland                  |> land
 !                  albocean                 |> ocean & sea ice

--- a/main/LULCC/MOD_Lulcc_Driver.F90
+++ b/main/LULCC/MOD_Lulcc_Driver.F90
@@ -13,8 +13,8 @@ MODULE MOD_Lulcc_Driver
  CONTAINS
 
 
-   SUBROUTINE LulccDriver (casename,dir_landdata,dir_restart,&
-                           idate,greenwich)
+   SUBROUTINE LulccDriver (casename, dir_landdata, dir_restart, &
+                           idate, greenwich)
 
 !-----------------------------------------------------------------------
 !
@@ -117,8 +117,8 @@ MODULE MOD_Lulcc_Driver
          print *, ">>> LULCC: initializing..."
       ENDIF
 
-      CALL LulccInitialize (casename,dir_landdata,dir_restart,&
-                            idate,greenwich)
+      CALL LulccInitialize (casename, dir_landdata, dir_restart, &
+                            idate, greenwich)
 
 
       ! =============================================================

--- a/main/LULCC/MOD_Lulcc_Initialize.F90
+++ b/main/LULCC/MOD_Lulcc_Initialize.F90
@@ -11,8 +11,8 @@ MODULE MOD_Lulcc_Initialize
 
 CONTAINS
 
-   SUBROUTINE LulccInitialize (casename,dir_landdata,dir_restart,&
-                               idate,greenwich)
+   SUBROUTINE LulccInitialize (casename, dir_landdata, dir_restart, &
+                               idate, greenwich)
 
 !-----------------------------------------------------------------------
 !
@@ -65,8 +65,7 @@ CONTAINS
 
 !-----------------------------------------------------------------------
 
-      ! initial time of model run
-      ! ............................
+      ! initial time of model run and consts
       CALL adj2begin(idate)
 
       year = idate(1)
@@ -132,9 +131,9 @@ CONTAINS
       CALL init_gridbased_mesh_grid ()
       CALL gdiag%define_by_copy (gridmesh)
 #else
-      CALL gdiag%define_by_ndims(3600,1800)
+      CALL gdiag%define_by_ndims (3600,1800)
 #endif
-      CALL srfdata_diag_init (dir_landdata,lulcc_call=.true.)
+      CALL srfdata_diag_init (dir_landdata, lulcc_call=.true.)
 #endif
 
       ! --------------------------------------------------------------------
@@ -144,8 +143,8 @@ CONTAINS
       CALL deallocate_TimeVariables
 
       ! initialize all state variables of next year
-      CALL initialize (casename,dir_landdata,dir_restart,&
-                       idate,year,greenwich,lulcc_call=.true.)
+      CALL initialize (casename, dir_landdata, dir_restart,&
+                       idate, year, greenwich, lulcc_call=.true.)
 
    END SUBROUTINE LulccInitialize
 

--- a/main/MOD_Forcing.F90
+++ b/main/MOD_Forcing.F90
@@ -1073,7 +1073,7 @@ CONTAINS
             CALL block_data_copy (metdata, forcn_UB(ivar))
 
             ! calculate time average coszen, for shortwave radiation
-            IF (tintalgo(ivar) == 'coszen') THEN
+            IF (ivar == 7) THEN
                CALL calavgcos(idate)
             ENDIF
          ENDIF

--- a/main/MOD_Forcing.F90
+++ b/main/MOD_Forcing.F90
@@ -1035,7 +1035,7 @@ CONTAINS
             CALL setstampUB(ivar, year, month, day, time_i)
 
             ! when reaching the END of forcing data, show a Warning but still try to run
-            IF (year <= endyr) THEN
+            IF ( year>endyr .or. (month>endmo .and. year==endyr) ) THEN
                write(*,*) 'model year: ', year, 'forcing end year defined: ', endyr
                print *, 'Warning: reaching the END of forcing data defined!'
             ENDIF


### PR DESCRIPTION
    -add(mksrfdata/MOD_SrfdataDiag.F90):
        Add 'forc_free_mem' to avoid repeat allocation for output LULCC TransferMatrix.

    -add(main/LULCC/MOD_Lulcc_Initialize.F90):
        add lulcc_call to control 'forc_free_mem' CALL.

    -mod(CoLM.F90,CoLMMAIN.F90):
        modify the head annotation for CoLMMAIN.F90 and CoLM.F90.

    -mod(MOD_Forcing.F90):
        when the modeling year is beyond the forcing end year defined,
        only show warning msg, model will still run until error occurs.