### PR TITLE
1) Make lulcc transfer trace&matrix in mksrfdata stage instead of running [by @Wanyi Lin]; 2) some code optimazations and functions added; 3) bug fix for K/U profile [report by @Baiying Liu], single point forcing time judgement; 4) code indent and format adjustment.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ OBJS_MKSRFDATA = \
 				  Aggregation_TopographyFactors.o   \
 				  Aggregation_Urban.o               \
 				  Aggregation_SoilTexture.o         \
+				  MOD_Lulcc_TransferTrace.o         \
 				  MKSRFDATA.o
 
 $(OBJS_MKSRFDATA) : %.o : %.F90 ${HEADER} ${OBJS_SHARED}
@@ -317,9 +318,9 @@ OBJS_MAIN = \
 				CoLMMAIN_Urban.o                          \
 				MOD_Lulcc_Vars_TimeInvariants.o           \
 				MOD_Lulcc_Vars_TimeVariables.o            \
-				MOD_Lulcc_Initialize.o                    \
-				MOD_Lulcc_TransferTrace.o                 \
+				MOD_Lulcc_TransferTraceReadin.o           \
 				MOD_Lulcc_MassEnergyConserve.o            \
+				MOD_Lulcc_Initialize.o                    \
 				MOD_Lulcc_Driver.o                        \
 				CoLMDRIVER.o                              \
 				CoLMMAIN.o                                \

--- a/main/CoLM.F90
+++ b/main/CoLM.F90
@@ -530,7 +530,7 @@ PROGRAM CoLM
 
          ! Write out the model state variables for restart run
          ! ----------------------------------------------------------------------
-         IF (save_to_restart (idate, deltim, itstamp, ptstamp)) THEN
+         IF (save_to_restart (idate, deltim, itstamp, ptstamp, etstamp)) THEN
 #ifdef LULCC
             IF (jdate(1) >= 2000) THEN
                CALL WRITE_TimeVariables (jdate, jdate(1), casename, dir_restart)

--- a/main/CoLM.F90
+++ b/main/CoLM.F90
@@ -533,9 +533,9 @@ PROGRAM CoLM
          IF (save_to_restart (idate, deltim, itstamp, ptstamp)) THEN
 #ifdef LULCC
             IF (jdate(1) >= 2000) THEN
-            CALL WRITE_TimeVariables (jdate, jdate(1), casename, dir_restart)
+               CALL WRITE_TimeVariables (jdate, jdate(1), casename, dir_restart)
             ELSE
-              CALL WRITE_TimeVariables (jdate, (jdate(1)/5)*5, casename, dir_restart)
+               CALL WRITE_TimeVariables (jdate, (jdate(1)/5)*5, casename, dir_restart)
             ENDIF
 #else
             CALL WRITE_TimeVariables (jdate, lc_year,  casename, dir_restart)

--- a/main/CoLM.F90
+++ b/main/CoLM.F90
@@ -469,7 +469,9 @@ PROGRAM CoLM
          ! DO land use and land cover change simulation
          ! ----------------------------------------------------------------------
 #ifdef LULCC
-         IF ( isendofyear(idate, deltim) ) THEN
+         IF ( isendofyear(idate, deltim) .and. &
+            ( jdate(1)>=2000 .or. (jdate(1)>1985 .and. MOD(jdate(1),5)==0) ) ) THEN
+
             ! Deallocate all Forcing and Fluxes variable of last year
             CALL deallocate_1D_Forcing
             CALL deallocate_1D_Fluxes
@@ -478,7 +480,7 @@ PROGRAM CoLM
             CALL hist_final    ()
 
             ! Call LULCC driver
-            CALL LulccDriver (casename, dir_landdata, dir_restart, idate, greenwich)
+            CALL LulccDriver (casename, dir_landdata, dir_restart, jdate, greenwich)
 
             ! Allocate Forcing and Fluxes variable of next year
             CALL allocate_1D_Forcing
@@ -530,7 +532,11 @@ PROGRAM CoLM
          ! ----------------------------------------------------------------------
          IF (save_to_restart (idate, deltim, itstamp, ptstamp)) THEN
 #ifdef LULCC
+            IF (jdate(1) >= 2000) THEN
             CALL WRITE_TimeVariables (jdate, jdate(1), casename, dir_restart)
+            ELSE
+              CALL WRITE_TimeVariables (jdate, (jdate(1)/5)*5, casename, dir_restart)
+            ENDIF
 #else
             CALL WRITE_TimeVariables (jdate, lc_year,  casename, dir_restart)
 #endif

--- a/main/LULCC/MOD_Lulcc_Driver.F90
+++ b/main/LULCC/MOD_Lulcc_Driver.F90
@@ -14,7 +14,7 @@ MODULE MOD_Lulcc_Driver
 
 
    SUBROUTINE LulccDriver (casename, dir_landdata, dir_restart, &
-                           idate, greenwich)
+                           jdate, greenwich)
 
 !-----------------------------------------------------------------------
 !
@@ -87,7 +87,7 @@ MODULE MOD_Lulcc_Driver
    USE MOD_Lulcc_Vars_TimeVariables
    USE MOD_Lulcc_Initialize
    USE MOD_Vars_TimeVariables
-   USE MOD_Lulcc_TransferTrace
+   USE MOD_Lulcc_TransferTraceReadin
    USE MOD_Lulcc_MassEnergyConserve
    USE MOD_Namelist
 
@@ -98,7 +98,7 @@ MODULE MOD_Lulcc_Driver
    character(len=256), intent(in) :: dir_restart   !case restart data directory
 
    logical, intent(in)    :: greenwich   !true: greenwich time, false: local time
-   integer, intent(inout) :: idate(3)    !year, julian day, seconds of the starting time
+   integer, intent(inout) :: jdate(3)    !year, julian day, seconds of the starting time
 !-----------------------------------------------------------------------
 
       ! allocate Lulcc memory
@@ -118,7 +118,7 @@ MODULE MOD_Lulcc_Driver
       ENDIF
 
       CALL LulccInitialize (casename, dir_landdata, dir_restart, &
-                            idate, greenwich)
+                            jdate, greenwich)
 
 
       ! =============================================================
@@ -143,7 +143,7 @@ MODULE MOD_Lulcc_Driver
          ENDIF
          CALL allocate_LulccTransferTrace()
          CALL REST_LulccTimeVariables
-         CALL MAKE_LulccTransferTrace(idate(1))
+         CALL LulccTransferTraceReadin(jdate(1))
          CALL LulccMassEnergyConserve()
       ENDIF
 

--- a/main/LULCC/MOD_Lulcc_Initialize.F90
+++ b/main/LULCC/MOD_Lulcc_Initialize.F90
@@ -12,7 +12,7 @@ MODULE MOD_Lulcc_Initialize
 CONTAINS
 
    SUBROUTINE LulccInitialize (casename, dir_landdata, dir_restart, &
-                               idate, greenwich)
+                               jdate, greenwich)
 
 !-----------------------------------------------------------------------
 !
@@ -46,9 +46,6 @@ CONTAINS
    USE MOD_Vars_TimeInvariants
    USE MOD_Vars_TimeVariables
    USE MOD_Initialize
-#ifdef SrfdataDiag
-   USE MOD_SrfdataDiag, only: gdiag, srfdata_diag_init
-#endif
 
    IMPLICIT NONE
 
@@ -57,7 +54,7 @@ CONTAINS
    character(len=*), intent(in) :: dir_landdata
    character(len=*), intent(in) :: dir_restart
 
-   integer, intent(inout) :: idate(3)   ! year, julian day, seconds of the starting time
+   integer, intent(inout) :: jdate(3)   ! year, julian day, seconds of the starting time
    logical, intent(in)    :: greenwich  ! true: greenwich time, false: local time
 
 !-------------------------- Local Variables ----------------------------
@@ -66,10 +63,8 @@ CONTAINS
 !-----------------------------------------------------------------------
 
       ! initial time of model run and consts
-      CALL adj2begin(idate)
-
-      year = idate(1)
-      jday = idate(2)
+      year = jdate(1)
+      jday = jdate(2)
 
       CALL Init_GlobalVars
       CALL Init_LC_Const
@@ -125,17 +120,6 @@ CONTAINS
          CALL elm_patch%build (landelm, landpatch, use_frac = .true.)
       ENDIF
 
-      ! initialize for SrfdataDiag, it is needed in the MOD_Lulcc_TransferTrace for outputing
-      ! transfer_matrix
-#ifdef SrfdataDiag
-#ifdef GRIDBASED
-      CALL init_gridbased_mesh_grid ()
-      CALL gdiag%define_by_copy (gridmesh)
-#else
-      CALL gdiag%define_by_ndims (3600,1800)
-#endif
-      CALL srfdata_diag_init (dir_landdata, lulcc_call=.true.)
-#endif
 
       ! --------------------------------------------------------------------
       ! Deallocates memory for CoLM 1d [numpatch] variables
@@ -145,7 +129,7 @@ CONTAINS
 
       ! initialize all state variables of next year
       CALL initialize (casename, dir_landdata, dir_restart,&
-                       idate, year, greenwich, lulcc_call=.true.)
+                       jdate, year, greenwich, lulcc_call=.true.)
 
    END SUBROUTINE LulccInitialize
 

--- a/main/LULCC/MOD_Lulcc_MassEnergyConserve.F90
+++ b/main/LULCC/MOD_Lulcc_MassEnergyConserve.F90
@@ -209,7 +209,8 @@ ENDIF
                                  inp_ = inp_ + 1
                               ENDDO
                               IF (.not.(FOUND)) THEN
-                                 PRINT*, 'source patch not found, np', np, 'patchclass_', patchclass_(grid_patch_s_(j):grid_patch_e_(j))
+                                 PRINT*, 'source patch not found, np', np, 'patchclass_', &
+                                    patchclass_(grid_patch_s_(j):grid_patch_e_(j))
                               ENDIF
                            ELSE
                              CYCLE

--- a/main/LULCC/MOD_Lulcc_MassEnergyConserve.F90
+++ b/main/LULCC/MOD_Lulcc_MassEnergyConserve.F90
@@ -51,7 +51,7 @@ CONTAINS
    USE MOD_Vars_TimeVariables
    USE MOD_Lulcc_Vars_TimeInvariants
    USE MOD_Lulcc_Vars_TimeVariables
-   USE MOD_Lulcc_TransferTrace
+   USE MOD_Lulcc_TransferTraceReadin
 #if (defined LULC_IGBP_PFT || defined LULC_IGBP_PC)
    USE MOD_LandPFT
    USE MOD_Vars_PFTimeInvariants
@@ -103,7 +103,7 @@ CONTAINS
    real(r8):: wt                        !fraction of vegetation covered with snow [-]
    real(r8), parameter :: m = 1.0       !the value of m used in CLM4.5 is 1.0.
    ! real(r8) :: deltim = 1800.         !time step (seconds) TODO: be intent in
-   logical :: FROM_SOIL
+   logical :: FROM_SOIL, FOUND
 !-----------------------------------------------------------------------
 
       IF (p_is_worker) THEN
@@ -170,6 +170,7 @@ IF (DEF_USE_PFT .or. DEF_FAST_PC) THEN
                      lccpct_np(URBAN  )   = lccpct_patches(np,URBAN  )
                      lccpct_np(WETLAND)   = lccpct_patches(np,WETLAND)
                      lccpct_np(WATERBODY) = lccpct_patches(np,WATERBODY)
+                     lccpct_np(GLACIERS)  = lccpct_patches(np,GLACIERS)
 ELSE
                      lccpct_np(:) = lccpct_patches(np,1:nlc)
 ENDIF
@@ -188,6 +189,7 @@ ENDIF
                         DO ilc = 1, nlc
 
                            IF (lccpct_np(ilc) .gt. 0) THEN
+                              FOUND = .FALSE.
                               k = k + 1
                               inp_ = np_
 
@@ -201,11 +203,14 @@ ENDIF
 
                                  IF (patchclass_(inp_) .eq. ilc) THEN
                                     frnp_(k) = inp_
+                                    FOUND = .TRUE.
                                     EXIT
                                  ENDIF
                                  inp_ = inp_ + 1
                               ENDDO
-
+                              IF (.not.(FOUND)) THEN
+                                 PRINT*, 'source patch not found, np', np, 'patchclass_', patchclass_(grid_patch_s_(j):grid_patch_e_(j))
+                              ENDIF
                            ELSE
                              CYCLE
                            ENDIF
@@ -606,52 +611,52 @@ ENDIF
                                                 * lccpct_np(patchclass_(frnp_(k)))/sum_lccpct_np
 
                            ! TODO: or use same type assignment
-                           smp       (:,np) = smp    (:,np) + smp_   (:,frnp_(k))
+                           smp       (:,np) = smp    (:,np) + smp_   (:,frnp_(k)) &
                                             * lccpct_np(patchclass_(frnp_(k)))/sum_lccpct_np
-                           hk        (:,np) = hk     (:,np) + hk_    (:,frnp_(k))
+                           hk        (:,np) = hk     (:,np) + hk_    (:,frnp_(k)) &
                                             * lccpct_np(patchclass_(frnp_(k)))/sum_lccpct_np
 
                            IF(DEF_USE_PLANTHYDRAULICS)THEN
-                              vegwp  (:,np) = vegwp  (:,np) + vegwp_ (:,frnp_(k))
+                              vegwp  (:,np) = vegwp  (:,np) + vegwp_ (:,frnp_(k)) &
                                             * lccpct_np(patchclass_(frnp_(k)))/sum_lccpct_np
-                              gs0sun   (np) = gs0sun   (np) + gs0sun_  (frnp_(k))
+                              gs0sun   (np) = gs0sun   (np) + gs0sun_  (frnp_(k)) &
                                             * lccpct_np(patchclass_(frnp_(k)))/sum_lccpct_np
-                              gs0sha   (np) = gs0sha   (np) + gs0sha_  (frnp_(k))
+                              gs0sha   (np) = gs0sha   (np) + gs0sha_  (frnp_(k)) &
                                             * lccpct_np(patchclass_(frnp_(k)))/sum_lccpct_np
                            ENDIF
 
                            IF(DEF_USE_OZONESTRESS)THEN
-                              lai_old  (np) = lai_old  (np) + lai_old_ (frnp_(k))
+                              lai_old  (np) = lai_old  (np) + lai_old_ (frnp_(k)) &
                                             * lccpct_np(patchclass_(frnp_(k)))/sum_lccpct_np
                            ENDIF
 
-                           trad        (np) = trad     (np) + trad_    (frnp_(k))
+                           trad        (np) = trad     (np) + trad_    (frnp_(k)) &
                                             * lccpct_np(patchclass_(frnp_(k)))/sum_lccpct_np
-                           tref        (np) = tref     (np) + tref_    (frnp_(k))
+                           tref        (np) = tref     (np) + tref_    (frnp_(k)) &
                                             * lccpct_np(patchclass_(frnp_(k)))/sum_lccpct_np
-                           qref        (np) = qref     (np) + qref_    (frnp_(k))
+                           qref        (np) = qref     (np) + qref_    (frnp_(k)) &
                                             * lccpct_np(patchclass_(frnp_(k)))/sum_lccpct_np
-                           rst         (np) = rst      (np) + rst_     (frnp_(k))
+                           rst         (np) = rst      (np) + rst_     (frnp_(k)) &
                                             * lccpct_np(patchclass_(frnp_(k)))/sum_lccpct_np
-                           emis        (np) = emis     (np) + emis_    (frnp_(k))
+                           emis        (np) = emis     (np) + emis_    (frnp_(k)) &
                                             * lccpct_np(patchclass_(frnp_(k)))/sum_lccpct_np
-                           z0m         (np) = z0m      (np) + z0m_     (frnp_(k))
+                           z0m         (np) = z0m      (np) + z0m_     (frnp_(k)) &
                                             * lccpct_np(patchclass_(frnp_(k)))/sum_lccpct_np
-                           zol         (np) = zol      (np) + zol_     (frnp_(k))
+                           zol         (np) = zol      (np) + zol_     (frnp_(k)) &
                                             * lccpct_np(patchclass_(frnp_(k)))/sum_lccpct_np
-                           rib         (np) = rib      (np) + rib_     (frnp_(k))
+                           rib         (np) = rib      (np) + rib_     (frnp_(k)) &
                                             * lccpct_np(patchclass_(frnp_(k)))/sum_lccpct_np
-                           ustar       (np) = ustar    (np) + ustar_   (frnp_(k))
+                           ustar       (np) = ustar    (np) + ustar_   (frnp_(k)) &
                                             * lccpct_np(patchclass_(frnp_(k)))/sum_lccpct_np
-                           qstar       (np) = qstar    (np) + qstar_   (frnp_(k))
+                           qstar       (np) = qstar    (np) + qstar_   (frnp_(k)) &
                                             * lccpct_np(patchclass_(frnp_(k)))/sum_lccpct_np
-                           tstar       (np) = tstar    (np) + tstar_   (frnp_(k))
+                           tstar       (np) = tstar    (np) + tstar_   (frnp_(k)) &
                                             * lccpct_np(patchclass_(frnp_(k)))/sum_lccpct_np
-                           fm          (np) = fm       (np) + fm_      (frnp_(k))
+                           fm          (np) = fm       (np) + fm_      (frnp_(k)) &
                                             * lccpct_np(patchclass_(frnp_(k)))/sum_lccpct_np
-                           fh          (np) = fh       (np) + fh_      (frnp_(k))
+                           fh          (np) = fh       (np) + fh_      (frnp_(k)) &
                                             * lccpct_np(patchclass_(frnp_(k)))/sum_lccpct_np
-                           fq          (np) = fq       (np) + fq_      (frnp_(k))
+                           fq          (np) = fq       (np) + fq_      (frnp_(k)) &
                                             * lccpct_np(patchclass_(frnp_(k)))/sum_lccpct_np
                         ENDDO
 
@@ -659,15 +664,15 @@ ENDIF
                         wbef = 0
                         wpre = 0
                         DO k = 1, num
-                           wbef = wbef + ldew_(frnp_(k))
+                           wbef = wbef + ldew_(frnp_(k)) &
                                        * lccpct_np(patchclass_(frnp_(k)))/sum_lccpct_np
-                           wbef = wbef + scv_ (frnp_(k))
+                           wbef = wbef + scv_ (frnp_(k)) &
                                        * lccpct_np(patchclass_(frnp_(k)))/sum_lccpct_np
-                           wbef = wbef + wa_  (frnp_(k))
+                           wbef = wbef + wa_  (frnp_(k)) &
                                        * lccpct_np(patchclass_(frnp_(k)))/sum_lccpct_np
-                           wbef = wbef + sum(wliq_soisno_(maxsnl+1:nl_soil,frnp_(k)))
+                           wbef = wbef + sum(wliq_soisno_(maxsnl+1:nl_soil,frnp_(k))) &
                                        * lccpct_np(patchclass_(frnp_(k)))/sum_lccpct_np
-                           wbef = wbef + sum(wice_soisno_(maxsnl+1:nl_soil,frnp_(k)))
+                           wbef = wbef + sum(wice_soisno_(maxsnl+1:nl_soil,frnp_(k))) &
                                        * lccpct_np(patchclass_(frnp_(k)))/sum_lccpct_np
                         ENDDO
 

--- a/main/LULCC/MOD_Lulcc_TransferTraceReadin.F90
+++ b/main/LULCC/MOD_Lulcc_TransferTraceReadin.F90
@@ -1,0 +1,128 @@
+#include <define.h>
+
+MODULE MOD_Lulcc_TransferTraceReadin
+
+!------------------------------------------------------------------------
+!
+! !DESCRIPTION:
+!  The transfer matrix and patch tracing vector were created using the
+!  land cover type data of the adjacent two years. Based on next year's
+!  patch, the pixels within the patch and last years' land cover type of
+!  these pixels were obtained. Then the percent of source land cover
+!  type of each patch was derived.
+!
+!  Created by Wanyi Lin, Shupeng Zhang and Hua Yuan, 07/2023
+!------------------------------------------------------------------------
+
+   USE MOD_Precision
+   USE MOD_Vars_Global
+   IMPLICIT NONE
+   SAVE
+
+   real(r8), allocatable, dimension(:,:) :: lccpct_patches(:,:) !frac of source patches in a patch
+
+   ! PUBLIC MEMBER FUNCTIONS:
+   PUBLIC :: allocate_LulccTransferTrace
+   PUBLIC :: deallocate_LulccTransferTrace
+   PUBLIC :: LulccTransferTraceReadin
+
+   ! PRIVATE MEMBER FUNCTIONS:
+
+
+CONTAINS
+
+
+   SUBROUTINE allocate_LulccTransferTrace
+   ! --------------------------------------------------------------------
+   ! Allocates memory for Lulcc time invariant variables
+   ! --------------------------------------------------------------------
+
+   USE MOD_Precision
+   USE MOD_Vars_Global
+   USE MOD_LandPatch
+   USE MOD_SPMD_Task
+
+   IMPLICIT NONE
+
+   integer :: nlc = N_land_classification
+
+      IF (p_is_worker) THEN
+        allocate (lccpct_patches (numpatch, 0:nlc))
+        lccpct_patches (:,:) = 0
+      ENDIF
+
+   END SUBROUTINE allocate_LulccTransferTrace
+
+
+   SUBROUTINE LulccTransferTraceReadin (lc_year)
+
+   USE MOD_Precision
+   USE MOD_Namelist
+   USE MOD_SPMD_Task
+   USE MOD_Grid
+   USE MOD_LandPatch
+   USE MOD_NetCDFVector
+   USE MOD_NetCDFBlock
+   USE MOD_AggregationRequestData
+   USE MOD_Mesh
+   USE MOD_MeshFilter
+   USE MOD_LandElm
+   USE MOD_DataType
+   USE MOD_Block
+   USE MOD_Pixel
+   USE MOD_5x5DataReadin
+   USE MOD_RegionClip
+   USE MOD_Utils
+#ifdef SrfdataDiag
+   USE MOD_SrfdataDiag
+#endif
+#ifdef RangeCheck
+   USE MOD_RangeCheck
+#endif
+   USE MOD_Vars_TimeInvariants
+
+   IMPLICIT NONE
+
+   integer, intent(in) :: lc_year
+
+   character(len=256) :: dir_landdata, lndname, thisyr
+   character(len=4)   :: c2
+   integer :: ilc
+   real(r8), allocatable :: tmpvec(:)
+
+
+   IF (p_is_worker) THEN
+      IF (allocated(tmpvec)) deallocate (tmpvec)
+      allocate (tmpvec(numpatch))
+   ENDIF
+
+   write(thisyr,'(i4.4)') lc_year
+   dir_landdata = DEF_dir_landdata
+   DO ilc = 0, N_land_classification
+      write(c2, '(i2.2)') ilc
+      lndname = trim(dir_landdata)//'/lulcc/'//trim(thisyr)//'/lccpct_patches_lc'//trim(c2)//'.nc'
+      CALL ncio_read_vector(lndname, 'lccpct_patches', landpatch, tmpvec)
+
+      IF (p_is_worker) THEN
+         lccpct_patches(:,ilc) = tmpvec
+      ENDIF
+   ENDDO
+
+
+   END SUBROUTINE LulccTransferTraceReadin
+
+
+   SUBROUTINE deallocate_LulccTransferTrace
+   ! --------------------------------------------------
+   ! Deallocates memory for Lulcc time invariant variables
+   ! --------------------------------------------------
+   USE MOD_SPMD_Task
+
+      IF (p_is_worker) THEN
+         IF (allocated(lccpct_patches)) deallocate (lccpct_patches)
+      ENDIF
+
+   END SUBROUTINE deallocate_LulccTransferTrace
+
+END MODULE MOD_Lulcc_TransferTraceReadin
+! ---------- EOP ------------

--- a/main/MOD_CanopyLayerProfile.F90
+++ b/main/MOD_CanopyLayerProfile.F90
@@ -349,7 +349,8 @@ CONTAINS
          IF (udiff_lb == 0) THEN !root found
             rootn = rootn + 1
             IF (rootn > 2) THEN
-               print *, "Warning: U root number > 2, attention!"
+               rootn = 2
+               print *, "Warning: U root number > 2, only the first 2 are used!"
                RETURN !CALL abort
             ENDIF
             roots(rootn) = zmid
@@ -358,7 +359,8 @@ CONTAINS
          IF (ztop-zmid < 0.01) THEN
             rootn = rootn + 1 !root found
             IF (rootn > 2) THEN
-               print *, "Warning: U root number > 2, attention!"
+               rootn = 2
+               print *, "Warning: U root number > 2, only the first 2 are used!"
                RETURN !CALL abort
             ENDIF
             roots(rootn) = (ztop+zmid)/2.
@@ -375,7 +377,8 @@ CONTAINS
          IF (udiff_ub == 0) THEN !root found
             rootn = rootn + 1
             IF (rootn > 2) THEN
-               print *, "Warning: U root number > 2, attention!"
+               rootn = 2
+               print *, "Warning: U root number > 2, only the first 2 are used!"
                RETURN !CALL abort
             ENDIF
             roots(rootn) = zmid
@@ -384,7 +387,8 @@ CONTAINS
          IF (zmid-zbot < 0.01) THEN
             rootn = rootn + 1 !root found
             IF (rootn > 2) THEN
-               print *, "Warning: U root number > 2, attention!"
+               rootn = 2
+               print *, "Warning: U root number > 2, only the first 2 are used!"
                RETURN !CALL abort
             ENDIF
             roots(rootn) = (zmid+zbot)/2.
@@ -586,7 +590,8 @@ CONTAINS
          IF (kdiff_lb == 0) THEN !root found
             rootn = rootn + 1
             IF (rootn > 2) THEN
-               print *, "Warning: K root number > 2, attention!"
+               rootn = 2
+               print *, "Warning: K root number > 2, only the first 2 are used!"
                RETURN !CALL abort
             ENDIF
             roots(rootn) = zmid
@@ -595,7 +600,8 @@ CONTAINS
          IF (ztop-zmid < 0.01) THEN
             rootn = rootn + 1 !root found
             IF (rootn > 2) THEN
-               print *, "Warning: K root number > 2, attention!"
+               rootn = 2
+               print *, "Warning: K root number > 2, only the first 2 are used!"
                RETURN !CALL abort
             ENDIF
             roots(rootn) = (ztop+zmid)/2.
@@ -612,7 +618,8 @@ CONTAINS
          IF (kdiff_ub == 0) THEN !root found
             rootn = rootn + 1
             IF (rootn > 2) THEN
-               print *, "Warning: K root number > 2, attention!"
+               rootn = 2
+               print *, "Warning: K root number > 2, only the first 2 are used!"
                RETURN !CALL abort
             ENDIF
             roots(rootn) = zmid
@@ -621,7 +628,8 @@ CONTAINS
          IF (zmid-zbot < 0.01) THEN
             rootn = rootn + 1 !root found
             IF (rootn > 2) THEN
-               print *, "Warning: K root number > 2, attention!"
+               rootn = 2
+               print *, "Warning: K root number > 2, only the first 2 are used!"
                RETURN !CALL abort
             ENDIF
             roots(rootn) = (zmid+zbot)/2.

--- a/main/MOD_Forcing.F90
+++ b/main/MOD_Forcing.F90
@@ -1036,7 +1036,8 @@ CONTAINS
 
             ! when reaching the END of forcing data, show a Warning but still try to run
             IF ( year>endyr .or. (month>endmo .and. year==endyr) ) THEN
-               write(*,*) 'model year: ', year, 'forcing end year defined: ', endyr
+               write(*,*) 'model year/month:               ', year,  month
+               write(*,*) 'forcing end year/month defined: ', endyr, endmo
                print *, 'Warning: reaching the END of forcing data defined!'
             ENDIF
 
@@ -1546,6 +1547,10 @@ CONTAINS
 
          time_i = iforctime(var_i)+1
          year = tstamp_UB(var_i)%year
+         day  = tstamp_UB(var_i)%day
+
+         CALL julian2monthday(year, day, month, mday)
+
          RETURN
       ENDIF
 

--- a/main/MOD_NetSolar.F90
+++ b/main/MOD_NetSolar.F90
@@ -45,7 +45,7 @@ CONTAINS
    USE MOD_Precision
    USE MOD_Vars_Global
    USE MOD_Namelist, only: DEF_USE_SNICAR
-   USE MOD_TimeManager, only: isgreenwich
+   USE MOD_TimeManager
 #if (defined LULC_IGBP_PFT || defined LULC_IGBP_PC)
    USE MOD_LandPFT, only: patch_pft_s, patch_pft_e
    USE MOD_Vars_PFTimeInvariants
@@ -216,11 +216,13 @@ CONTAINS
          ! balance check and adjustment for soil and snow absorption
          ! this could happen when there is adjustment to ssun,ssha
          IF (abs(sabg_soil+sabg_snow-sabg)>1.e-6) THEN
-            print *, "MOD_NetSolar.F90: NOTE imbalance in spliting soil and snow surface!", &
-                      sabg_soil+sabg_snow-sabg
-            print *, "Patchtype = ", patchtype
-            print *, "sabg:", sabg, "sabg_soil:", sabg_soil, "sabg_snow", sabg_snow
-            print *, "sabg_soil+sabg_snow:", sabg_soil+sabg_snow, "fsno:", fsno
+            IF (.not. (idate(2)==1 .and. idate(3)==int(deltim))) THEN
+               print *, "MOD_NetSolar.F90: NOTE imbalance in spliting soil and snow surface!", &
+                         sabg_soil+sabg_snow-sabg
+               print *, "Patchtype = ", patchtype
+               print *, "sabg:", sabg, "sabg_soil:", sabg_soil, "sabg_snow", sabg_snow
+               print *, "sabg_soil+sabg_snow:", sabg_soil+sabg_snow, "fsno:", fsno
+            ENDIF
 
             sabg_noadj = sabg_soil + sabg_snow
 

--- a/main/MOD_NetSolar.F90
+++ b/main/MOD_NetSolar.F90
@@ -45,7 +45,7 @@ CONTAINS
    USE MOD_Precision
    USE MOD_Vars_Global
    USE MOD_Namelist, only: DEF_USE_SNICAR
-   USE MOD_TimeManager
+   USE MOD_TimeManager, only: isgreenwich
 #if (defined LULC_IGBP_PFT || defined LULC_IGBP_PC)
    USE MOD_LandPFT, only: patch_pft_s, patch_pft_e
    USE MOD_Vars_PFTimeInvariants

--- a/main/MOD_Vars_TimeInvariants.F90
+++ b/main/MOD_Vars_TimeInvariants.F90
@@ -565,7 +565,7 @@ CONTAINS
 #endif
 
       IF (p_is_master) THEN
-         write(*,'(A29)') 'Loading Time Invariants done.'
+         write(*,*) 'Loading Time Invariants done.'
       ENDIF
 
    END SUBROUTINE READ_TimeInvariants
@@ -647,7 +647,7 @@ CONTAINS
       CALL ncio_write_vector (file_restart, 'wf_gravels', 'soil', nl_soil, 'patch', landpatch, wf_gravels, compress) ! gravimetric fraction of gravels
       CALL ncio_write_vector (file_restart, 'wf_sand   ', 'soil', nl_soil, 'patch', landpatch, wf_sand   , compress) ! gravimetric fraction of sand
       CALL ncio_write_vector (file_restart, 'wf_clay   ', 'soil', nl_soil, 'patch', landpatch, wf_clay   , compress) ! gravimetric fraction of clay
-      CALL ncio_write_vector (file_restart, 'wf_om     ', 'soil', nl_soil, 'patch', landpatch, wf_om     , compress) ! gravimetric fraction of om 
+      CALL ncio_write_vector (file_restart, 'wf_om     ', 'soil', nl_soil, 'patch', landpatch, wf_om     , compress) ! gravimetric fraction of om
       CALL ncio_write_vector (file_restart, 'OM_density', 'soil', nl_soil, 'patch', landpatch, OM_density, compress) ! OM_density
       CALL ncio_write_vector (file_restart, 'BD_all    ', 'soil', nl_soil, 'patch', landpatch, BD_all    , compress) ! bulk density of soil
       CALL ncio_write_vector (file_restart, 'wfc       ', 'soil', nl_soil, 'patch', landpatch, wfc       , compress) ! field capacity

--- a/main/MOD_Vars_TimeVariables.F90
+++ b/main/MOD_Vars_TimeVariables.F90
@@ -1136,7 +1136,7 @@ ENDIF
 #endif
 
       IF (p_is_master) THEN
-         write(*,'(/,A26)') 'Loading Time Variables ...'
+         write(*,*) 'Loading Time Variables ...'
       ENDIF
 
       ! land cover type year
@@ -1289,7 +1289,7 @@ ENDIF
 #endif
 
       IF (p_is_master) THEN
-         write(*,'(A29)') 'Loading Time Variables done.'
+         write(*,*) 'Loading Time Variables done.'
       ENDIF
 
    END SUBROUTINE READ_TimeVariables

--- a/main/MOD_Vars_TimeVariables.F90
+++ b/main/MOD_Vars_TimeVariables.F90
@@ -866,7 +866,7 @@ CONTAINS
 
 
    !---------------------------------------
-   FUNCTION save_to_restart (idate, deltim, itstamp, ptstamp) result(rwrite)
+   FUNCTION save_to_restart (idate, deltim, itstamp, ptstamp, etstamp) result(rwrite)
 
    USE MOD_Namelist
    IMPLICIT NONE
@@ -875,7 +875,7 @@ CONTAINS
 
    integer,  intent(in) :: idate(3)
    real(r8), intent(in) :: deltim
-   type(timestamp), intent(in) :: itstamp, ptstamp
+   type(timestamp), intent(in) :: itstamp, ptstamp, etstamp
 
 
       ! added by yuan, 08/31/2014
@@ -899,6 +899,8 @@ CONTAINS
       IF (rwrite) THEN
          rwrite = ((ptstamp <= itstamp) .or. isendofyear(idate,deltim))
       ENDIF
+
+      rwrite = rwrite .or. (.not. (itstamp < etstamp))
 
    END FUNCTION save_to_restart
 

--- a/mksrfdata/Aggregation_DBedrock.F90
+++ b/mksrfdata/Aggregation_DBedrock.F90
@@ -1,7 +1,7 @@
 #include <define.h>
 
 SUBROUTINE Aggregation_DBedrock ( &
-      gland, dir_rawdata, dir_model_landdata)
+      gland, dir_rawdata, dir_model_landdata, lc_year)
 
 !-----------------------------------------------------------------------
 !  Depth to bedrock
@@ -30,12 +30,13 @@ SUBROUTINE Aggregation_DBedrock ( &
    IMPLICIT NONE
 
    ! arguments:
+   integer, intent(in) :: lc_year
    type(grid_type),  intent(in) :: gland
    character(len=*), intent(in) :: dir_rawdata
    character(len=*), intent(in) :: dir_model_landdata
 
    ! local variables:
-   character(len=256) :: landdir, lndname
+   character(len=256) :: landdir, lndname, cyear
 
    type (block_data_real8_2d) :: dbedrock
    real(r8), allocatable :: dbedrock_patches(:)
@@ -46,7 +47,8 @@ SUBROUTINE Aggregation_DBedrock ( &
    integer :: typpatch(N_land_classification+1), ityp
 #endif
 
-      landdir = trim(dir_model_landdata) // '/dbedrock/'
+      write(cyear,'(i4.4)') lc_year
+      landdir = trim(dir_model_landdata) // '/dbedrock/' //trim(cyear)
 
 #ifdef USEMPI
       CALL mpi_barrier (p_comm_glb, p_err)
@@ -104,7 +106,7 @@ SUBROUTINE Aggregation_DBedrock ( &
 
 #ifdef SrfdataDiag
       typpatch = (/(ityp, ityp = 0, N_land_classification)/)
-      lndname  = trim(dir_model_landdata) // '/diag/dbedrock_patch.nc'
+      lndname  = trim(dir_model_landdata) // '/diag/dbedrock_patch_' // trim(cyear) // '.nc'
       CALL srfdata_map_and_write (dbedrock_patches, landpatch%settyp, typpatch, m_patch2diag, &
          -1.0e36_r8, lndname, 'dbedrock', compress = 1, write_mode = 'one')
 #endif

--- a/mksrfdata/MKSRFDATA.F90
+++ b/mksrfdata/MKSRFDATA.F90
@@ -430,7 +430,7 @@ IF (.not. (skip_rest)) THEN
    CALL Aggregation_SoilBrightness  (grid_500m, dir_rawdata, dir_landdata, lc_year)
 
    IF (DEF_USE_BEDROCK) THEN
-      CALL Aggregation_DBedrock     (grid_500m, dir_rawdata, dir_landdata)
+      CALL Aggregation_DBedrock     (grid_500m, dir_rawdata, dir_landdata, lc_year)
    ENDIF
 
    CALL Aggregation_LAI             (grid_lai,  dir_rawdata, dir_landdata, lc_year)

--- a/mksrfdata/MKSRFDATA.F90
+++ b/mksrfdata/MKSRFDATA.F90
@@ -106,74 +106,74 @@ PROGRAM MKSRFDATA
 
 
 #ifdef USEMPI
-   CALL spmd_init ()
+      CALL spmd_init ()
 #endif
 
-   IF (p_is_master) THEN
-      CALL system_clock (start_time)
-   ENDIF
+      IF (p_is_master) THEN
+         CALL system_clock (start_time)
+      ENDIF
 
-   CALL getarg(1, nlfile)
+      CALL getarg(1, nlfile)
 
-   CALL read_namelist (nlfile)
+      CALL read_namelist (nlfile)
 
-   CALL initimetype (DEF_simulation_time%greenwich)
+      CALL initimetype (DEF_simulation_time%greenwich)
 
 #ifdef SinglePoint
 #ifndef URBAN_MODEL
 
-   CALL read_surface_data_single (SITE_fsitedata, mksrfdata = .true.)
+      CALL read_surface_data_single (SITE_fsitedata, mksrfdata = .true.)
 #if (defined LULC_IGBP_PFT || defined LULC_IGBP_PC)
-   CALL write_surface_data_single (numpatch, numpft)
+      CALL write_surface_data_single (numpatch, numpft)
 #else
-   CALL write_surface_data_single (numpatch)
+      CALL write_surface_data_single (numpatch)
 #endif
 
 #else
 
-   CALL read_urban_surface_data_single (SITE_fsitedata, mksrfdata=.true.)
-   CALL write_urban_surface_data_single(numurban)
+      CALL read_urban_surface_data_single (SITE_fsitedata, mksrfdata=.true.)
+      CALL write_urban_surface_data_single(numurban)
 
 #endif
 
-   CALL single_srfdata_final ()
-   write(*,*)  'Successful in surface data making.'
-   CALL CoLM_stop()
+      CALL single_srfdata_final ()
+      write(*,*)  'Successful in surface data making.'
+      CALL CoLM_stop()
 #endif
 
-   IF (USE_srfdata_from_larger_region) THEN
+      IF (USE_srfdata_from_larger_region) THEN
 
-      CALL srfdata_region_clip (DEF_dir_existing_srfdata, DEF_dir_landdata)
+         CALL srfdata_region_clip (DEF_dir_existing_srfdata, DEF_dir_landdata)
 
 #ifdef USEMPI
-      CALL mpi_barrier (p_comm_glb, p_err)
-      CALL spmd_exit
+         CALL mpi_barrier (p_comm_glb, p_err)
+         CALL spmd_exit
 #endif
-      CALL EXIT()
-   ENDIF
+         CALL EXIT()
+      ENDIF
 
-   IF (USE_srfdata_from_3D_gridded_data) THEN
+      IF (USE_srfdata_from_3D_gridded_data) THEN
 
-      ! TODO
-      ! CALL srfdata_retrieve_from_3D_data (DEF_dir_existing_srfdata, DEF_dir_landdata)
+         ! TODO
+         ! CALL srfdata_retrieve_from_3D_data (DEF_dir_existing_srfdata, DEF_dir_landdata)
 
 #ifdef USEMPI
-      CALL mpi_barrier (p_comm_glb, p_err)
-      CALL spmd_exit
+         CALL mpi_barrier (p_comm_glb, p_err)
+         CALL spmd_exit
 #endif
-      CALL EXIT()
-   ENDIF
+         CALL EXIT()
+      ENDIF
 
-   dir_rawdata  = DEF_dir_rawdata
-   dir_landdata = DEF_dir_landdata
-   edges = DEF_domain%edges
-   edgen = DEF_domain%edgen
-   edgew = DEF_domain%edgew
-   edgee = DEF_domain%edgee
-   lc_year = DEF_LC_YEAR
+      dir_rawdata  = DEF_dir_rawdata
+      dir_landdata = DEF_dir_landdata
+      edges        = DEF_domain%edges
+      edgen        = DEF_domain%edgen
+      edgew        = DEF_domain%edgew
+      edgee        = DEF_domain%edgee
 
-   lai_year = lc_year
-   skip_rest = .FALSE.
+      lc_year   = DEF_LC_YEAR
+      lai_year  = lc_year
+      skip_rest = .FALSE.
 
 #ifdef LULCC
       IF ( lc_year < 2000 ) THEN
@@ -181,305 +181,305 @@ PROGRAM MKSRFDATA
       ENDIF
 #endif
 
-   ! define blocks
-   CALL gblock%set ()
+      ! define blocks
+      CALL gblock%set ()
 
-   CALL Init_GlobalVars
-   CAll Init_LC_Const
+      CALL Init_GlobalVars
+      CAll Init_LC_Const
 
-! ...........................................................................
-! 1. Read in or create the modeling grids coordinates and related information
-! ...........................................................................
+      ! ...........................................................................
+      ! 1. Read in or create the modeling grids coordinates and related information
+      ! ...........................................................................
 
-   ! define domain in pixel coordinate
-   CALL pixel%set_edges (edges, edgen, edgew, edgee)
-   CALL pixel%assimilate_gblock ()
+      ! define domain in pixel coordinate
+      CALL pixel%set_edges (edges, edgen, edgew, edgee)
+      CALL pixel%assimilate_gblock ()
 
-   ! define grid coordinates of mesh
+      ! define grid coordinates of mesh
 #ifdef GRIDBASED
-   CALL init_gridbased_mesh_grid ()
+      CALL init_gridbased_mesh_grid ()
 #endif
 
 #ifdef CATCHMENT
-   CALL gridmesh%define_by_name ('merit_90m')
+      CALL gridmesh%define_by_name ('merit_90m')
 #endif
 
 #ifdef UNSTRUCTURED
-   CALL gridmesh%define_from_file (DEF_file_mesh)
+      CALL gridmesh%define_from_file (DEF_file_mesh)
 #endif
 
-   ! define grid coordinates of mesh filter
-   has_mesh_filter = inquire_mesh_filter ()
-   IF (has_mesh_filter) THEN
-      CALL grid_filter%define_from_file (DEF_file_mesh_filter)
-   ENDIF
+      ! define grid coordinates of mesh filter
+      has_mesh_filter = inquire_mesh_filter ()
+      IF (has_mesh_filter) THEN
+         CALL grid_filter%define_from_file (DEF_file_mesh_filter)
+      ENDIF
 
-   ! define grid coordinates of hydro units in catchment
+      ! define grid coordinates of hydro units in catchment
 #ifdef CATCHMENT
-   CALL grid_hru%define_by_name ('merit_90m')
+      CALL grid_hru%define_by_name ('merit_90m')
 #endif
 
-   CALL grid_500m%define_by_name ('colm_500m')
+      CALL grid_500m%define_by_name ('colm_500m')
 
-   ! define grid coordinates of land types
+      ! define grid coordinates of land types
 #ifdef LULC_USGS
-   CALL grid_patch%define_by_name ('colm_1km')
+      CALL grid_patch%define_by_name ('colm_1km')
 #endif
 #ifdef LULC_IGBP
-   CALL grid_patch%define_by_name ('colm_500m')
+      CALL grid_patch%define_by_name ('colm_500m')
 #endif
 #if (defined LULC_IGBP_PFT || defined LULC_IGBP_PC)
-   CALL grid_patch%define_by_name ('colm_500m')
+      CALL grid_patch%define_by_name ('colm_500m')
 #endif
 #if (defined CROP)
-   ! define grid for crop parameters
-   CALL grid_crop%define_from_file (trim(DEF_dir_rawdata)//&
-      '/global_CFT_surface_data.nc', 'lat', 'lon')
+      ! define grid for crop parameters
+      CALL grid_crop%define_from_file (trim(DEF_dir_rawdata)//&
+         '/global_CFT_surface_data.nc', 'lat', 'lon')
 #endif
 
-   ! define grid for forest height
+      ! define grid for forest height
 #ifdef LULC_USGS
-   CALL grid_htop%define_by_name ('colm_1km')
+      CALL grid_htop%define_by_name ('colm_1km')
 #else
-   CALL grid_htop%define_by_name ('colm_500m')
+      CALL grid_htop%define_by_name ('colm_500m')
 #endif
 
-   ! define grid for soil parameters raw data
-   CALL grid_soil%define_by_name ('colm_500m')
+      ! define grid for soil parameters raw data
+      CALL grid_soil%define_by_name ('colm_500m')
 
-   ! define grid for LAI raw data
-   CALL grid_lai%define_by_name ('colm_500m')
+      ! define grid for LAI raw data
+      CALL grid_lai%define_by_name ('colm_500m')
 
-   ! define grid for topography
-   CALL grid_topo%define_by_name ('colm_500m')
+      ! define grid for topography
+      CALL grid_topo%define_by_name ('colm_500m')
 
-   ! define grid for topography factors
-   IF (DEF_USE_Forcing_Downscaling) THEN
-      lndname = trim(DEF_DS_HiresTopographyDataDir) // '/slope.nc'
-      CALL grid_topo_factor%define_from_file (lndname,"lat","lon")
-   ENDIF
+      ! define grid for topography factors
+      IF (DEF_USE_Forcing_Downscaling) THEN
+         lndname = trim(DEF_DS_HiresTopographyDataDir) // '/slope.nc'
+         CALL grid_topo_factor%define_from_file (lndname,"lat","lon")
+      ENDIF
 
-   ! add by dong, only test for making urban data
+      ! add by dong, only test for making urban data
 #ifdef URBAN_MODEL
-   CALL grid_urban%define_by_name      ('colm_500m')
-   CALL grid_urban_500m%define_by_name ('colm_500m')
-   CALL grid_urban_5km%define_by_name  ('colm_5km' )
+      CALL grid_urban%define_by_name      ('colm_500m')
+      CALL grid_urban_500m%define_by_name ('colm_500m')
+      CALL grid_urban_5km%define_by_name  ('colm_5km' )
 #endif
 
-   ! assimilate grids to build pixels
+      ! assimilate grids to build pixels
 #ifndef SinglePoint
-   CALL pixel%assimilate_grid (gridmesh)
+      CALL pixel%assimilate_grid (gridmesh)
 #endif
-   IF (has_mesh_filter) THEN
-      CALL pixel%assimilate_grid (grid_filter)
-   ENDIF
+      IF (has_mesh_filter) THEN
+         CALL pixel%assimilate_grid (grid_filter)
+      ENDIF
 #ifdef CATCHMENT
-   CALL pixel%assimilate_grid (grid_hru  )
+      CALL pixel%assimilate_grid (grid_hru  )
 #endif
-   CALL pixel%assimilate_grid (grid_500m )
-   CALL pixel%assimilate_grid (grid_patch)
+      CALL pixel%assimilate_grid (grid_500m )
+      CALL pixel%assimilate_grid (grid_patch)
 #if (defined CROP)
-   CALL pixel%assimilate_grid (grid_crop )
+      CALL pixel%assimilate_grid (grid_crop )
 #endif
-   CALL pixel%assimilate_grid (grid_htop )
-   CALL pixel%assimilate_grid (grid_soil )
-   CALL pixel%assimilate_grid (grid_lai  )
-   CALL pixel%assimilate_grid (grid_topo )
+      CALL pixel%assimilate_grid (grid_htop )
+      CALL pixel%assimilate_grid (grid_soil )
+      CALL pixel%assimilate_grid (grid_lai  )
+      CALL pixel%assimilate_grid (grid_topo )
 
-   IF (DEF_USE_Forcing_Downscaling) THEN
-      CALL pixel%assimilate_grid (grid_topo_factor)
-   ENDIF
+      IF (DEF_USE_Forcing_Downscaling) THEN
+         CALL pixel%assimilate_grid (grid_topo_factor)
+      ENDIF
 
 #ifdef URBAN_MODEL
-   CALL pixel%assimilate_grid (grid_urban     )
-   CALL pixel%assimilate_grid (grid_urban_500m)
-   CALL pixel%assimilate_grid (grid_urban_5km )
+      CALL pixel%assimilate_grid (grid_urban     )
+      CALL pixel%assimilate_grid (grid_urban_500m)
+      CALL pixel%assimilate_grid (grid_urban_5km )
 #endif
 
-   ! map pixels to grid coordinates
+      ! map pixels to grid coordinates
 #ifndef SinglePoint
-   CALL pixel%map_to_grid (gridmesh)
+      CALL pixel%map_to_grid (gridmesh)
 #endif
-   IF (has_mesh_filter) THEN
-      CALL pixel%map_to_grid (grid_filter)
-   ENDIF
+      IF (has_mesh_filter) THEN
+         CALL pixel%map_to_grid (grid_filter)
+      ENDIF
 #ifdef CATCHMENT
-   CALL pixel%map_to_grid (grid_hru  )
+      CALL pixel%map_to_grid (grid_hru  )
 #endif
-   CALL pixel%map_to_grid (grid_500m )
-   CALL pixel%map_to_grid (grid_patch)
+      CALL pixel%map_to_grid (grid_500m )
+      CALL pixel%map_to_grid (grid_patch)
 #if (defined CROP)
-   CALL pixel%map_to_grid (grid_crop )
+      CALL pixel%map_to_grid (grid_crop )
 #endif
-   CALL pixel%map_to_grid (grid_htop )
-   CALL pixel%map_to_grid (grid_soil )
-   CALL pixel%map_to_grid (grid_lai  )
-   CALL pixel%map_to_grid (grid_topo )
+      CALL pixel%map_to_grid (grid_htop )
+      CALL pixel%map_to_grid (grid_soil )
+      CALL pixel%map_to_grid (grid_lai  )
+      CALL pixel%map_to_grid (grid_topo )
 
-   IF (DEF_USE_Forcing_Downscaling) THEN
-      CALL pixel%map_to_grid (grid_topo_factor)
-   ENDIF
+      IF (DEF_USE_Forcing_Downscaling) THEN
+         CALL pixel%map_to_grid (grid_topo_factor)
+      ENDIF
 
 #ifdef URBAN_MODEL
-   CALL pixel%map_to_grid (grid_urban     )
-   CALL pixel%map_to_grid (grid_urban_500m)
-   CALL pixel%map_to_grid (grid_urban_5km )
+      CALL pixel%map_to_grid (grid_urban     )
+      CALL pixel%map_to_grid (grid_urban_500m)
+      CALL pixel%map_to_grid (grid_urban_5km )
 #endif
 
 
-   ! build land elms
-   CALL mesh_build ()
-   CALL landelm_build
+      ! build land elms
+      CALL mesh_build ()
+      CALL landelm_build
 
 #if (defined GRIDBASED || defined UNSTRUCTURED)
-   IF (DEF_LANDONLY) THEN
-      !TODO: distinguish USGS and IGBP land cover
+      IF (DEF_LANDONLY) THEN
+         !TODO: distinguish USGS and IGBP land cover
 #ifndef LULC_USGS
-      write(cyear,'(i4.4)') lc_year
-      lndname = trim(DEF_dir_rawdata)//'/landtypes/landtype-igbp-modis-'//trim(cyear)//'.nc'
+         write(cyear,'(i4.4)') lc_year
+         lndname = trim(DEF_dir_rawdata)//'/landtypes/landtype-igbp-modis-'//trim(cyear)//'.nc'
 #else
-      lndname = trim(DEF_dir_rawdata)//'/landtypes/landtype-usgs-update.nc'
+         lndname = trim(DEF_dir_rawdata)//'/landtypes/landtype-usgs-update.nc'
 #endif
-      CALL mesh_filter (grid_patch, lndname, 'landtype')
-   ENDIF
+         CALL mesh_filter (grid_patch, lndname, 'landtype')
+      ENDIF
 #endif
 
-   ! Filtering pixels
-   IF (has_mesh_filter) THEN
-      CALL mesh_filter (grid_filter, DEF_file_mesh_filter, 'mesh_filter')
-   ENDIF
+      ! Filtering pixels
+      IF (has_mesh_filter) THEN
+         CALL mesh_filter (grid_filter, DEF_file_mesh_filter, 'mesh_filter')
+      ENDIF
 
 #ifdef CATCHMENT
-   CALL landhru_build
+      CALL landhru_build
 #endif
 
-   ! build land patches
-   CALL landpatch_build(lc_year)
+      ! build land patches
+      CALL landpatch_build(lc_year)
 
 #ifdef URBAN_MODEL
-   CALL landurban_build(lc_year)
+      CALL landurban_build(lc_year)
 #endif
 
 #ifdef CROP
-   CALL landcrop_build (lc_year)
+      CALL landcrop_build (lc_year)
 #endif
 
 #if (defined LULC_IGBP_PFT || defined LULC_IGBP_PC)
-   CALL landpft_build  (lc_year)
+      CALL landpft_build  (lc_year)
 #endif
 
 ! ................................................................
 ! 2. SAVE land surface tessellation information
 ! ................................................................
 
-   CALL gblock%save_to_file    (dir_landdata)
+      CALL gblock%save_to_file    (dir_landdata)
 
-   CALL pixel%save_to_file     (dir_landdata)
+      CALL pixel%save_to_file     (dir_landdata)
 
-   CALL mesh_save_to_file      (dir_landdata, lc_year)
+      CALL mesh_save_to_file      (dir_landdata, lc_year)
 
-   CALL pixelset_save_to_file  (dir_landdata, 'landelm'  , landelm  , lc_year)
+      CALL pixelset_save_to_file  (dir_landdata, 'landelm'  , landelm  , lc_year)
 
 #ifdef CATCHMENT
-   CALL pixelset_save_to_file  (dir_landdata, 'landhru'  , landhru  , lc_year)
+      CALL pixelset_save_to_file  (dir_landdata, 'landhru'  , landhru  , lc_year)
 #endif
 
-   CALL pixelset_save_to_file  (dir_landdata, 'landpatch', landpatch, lc_year)
+      CALL pixelset_save_to_file  (dir_landdata, 'landpatch', landpatch, lc_year)
 
 #if (defined LULC_IGBP_PFT || defined LULC_IGBP_PC)
-   CALL pixelset_save_to_file  (dir_landdata, 'landpft'  , landpft  , lc_year)
+      CALL pixelset_save_to_file  (dir_landdata, 'landpft'  , landpft  , lc_year)
 #endif
 
 #ifdef URBAN_MODEL
-   CALL pixelset_save_to_file  (dir_landdata, 'landurban', landurban, lc_year)
+      CALL pixelset_save_to_file  (dir_landdata, 'landurban', landurban, lc_year)
 #endif
 
 ! ................................................................
 ! 3. Mapping land characteristic parameters to the model grids
 ! ................................................................
 #ifdef SrfdataDiag
-   CALL elm_patch%build (landelm, landpatch, use_frac = .true.)
+      CALL elm_patch%build (landelm, landpatch, use_frac = .true.)
 #ifdef GRIDBASED
-   CALL gdiag%define_by_copy (gridmesh)
+      CALL gdiag%define_by_copy (gridmesh)
 #else
-   CALL gdiag%define_by_ndims(3600,1800)
+      CALL gdiag%define_by_ndims(3600,1800)
 #endif
 
-   CALL srfdata_diag_init (dir_landdata, lc_year)
+      CALL srfdata_diag_init (dir_landdata, lc_year)
 #endif
 
-   !TODO: for lulcc, need to run for each year and SAVE to different subdirs
+      !TODO: for lulcc, need to run for each year and SAVE to different subdirs
 
 #ifdef LULCC
-   IF (lai_year<2000 .and. MOD(lai_year,5) /= 0) THEN
-      CALL Aggregation_LAI          (grid_lai,  dir_rawdata, dir_landdata, lai_year)
-      skip_rest = .TRUE.
-   ELSE
-      CALL MAKE_LulccTransferTrace  (lc_year)
-   ENDIF
+      IF (lai_year<2000 .and. MOD(lai_year,5) /= 0) THEN
+         CALL Aggregation_LAI          (grid_lai,  dir_rawdata, dir_landdata, lai_year)
+         skip_rest = .TRUE.
+      ELSE
+         CALL MAKE_LulccTransferTrace  (lc_year)
+      ENDIF
 #endif
 
 IF (.not. (skip_rest)) THEN
 
-   CALL Aggregation_PercentagesPFT  (grid_500m, dir_rawdata, dir_landdata, lc_year)
+      CALL Aggregation_PercentagesPFT  (grid_500m, dir_rawdata, dir_landdata, lc_year)
 
-   CALL Aggregation_LakeDepth       (grid_500m, dir_rawdata, dir_landdata, lc_year)
+      CALL Aggregation_LakeDepth       (grid_500m, dir_rawdata, dir_landdata, lc_year)
 
-   CALL Aggregation_SoilParameters  (grid_soil, dir_rawdata, dir_landdata, lc_year)
+      CALL Aggregation_SoilParameters  (grid_soil, dir_rawdata, dir_landdata, lc_year)
 
-   CALL Aggregation_SoilBrightness  (grid_500m, dir_rawdata, dir_landdata, lc_year)
+      CALL Aggregation_SoilBrightness  (grid_500m, dir_rawdata, dir_landdata, lc_year)
 
-   IF (DEF_USE_BEDROCK) THEN
-      CALL Aggregation_DBedrock     (grid_500m, dir_rawdata, dir_landdata, lc_year)
-   ENDIF
+      IF (DEF_USE_BEDROCK) THEN
+         CALL Aggregation_DBedrock     (grid_500m, dir_rawdata, dir_landdata, lc_year)
+      ENDIF
 
-   CALL Aggregation_LAI             (grid_lai,  dir_rawdata, dir_landdata, lc_year)
+      CALL Aggregation_LAI             (grid_lai,  dir_rawdata, dir_landdata, lc_year)
 
-   CALL Aggregation_ForestHeight    (grid_htop, dir_rawdata, dir_landdata, lc_year)
+      CALL Aggregation_ForestHeight    (grid_htop, dir_rawdata, dir_landdata, lc_year)
 
-   CALL Aggregation_Topography      (grid_topo, dir_rawdata, dir_landdata, lc_year)
+      CALL Aggregation_Topography      (grid_topo, dir_rawdata, dir_landdata, lc_year)
 
-   IF (DEF_USE_Forcing_Downscaling) THEN
-      CALL Aggregation_TopographyFactors (grid_topo_factor, &
-         trim(DEF_DS_HiresTopographyDataDir), dir_landdata, lc_year)
-   ENDIF
+      IF (DEF_USE_Forcing_Downscaling) THEN
+         CALL Aggregation_TopographyFactors (grid_topo_factor, &
+            trim(DEF_DS_HiresTopographyDataDir), dir_landdata, lc_year)
+      ENDIF
 
 #ifdef URBAN_MODEL
-   CALL Aggregation_urban (dir_rawdata, dir_landdata, lc_year, &
-                           grid_urban_5km, grid_urban_500m)
+      CALL Aggregation_urban (dir_rawdata, dir_landdata, lc_year, &
+                              grid_urban_5km, grid_urban_500m)
 #endif
 
-   CALL Aggregation_SoilTexture     (grid_soil, dir_rawdata, dir_landdata, lc_year)
+      CALL Aggregation_SoilTexture     (grid_soil, dir_rawdata, dir_landdata, lc_year)
 
 ENDIF
 
 ! ................................................................
-! 4. Free memories.
+! 4. Write out time info.
 ! ................................................................
 
 #ifdef USEMPI
-   CALL mpi_barrier (p_comm_glb, p_err)
+      CALL mpi_barrier (p_comm_glb, p_err)
 #endif
 
-   IF (p_is_master) THEN
-      CALL system_clock (end_time, count_rate = c_per_sec)
-      time_used = (end_time - start_time) / c_per_sec
-      IF (time_used >= 3600) THEN
-         write(*,101) time_used/3600, mod(time_used,3600)/60, mod(time_used,60)
-         101 format (/, 'Overall system time used:', I4, ' hours', I3, ' minutes', I3, ' seconds.')
-      ELSEIF (time_used >= 60) THEN
-         write(*,102) time_used/60, mod(time_used,60)
-         102 format (/, 'Overall system time used:', I3, ' minutes', I3, ' seconds.')
-      ELSE
-         write(*,103) time_used
-         103 format (/, 'Overall system time used:', I3, ' seconds.')
+      IF (p_is_master) THEN
+         CALL system_clock (end_time, count_rate = c_per_sec)
+         time_used = (end_time - start_time) / c_per_sec
+         IF (time_used >= 3600) THEN
+            write(*,101) time_used/3600, mod(time_used,3600)/60, mod(time_used,60)
+            101 format (/, 'Overall system time used:', I4, ' hours', I3, ' minutes', I3, ' seconds.')
+         ELSEIF (time_used >= 60) THEN
+            write(*,102) time_used/60, mod(time_used,60)
+            102 format (/, 'Overall system time used:', I3, ' minutes', I3, ' seconds.')
+         ELSE
+            write(*,103) time_used
+            103 format (/, 'Overall system time used:', I3, ' seconds.')
+         ENDIF
+
+         write(*,*)  'Successful in surface data making.'
       ENDIF
 
-      write(*,*)  'Successful in surface data making.'
-   ENDIF
-
 #ifdef USEMPI
-   CALL spmd_exit
+      CALL spmd_exit
 #endif
 
 END PROGRAM MKSRFDATA

--- a/mksrfdata/MOD_Lulcc_TransferTrace.F90
+++ b/mksrfdata/MOD_Lulcc_TransferTrace.F90
@@ -12,6 +12,11 @@ MODULE MOD_Lulcc_TransferTrace
 !  type of each patch was derived.
 !
 !  Created by Wanyi Lin, Shupeng Zhang and Hua Yuan, 07/2023
+!
+! !HISTORY:
+!  05/2025, Wanyi Lin and Hua Yuan: code moved from main/LULCC/, now generate
+!           the transfer matrix and patch tracing vector when making surface
+!           data and SAVE it to a type (lulcc) of surface data.
 !------------------------------------------------------------------------
 
    USE MOD_Precision
@@ -221,10 +226,12 @@ CONTAINS
       CALL system('mkdir -p ' // trim(dir_landdata) // '/lulcc/' // trim(thisyr))
       DO ilc = 0, N_land_classification
          write(c2, '(i2.2)') ilc
-         lndname = trim(dir_landdata)//'/lulcc/'//trim(thisyr)//'/lccpct_patches_lc'//trim(c2)//'.nc'
+         lndname = trim(dir_landdata)//'/lulcc/'//trim(thisyr)//&
+            '/lccpct_patches_lc'//trim(c2)//'.nc'
          CALL ncio_create_file_vector (lndname, landpatch)
          CALL ncio_define_dimension_vector (lndname, landpatch, 'patch')
-         CALL ncio_write_vector (lndname, 'lccpct_patches', 'patch', landpatch, lccpct_patches(:,ilc), DEF_Srfdata_CompressLevel)
+         CALL ncio_write_vector (lndname, 'lccpct_patches', 'patch', &
+            landpatch, lccpct_patches(:,ilc), DEF_Srfdata_CompressLevel)
       ENDDO
 
 #ifdef SrfdataDiag

--- a/mksrfdata/MOD_Lulcc_TransferTrace.F90
+++ b/mksrfdata/MOD_Lulcc_TransferTrace.F90
@@ -133,10 +133,10 @@ CONTAINS
          ! read the previous year land cover data
          ! TODO: Add IF statement for using different LC products
          ! IF use MODIS data THEN
-         ! CALL read_5x5_data (dir_5x5, suffix, gpatch, 'LC', lcdatafr)
+         CALL read_5x5_data (dir_5x5, suffix, grid_patch, 'LC', lcdatafr)
          ! ELSE
          ! 'LC_GLC' is not recomended for IGBP
-         CALL read_5x5_data (dir_5x5, suffix, grid_patch, 'LC_GLC', lcdatafr)
+         !CALL read_5x5_data (dir_5x5, suffix, grid_patch, 'LC_GLC', lcdatafr)
 
 #ifdef USEMPI
          CALL aggregation_data_daemon (grid_patch, data_i4_2d_in1 = lcdatafr)

--- a/mksrfdata/MOD_Lulcc_TransferTrace.F90
+++ b/mksrfdata/MOD_Lulcc_TransferTrace.F90
@@ -89,6 +89,7 @@ CONTAINS
 
 !-------------------------- Local Variables ----------------------------
    character(len=256) :: dir_5x5, suffix, lastyr, thisyr, dir_landdata, lndname
+   character(len=4)   :: c2
    integer :: i,ipatch,ipxl,ipxstt,ipxend,numpxl,ilc
    integer, allocatable, dimension(:) :: locpxl
    type (block_data_int32_2d)         :: lcdatafr !land cover data of last year
@@ -100,13 +101,22 @@ CONTAINS
 #ifdef SrfdataDiag
    integer  :: ityp
    integer, allocatable, dimension(:) :: typindex
+#endif
 !-----------------------------------------------------------------------
+      IF ( (lc_year < 1990) .or. (lc_year < 2000 .and. MOD(lc_year, 5) /= 0) ) RETURN
 
+      write(thisyr,'(i4.4)') lc_year
+      IF (lc_year <= 2000 .and. MOD(lc_year, 5) == 0) THEN
+         write(lastyr,'(i4.4)') MAX(1985, lc_year-5)
+      ELSE
+         write(lastyr,'(i4.4)') MAX(1985, lc_year-1)
+      ENDIF
+
+#ifdef SrfdataDiag
       allocate( typindex(N_land_classification+1) )
 #endif
 
-      write(thisyr,'(i4.4)') lc_year
-      write(lastyr,'(i4.4)') lc_year-1
+      CALL allocate_LulccTransferTrace
 
 #ifdef USEMPI
       CALL mpi_barrier (p_comm_glb, p_err)
@@ -121,7 +131,12 @@ CONTAINS
          dir_5x5 = trim(DEF_dir_rawdata) // '/plant_15s'
          suffix  = 'MOD'//trim(lastyr)
          ! read the previous year land cover data
-         CALL read_5x5_data (dir_5x5, suffix, grid_patch, 'LC', lcdatafr)
+         ! TODO: Add IF statement for using different LC products
+         ! IF use MODIS data THEN
+         ! CALL read_5x5_data (dir_5x5, suffix, gpatch, 'LC', lcdatafr)
+         ! ELSE
+         ! 'LC_GLC' is not recomended for IGBP
+         CALL read_5x5_data (dir_5x5, suffix, grid_patch, 'LC_GLC', lcdatafr)
 
 #ifdef USEMPI
          CALL aggregation_data_daemon (grid_patch, data_i4_2d_in1 = lcdatafr)
@@ -163,9 +178,7 @@ CONTAINS
 
             DO WHILE (ipatch.le.grid_patch_e(i))
 
-               IF (ipatch.le.0) THEN
-                  CYCLE
-               ENDIF
+               IF (ipatch.le.0) CYCLE
 
                ! using this year patch mapping to aggregate the previous year land cover data
                CALL aggregation_request_data (landpatch, ipatch, grid_patch, zip = .true., &
@@ -204,14 +217,23 @@ CONTAINS
 #endif
       ENDIF
 
-#ifdef SrfdataDiag
       dir_landdata = DEF_dir_landdata
+      CALL system('mkdir -p ' // trim(dir_landdata) // '/lulcc/' // trim(thisyr))
+      DO ilc = 0, N_land_classification
+         write(c2, '(i2.2)') ilc
+         lndname = trim(dir_landdata)//'/lulcc/'//trim(thisyr)//'/lccpct_patches_lc'//trim(c2)//'.nc'
+         CALL ncio_create_file_vector (lndname, landpatch)
+         CALL ncio_define_dimension_vector (lndname, landpatch, 'patch')
+         CALL ncio_write_vector (lndname, 'lccpct_patches', 'patch', landpatch, lccpct_patches(:,ilc), DEF_Srfdata_CompressLevel)
+      ENDDO
+
+#ifdef SrfdataDiag
       typindex = (/(ityp, ityp = 0, N_land_classification)/)
       lndname  = trim(dir_landdata) // &
-                 '/diag/transfer_matrix'// trim(lastyr)//'-'// trim(thisyr) // '.nc'
+                 '/diag/lccpct_matrix_' // trim(thisyr) // '.nc'
       DO ilc = 0, N_land_classification
          CALL srfdata_map_and_write (lccpct_matrix(:,ilc), landpatch%settyp, typindex, &
-            m_patch2diag, -1.0e36_r8, lndname, 'TRANSFER_MATRIX', compress = 0, &
+            m_patch2diag, -1.0e36_r8, lndname, 'lccpct_matrix', compress = 0, &
             write_mode = 'one', lastdimname = 'source_patch', lastdimvalue = ilc)
       ENDDO
       deallocate(typindex)
@@ -230,7 +252,10 @@ CONTAINS
          IF (allocated(area_one))    deallocate (area_one)
       ENDIF
 
+      CALL deallocate_LulccTransferTrace
+
    END SUBROUTINE MAKE_LulccTransferTrace
+
 
 
    SUBROUTINE deallocate_LulccTransferTrace


### PR DESCRIPTION
    -add(mksrfdata/MOD_Lulcc_TransferTrace.F90):
        move makeing transfer trace from lulcc to mksrfdata. [by @Wanyi Lin]

    -opt(CoLM.F90,MOD_Lulcc_Driver.F90,MOD_Lulcc_Initialize.F90,MOD_SrfdataDiag.F90):
        optimazation for lulcc runs. [by @Wanyi Lin]

    -fix(MOD_Lulcc_MassEnergyConserve.F90):
        small bug fix form MEC scheme. [by @Wanyi Lin]

    -mod(MOD_NetSolar.F90):
        don't output imbalanced soil/snow absorption for the first step of a new year.

    -opt(MKSRFDATA.F90):
        deal with lulcc years before 2000 (five years one data). [by @Wanyi Lin]

    -mod(Aggregation_DBedrock.F90,MKSRFDATA.F90):
        add lc_year info for making DBedrock surface data is case of LULCC.

    -fix(MOD_CanopyLayerProfile.F90):
        when more than two roots found for K and U profile calculation, only the
        first two roots are used. [report by @Baiying Liu]

    -add(CoLM.F90,MOD_Vars_TimeVariables.F90):
        output restart file when reaching the end time stamp.

    -fix(MOD_Forcing.F90):
        output month value for point case for forcing time range comparison.

    -adj(*.F90):
        code indent, format adjustment, annotation added.