### PR TITLE
LAI reading fix for year beyond the data available. [report by @Xianxiang Li]

### DIFF
--- a/main/LULCC/MOD_Lulcc_MassEnergyConserve.F90
+++ b/main/LULCC/MOD_Lulcc_MassEnergyConserve.F90
@@ -839,7 +839,7 @@ ENDIF
 
                         ! account for vegetation snow
                         IF ( DEF_VEG_SNOW ) THEN
-                           lai_p(np) = tlai_p(np) * sigf_p(np)
+                           lai_p(ps:pe) = tlai_p(ps:pe) * sigf_p(ps:pe)
                            lai(np) = sum(lai_p(ps:pe)*pftfrac(ps:pe))
                         ENDIF
 

--- a/main/MOD_Albedo.F90
+++ b/main/MOD_Albedo.F90
@@ -1342,31 +1342,32 @@ ENDIF
                           albgrd_dst    ,albgri_dst    ,flx_absdv     ,flx_absdn     ,&
                           flx_absiv     ,flx_absin      )
 
-   ! !DESCRIPTION:
-   ! The calling sequence is:
-   ! -> SNICAR_RT:   snow albedos: direct beam (SNICAR)
-   !    or
-   !    SNICAR_AD_RT: snow albedos: direct beam (SNICAR-AD)
-   ! -> SNICAR_RT:   snow albedos: diffuse (SNICAR)
-   !    or
-   !    SNICAR_AD_RT:   snow albedos: diffuse (SNICAR-AD)
-   !
-   ! ORIGINAL:
-   ! 1) The Community Land Model version5.0 (CLM5.0)
-   ! 2) Energy Exascale Earth System Model version 2.0 (E3SM v2.0) Land Model (ELM v2.0)
-   !
-   ! REFERENCES:
-   ! 1) Flanner et al, 2021, SNICAR-ADv3: a community tool for modeling spectral snow albedo.
-   ! Geosci. Model Dev., 14, 7673-7704, https://doi.org/10.5194/gmd-14-7673-2021
-   ! 2) Hao et al., 2023, Improving snow albedo modeling in the E3SM land model (version 2.0)
-   ! and assessing its impacts on snow and surface fluxes over the Tibetan Plateau.
-   ! Geosci. Model Dev., 16, 75-94, https://doi.org/10.5194/gmd-16-75-2023
-   !
-   ! REVISIONS:
-   ! Yongjiu Dai, and Hua Yuan, December, 2022 : ASSEMBLING and FITTING
-
-   !-----------------------------------------------------------------------
-   ! !USES:
+!-----------------------------------------------------------------------
+! !DESCRIPTION:
+!  The calling sequence is:
+!  -> SNICAR_RT:   snow albedos: direct beam (SNICAR)
+!     or
+!     SNICAR_AD_RT: snow albedos: direct beam (SNICAR-AD)
+!  -> SNICAR_RT:   snow albedos: diffuse (SNICAR)
+!     or
+!     SNICAR_AD_RT:   snow albedos: diffuse (SNICAR-AD)
+!
+! !ORIGINAL:
+!  1) The Community Land Model version5.0 (CLM5.0)
+!  2) Energy Exascale Earth System Model version 2.0 (E3SM v2.0) Land Model (ELM v2.0)
+!
+! !REFERENCES:
+!  1) Flanner et al, 2021, SNICAR-ADv3: a community tool for modeling spectral snow albedo.
+!  Geosci. Model Dev., 14, 7673-7704, https://doi.org/10.5194/gmd-14-7673-2021
+!  2) Hao et al., 2023, Improving snow albedo modeling in the E3SM land model (version 2.0)
+!  and assessing its impacts on snow and surface fluxes over the Tibetan Plateau.
+!  Geosci. Model Dev., 16, 75-94, https://doi.org/10.5194/gmd-16-75-2023
+!
+! !REVISIONS:
+!  Yongjiu Dai, and Hua Yuan, December, 2022 : ASSEMBLING and FITTING
+!
+!-----------------------------------------------------------------------
+! !USES:
    USE MOD_Vars_Global, only: maxsnl
    USE MOD_SnowSnicar, only: SNICAR_RT, SNICAR_AD_RT
 

--- a/main/MOD_Vars_TimeVariables.F90
+++ b/main/MOD_Vars_TimeVariables.F90
@@ -1097,7 +1097,7 @@ ENDIF
 #endif
 
 #ifdef EXTERNAL_LAKE
-      CALL WRITE_LakeTimeVars (idate, lc_year, site, dir_restart) 
+      CALL WRITE_LakeTimeVars (idate, lc_year, site, dir_restart)
 #endif
 
    END SUBROUTINE WRITE_TimeVariables
@@ -1289,7 +1289,7 @@ ENDIF
 #endif
 
       IF (p_is_master) THEN
-         write(*,*) 'Loading Time Variables done.'
+         write(*,'(A29)') 'Loading Time Variables done.'
       ENDIF
 
    END SUBROUTINE READ_TimeVariables

--- a/mksrfdata/Aggregation_LAI.F90
+++ b/mksrfdata/Aggregation_LAI.F90
@@ -143,8 +143,10 @@ SUBROUTINE Aggregation_LAI (gridlai, dir_rawdata, dir_model_landdata, lc_year)
          ntime      = 12
 #else
          IF (DEF_LAI_CHANGE_YEARLY) THEN
-            start_year = max(simulation_lai_year_start, DEF_LAI_START_YEAR)
-            end_year   = min(simulation_lai_year_end,   DEF_LAI_END_YEAR  )
+            start_year = max(simulation_lai_year_start, DEF_LAI_START_YEAR )
+            start_year = min(start_year,                DEF_LAI_END_YEAR   )
+            end_year   = min(simulation_lai_year_end,   DEF_LAI_END_YEAR   )
+            end_year   = max(end_year,                  DEF_LAI_START_YEAR )
             ntime      = 12
          ELSE
             start_year = lc_year
@@ -361,8 +363,10 @@ SUBROUTINE Aggregation_LAI (gridlai, dir_rawdata, dir_model_landdata, lc_year)
          ntime      = 12
 #else
       IF (DEF_LAI_CHANGE_YEARLY) THEN
-         start_year = max(simulation_lai_year_start, DEF_LAI_START_YEAR)
-         end_year   = min(simulation_lai_year_end,   DEF_LAI_END_YEAR  )
+         start_year = max(simulation_lai_year_start, DEF_LAI_START_YEAR )
+         start_year = min(start_year,                DEF_LAI_END_YEAR   )
+         end_year   = min(simulation_lai_year_end,   DEF_LAI_END_YEAR   )
+         end_year   = max(end_year,                  DEF_LAI_START_YEAR )
          ntime      = 12
       ELSE
          start_year = lc_year

--- a/mksrfdata/MOD_SingleSrfdata.F90
+++ b/mksrfdata/MOD_SingleSrfdata.F90
@@ -558,8 +558,10 @@ CONTAINS
          simulation_lai_year_end = idate(1)
 
          IF (DEF_LAI_CHANGE_YEARLY) THEN
-            start_year = max(simulation_lai_year_start, DEF_LAI_START_YEAR)
-            end_year   = min(simulation_lai_year_end,   DEF_LAI_END_YEAR  )
+            start_year = max(simulation_lai_year_start, DEF_LAI_START_YEAR )
+            start_year = min(start_year,                DEF_LAI_END_YEAR   )
+            end_year   = min(simulation_lai_year_end,   DEF_LAI_END_YEAR   )
+            end_year   = max(end_year,                  DEF_LAI_START_YEAR )
          ELSE
             start_year = DEF_LC_YEAR
             end_year   = DEF_LC_YEAR
@@ -1666,8 +1668,10 @@ ENDIF
             simulation_lai_year_end = idate(1)
 
             IF (DEF_LAI_CHANGE_YEARLY) THEN
-               start_year = max(simulation_lai_year_start, DEF_LAI_START_YEAR)
-               end_year   = min(simulation_lai_year_end,   DEF_LAI_END_YEAR  )
+               start_year = max(simulation_lai_year_start, DEF_LAI_START_YEAR )
+               start_year = min(start_year,                DEF_LAI_END_YEAR   )
+               end_year   = min(simulation_lai_year_end,   DEF_LAI_END_YEAR   )
+               end_year   = max(end_year,                  DEF_LAI_START_YEAR )
             ELSE
                start_year = DEF_LC_YEAR
                end_year   = DEF_LC_YEAR


### PR DESCRIPTION
    -fix(Aggregation_LAI.F90,MOD_SingleSrfdata.F90):
        fix for the start year after the END year available or
        the end year before the START year available.